### PR TITLE
Increase Go test coverage

### DIFF
--- a/server/auth/oauth_test.go
+++ b/server/auth/oauth_test.go
@@ -73,7 +73,7 @@ func TestExchangeCodeForToken(t *testing.T) {
 					return
 				}
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprintln(w, `{"access_token": "token123", "token_type": "bearer"}`)
+				_, _ = fmt.Fprintln(w, `{"access_token": "token123", "token_type": "bearer"}`)
 			},
 			wantToken: "token123",
 		},
@@ -88,7 +88,7 @@ func TestExchangeCodeForToken(t *testing.T) {
 			code: "valid-code",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprintln(w, `{}`)
+				_, _ = fmt.Fprintln(w, `{}`)
 			},
 			wantErr:    true,
 			errContain: "token exchange failed with status 500",
@@ -98,7 +98,7 @@ func TestExchangeCodeForToken(t *testing.T) {
 			code: "bad-code",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprintln(w, `{"error": "bad_verification_code", "error_description": "The code passed is incorrect or expired."}`)
+				_, _ = fmt.Fprintln(w, `{"error": "bad_verification_code", "error_description": "The code passed is incorrect or expired."}`)
 			},
 			wantErr:    true,
 			errContain: "bad_verification_code",
@@ -108,7 +108,7 @@ func TestExchangeCodeForToken(t *testing.T) {
 			code: "valid-code",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprintln(w, `not json`)
+				_, _ = fmt.Fprintln(w, `not json`)
 			},
 			wantErr:    true,
 			errContain: "failed to decode token exchange response",
@@ -118,7 +118,7 @@ func TestExchangeCodeForToken(t *testing.T) {
 			code: "valid-code",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprintln(w, `{"foo": "bar"}`)
+				_, _ = fmt.Fprintln(w, `{"foo": "bar"}`)
 			},
 			wantErr:    true,
 			errContain: "did not include access_token",

--- a/server/auth/oauth_test.go
+++ b/server/auth/oauth_test.go
@@ -1,0 +1,156 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestAuthorizeURL(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		GitHubClientID: "client-id",
+		CallbackURL:    "https://example.com/callback",
+		Scopes:         []string{"scope1", "scope2"},
+	}
+	got := c.AuthorizeURL("state123")
+	wantPrefix := "https://github.com/login/oauth/authorize?"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("got %q, want prefix %q", got, wantPrefix)
+	}
+	if !strings.Contains(got, "client_id=client-id") {
+		t.Error("missing client_id")
+	}
+	if !strings.Contains(got, "redirect_uri=https%3A%2F%2Fexample.com%2Fcallback") {
+		t.Error("missing redirect_uri")
+	}
+	if !strings.Contains(got, "scope=scope1+scope2") {
+		t.Error("missing scope")
+	}
+	if !strings.Contains(got, "state=state123") {
+		t.Error("missing state")
+	}
+}
+
+type mockTransport struct {
+	handler http.HandlerFunc
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	w := httptest.NewRecorder()
+	m.handler(w, req)
+	return w.Result(), nil
+}
+
+func TestExchangeCodeForToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		code       string
+		handler    http.HandlerFunc
+		wantToken  string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name: "success",
+			code: "valid-code",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				body, _ := io.ReadAll(r.Body)
+				values, _ := url.ParseQuery(string(body))
+				if values.Get("code") != "valid-code" {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintln(w, `{"access_token": "token123", "token_type": "bearer"}`)
+			},
+			wantToken: "token123",
+		},
+		{
+			name:       "empty code",
+			code:       "   ",
+			wantErr:    true,
+			errContain: "code is required",
+		},
+		{
+			name: "http error",
+			code: "valid-code",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintln(w, `{}`)
+			},
+			wantErr:    true,
+			errContain: "token exchange failed with status 500",
+		},
+		{
+			name: "github error response",
+			code: "bad-code",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintln(w, `{"error": "bad_verification_code", "error_description": "The code passed is incorrect or expired."}`)
+			},
+			wantErr:    true,
+			errContain: "bad_verification_code",
+		},
+		{
+			name: "invalid json response",
+			code: "valid-code",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintln(w, `not json`)
+			},
+			wantErr:    true,
+			errContain: "failed to decode token exchange response",
+		},
+		{
+			name: "missing access token",
+			code: "valid-code",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintln(w, `{"foo": "bar"}`)
+			},
+			wantErr:    true,
+			errContain: "did not include access_token",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Config{
+				GitHubClientID:     "client-id",
+				GitHubClientSecret: "client-secret",
+				CallbackURL:        "https://example.com/callback",
+			}
+			var client *http.Client
+			if tc.handler != nil {
+				client = &http.Client{
+					Transport: &mockTransport{handler: tc.handler},
+				}
+			}
+
+			token, err := c.ExchangeCodeForToken(context.Background(), tc.code, client)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ExchangeCodeForToken() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if err != nil && tc.errContain != "" {
+				if !strings.Contains(err.Error(), tc.errContain) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContain)
+				}
+			}
+			if token != tc.wantToken {
+				t.Errorf("ExchangeCodeForToken() = %q, want %q", token, tc.wantToken)
+			}
+		})
+	}
+}

--- a/server/auth/token_test.go
+++ b/server/auth/token_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,5 +28,81 @@ func TestResolveTokenFromRequest_FallsBackToCookie(t *testing.T) {
 	got := ResolveTokenFromRequest(req, "ingitdb_github_token")
 	if got != "cookie-token" {
 		t.Fatalf("expected cookie token, got %q", got)
+	}
+}
+
+func TestValidateGitHubToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		token      string
+		handler    http.HandlerFunc
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:  "valid token",
+			token: "valid-token",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/user" {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if r.Header.Get("Authorization") != "Bearer valid-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintln(w, `{"login": "octocat"}`)
+			},
+			wantErr: false,
+		},
+		{
+			name:       "empty token",
+			token:      "",
+			wantErr:    true,
+			errContain: "token is required",
+		},
+		{
+			name:  "invalid token",
+			token: "bad-token",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprintln(w, `{"message": "Bad credentials"}`)
+			},
+			wantErr:    true,
+			errContain: "github token validation failed",
+		},
+		{
+			name:  "http error",
+			token: "valid-token",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr:    true,
+			errContain: "github token validation failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var client *http.Client
+			if tc.handler != nil {
+				client = &http.Client{
+					Transport: &mockTransport{handler: tc.handler},
+				}
+			}
+			err := ValidateGitHubToken(context.Background(), tc.token, client)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateGitHubToken() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if err != nil && tc.errContain != "" {
+				// We expect "github token validation failed" prefix, but check substring just in case
+				if len(tc.errContain) > 0 { // Just to avoid unused var warning if I expand logic later
+					// Actually check content
+				}
+			}
+		})
 	}
 }

--- a/server/auth/token_test.go
+++ b/server/auth/token_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -54,7 +55,7 @@ func TestValidateGitHubToken(t *testing.T) {
 					return
 				}
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprintln(w, `{"login": "octocat"}`)
+				_, _ = fmt.Fprintln(w, `{"login": "octocat"}`)
 			},
 			wantErr: false,
 		},
@@ -69,7 +70,7 @@ func TestValidateGitHubToken(t *testing.T) {
 			token: "bad-token",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
-				fmt.Fprintln(w, `{"message": "Bad credentials"}`)
+				_, _ = fmt.Fprintln(w, `{"message": "Bad credentials"}`)
 			},
 			wantErr:    true,
 			errContain: "github token validation failed",
@@ -98,9 +99,8 @@ func TestValidateGitHubToken(t *testing.T) {
 				t.Fatalf("ValidateGitHubToken() error = %v, wantErr %v", err, tc.wantErr)
 			}
 			if err != nil && tc.errContain != "" {
-				// We expect "github token validation failed" prefix, but check substring just in case
-				if len(tc.errContain) > 0 { // Just to avoid unused var warning if I expand logic later
-					// Actually check content
+				if !strings.Contains(err.Error(), tc.errContain) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContain)
 				}
 			}
 		})


### PR DESCRIPTION
This PR increases the test coverage for the Go code in `ingitdb-cli`. It adds new tests for the `server/api`, `server/mcp`, and `server/auth` packages, covering previously untested functions and error paths. This includes tests for OAuth flows, token validation, MCP tools, and API handler constructors and error handling. The `server/auth` tests use a mock HTTP transport to simulate GitHub API responses.

---
*PR created automatically by Jules for task [1069221882289563495](https://jules.google.com/task/1069221882289563495) started by @trakhimenok*