### PR TITLE
feat(markdown): support markdown records with frontmatter and CRUD

### DIFF
--- a/pkg/dalgo2fsingitdb/markdown_crud_test.go
+++ b/pkg/dalgo2fsingitdb/markdown_crud_test.go
@@ -1,0 +1,420 @@
+package dalgo2fsingitdb
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dal-go/dalgo/dal"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// makeMarkdownDef builds a Definition with one Markdown SingleRecord
+// collection rooted at dirPath. When contentField is empty the default
+// ($content) is used.
+func makeMarkdownDef(t *testing.T, dirPath, contentField string) *ingitdb.Definition {
+	t.Helper()
+	contentColName := contentField
+	if contentColName == "" {
+		contentColName = ingitdb.DefaultMarkdownContentField
+	}
+	colDef := &ingitdb.CollectionDef{
+		ID:      "test.notes",
+		DirPath: dirPath,
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:         "{key}.md",
+			Format:       ingitdb.RecordFormatMarkdown,
+			RecordType:   ingitdb.SingleRecord,
+			ContentField: contentField,
+		},
+		Columns: map[string]*ingitdb.ColumnDef{
+			"title":        {Type: ingitdb.ColumnTypeString},
+			"date":         {Type: ingitdb.ColumnTypeString},
+			"tags":         {Type: ingitdb.ColumnTypeString},
+			contentColName: {Type: ingitdb.ColumnTypeString, Format: "markdown"},
+		},
+		ColumnsOrder: []string{"title", "date", "tags"},
+	}
+	return &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"test.notes": colDef,
+		},
+	}
+}
+
+// recordFilePath returns the on-disk path for a markdown record with the
+// given key under the standard {key}.md / $records layout.
+func recordFilePath(dirPath, key string) string {
+	return filepath.Join(dirPath, "$records", key+".md")
+}
+
+func TestMarkdown_InsertGet_DefaultContentField(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeMarkdownDef(t, dir, "")
+	db := openTestDB(t, dir, def)
+
+	body := "# Hello\n\nThis is the note body.\n"
+	data := map[string]any{
+		"title":                             "First note",
+		"date":                              "2024-01-01",
+		"tags":                              "intro",
+		ingitdb.DefaultMarkdownContentField: body,
+	}
+	key := dal.NewKeyWithID("test.notes", "first")
+	record := dal.NewRecordWithData(key, data)
+
+	ctx := context.Background()
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, record)
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// On-disk inspection: real .md file with frontmatter + body.
+	filePath := recordFilePath(dir, "first")
+	got, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%s): %v", filePath, err)
+	}
+	gotStr := string(got)
+	if !strings.HasPrefix(gotStr, "---\n") {
+		t.Errorf("file should start with ---\\n, got prefix: %q", gotStr[:min(len(gotStr), 8)])
+	}
+	if !strings.HasSuffix(gotStr, body) {
+		t.Errorf("file should end with the body bytes verbatim, got tail: %q", gotStr[max(0, len(gotStr)-len(body)-4):])
+	}
+	if !strings.Contains(gotStr, "title: First note") {
+		t.Errorf("frontmatter should contain title key, got: %q", gotStr)
+	}
+
+	// Read back via DALgo.
+	readData := map[string]any{}
+	readRecord := dal.NewRecordWithData(dal.NewKeyWithID("test.notes", "first"), readData)
+	err = db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, readRecord)
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if readRecord.Error() != nil {
+		t.Fatalf("record carries error after Get: %v", readRecord.Error())
+	}
+	if readData["title"] != "First note" {
+		t.Errorf("title: got %v, want %q", readData["title"], "First note")
+	}
+	if readData["tags"] != "intro" {
+		t.Errorf("tags: got %v, want %q", readData["tags"], "intro")
+	}
+	if readData[ingitdb.DefaultMarkdownContentField] != body {
+		t.Errorf("body: got %q, want %q",
+			readData[ingitdb.DefaultMarkdownContentField], body)
+	}
+}
+
+func TestMarkdown_InsertGet_CustomContentField(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeMarkdownDef(t, dir, "body")
+	db := openTestDB(t, dir, def)
+
+	bodyText := "Custom content field body.\n"
+	data := map[string]any{
+		"title": "Custom",
+		"body":  bodyText,
+	}
+	key := dal.NewKeyWithID("test.notes", "custom")
+	record := dal.NewRecordWithData(key, data)
+
+	ctx := context.Background()
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, record)
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// "body" must NOT appear in frontmatter.
+	filePath := recordFilePath(dir, "custom")
+	got, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("os.ReadFile: %v", err)
+	}
+	gotStr := string(got)
+	header, _, ok := strings.Cut(gotStr[4:], "---\n") // skip opening "---\n"
+	if !ok {
+		t.Fatalf("file missing closing frontmatter delimiter: %q", gotStr)
+	}
+	if strings.Contains(header, "body:") {
+		t.Errorf("frontmatter should not contain the custom content field key 'body', got header: %q", header)
+	}
+	if !strings.HasSuffix(gotStr, bodyText) {
+		t.Errorf("file should end with body bytes verbatim, got tail: %q", gotStr[max(0, len(gotStr)-len(bodyText)-4):])
+	}
+
+	// Read back: "body" is populated, default $content is absent.
+	readData := map[string]any{}
+	readRecord := dal.NewRecordWithData(dal.NewKeyWithID("test.notes", "custom"), readData)
+	err = db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, readRecord)
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if readData["body"] != bodyText {
+		t.Errorf("body: got %q, want %q", readData["body"], bodyText)
+	}
+	if _, present := readData[ingitdb.DefaultMarkdownContentField]; present {
+		t.Errorf("$content should not be set when content_field is overridden, got: %v",
+			readData[ingitdb.DefaultMarkdownContentField])
+	}
+}
+
+func TestMarkdown_Update(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeMarkdownDef(t, dir, "")
+	db := openTestDB(t, dir, def)
+
+	ctx := context.Background()
+	key := dal.NewKeyWithID("test.notes", "updateme")
+	initial := map[string]any{
+		"title":                             "Original",
+		ingitdb.DefaultMarkdownContentField: "Original body.\n",
+	}
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, dal.NewRecordWithData(key, initial))
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// Update: change title, leave body unchanged.
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		current := map[string]any{}
+		rec := dal.NewRecordWithData(key, current)
+		if getErr := tx.Get(ctx, rec); getErr != nil {
+			return getErr
+		}
+		current["title"] = "Updated"
+		return tx.Set(ctx, rec)
+	})
+	if err != nil {
+		t.Fatalf("Update transaction: %v", err)
+	}
+
+	// Verify.
+	readData := map[string]any{}
+	readRecord := dal.NewRecordWithData(dal.NewKeyWithID("test.notes", "updateme"), readData)
+	err = db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, readRecord)
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if readData["title"] != "Updated" {
+		t.Errorf("title: got %v, want %q", readData["title"], "Updated")
+	}
+	if readData[ingitdb.DefaultMarkdownContentField] != "Original body.\n" {
+		t.Errorf("body lost on update: got %q, want %q",
+			readData[ingitdb.DefaultMarkdownContentField], "Original body.\n")
+	}
+}
+
+func TestMarkdown_Delete(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeMarkdownDef(t, dir, "")
+	db := openTestDB(t, dir, def)
+
+	ctx := context.Background()
+	key := dal.NewKeyWithID("test.notes", "todelete")
+	data := map[string]any{
+		"title":                             "Doomed",
+		ingitdb.DefaultMarkdownContentField: "Soon to be deleted.\n",
+	}
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, dal.NewRecordWithData(key, data))
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	filePath := recordFilePath(dir, "todelete")
+	if _, statErr := os.Stat(filePath); statErr != nil {
+		t.Fatalf("expected file to exist after Insert, stat err: %v", statErr)
+	}
+
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Delete(ctx, key)
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, statErr := os.Stat(filePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("expected file to be gone after Delete, stat err: %v", statErr)
+	}
+
+	// Get on a deleted record: tx.Get returns no transport error, but the
+	// record's Exists() reports false (DALgo's not-found convention).
+	readRecord := dal.NewRecordWithData(dal.NewKeyWithID("test.notes", "todelete"), map[string]any{})
+	err = db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, readRecord)
+	})
+	if err != nil {
+		t.Fatalf("Get after delete: %v", err)
+	}
+	if readRecord.Exists() {
+		t.Error("expected record to not exist after delete")
+	}
+}
+
+func TestMarkdown_TimeField_RoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeMarkdownDef(t, dir, "")
+	// Replace the string "date" column with one that round-trips a time.Time
+	// via yaml.v3's YAML 1.2 timestamp handling.
+	def.Collections["test.notes"].Columns["date"] = &ingitdb.ColumnDef{
+		Type: ingitdb.ColumnTypeString, // schema is permissive; in-memory uses time.Time
+	}
+	db := openTestDB(t, dir, def)
+
+	when := time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC)
+	data := map[string]any{
+		"title":                             "Time-stamped note",
+		"date":                              when,
+		ingitdb.DefaultMarkdownContentField: "Body.\n",
+	}
+	key := dal.NewKeyWithID("test.notes", "timed")
+	ctx := context.Background()
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, dal.NewRecordWithData(key, data))
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// On disk, the date is serialized in YAML 1.2 timestamp form (no quotes).
+	filePath := recordFilePath(dir, "timed")
+	got, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("os.ReadFile: %v", err)
+	}
+	if !strings.Contains(string(got), "date: 2024-01-15") {
+		t.Errorf("file should contain an ISO-8601 date for time.Time, got: %q", got)
+	}
+
+	// Read back: yaml.v3 parses the bare timestamp back into a time.Time.
+	readData := map[string]any{}
+	readRecord := dal.NewRecordWithData(dal.NewKeyWithID("test.notes", "timed"), readData)
+	err = db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, readRecord)
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	gotTime, ok := readData["date"].(time.Time)
+	if !ok {
+		t.Fatalf("date field: got %T (%v), want time.Time", readData["date"], readData["date"])
+	}
+	if !gotTime.Equal(when) {
+		t.Errorf("date value: got %v, want %v", gotTime, when)
+	}
+}
+
+func TestMarkdown_UndeclaredFrontmatterKeysIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeMarkdownDef(t, dir, "")
+	_ = openTestDB(t, dir, def)
+
+	// Hand-author a .md file with an extra "author" key not in the schema.
+	if err := os.MkdirAll(filepath.Join(dir, "$records"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	raw := "---\ntitle: Hand-written\nauthor: Stranger\n---\nBody.\n"
+	if err := os.WriteFile(recordFilePath(dir, "handauthored"), []byte(raw), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	db := openTestDB(t, dir, def)
+	readData := map[string]any{}
+	readRecord := dal.NewRecordWithData(dal.NewKeyWithID("test.notes", "handauthored"), readData)
+	err := db.RunReadonlyTransaction(context.Background(), func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, readRecord)
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if readData["title"] != "Hand-written" {
+		t.Errorf("title: got %v, want %q", readData["title"], "Hand-written")
+	}
+	if _, present := readData["author"]; present {
+		t.Errorf("undeclared key 'author' should not appear in record, got: %v", readData["author"])
+	}
+	if readData[ingitdb.DefaultMarkdownContentField] != "Body.\n" {
+		t.Errorf("body: got %q, want %q", readData[ingitdb.DefaultMarkdownContentField], "Body.\n")
+	}
+}
+
+func TestMarkdown_Validate_ContentFieldOnNonMarkdownRejected(t *testing.T) {
+	t.Parallel()
+	rfd := ingitdb.RecordFileDef{
+		Name:         "{key}.yaml",
+		Format:       ingitdb.RecordFormatYAML,
+		RecordType:   ingitdb.SingleRecord,
+		ContentField: "body",
+	}
+	if err := rfd.Validate(); err == nil {
+		t.Fatal("expected error for content_field on non-markdown format, got nil")
+	}
+}
+
+func TestMarkdown_Validate_NonSingleRecordRejected(t *testing.T) {
+	t.Parallel()
+	rfd := ingitdb.RecordFileDef{
+		Name:       "all.md",
+		Format:     ingitdb.RecordFormatMarkdown,
+		RecordType: ingitdb.ListOfRecords,
+	}
+	err := rfd.Validate()
+	if err == nil {
+		t.Fatal("expected error for markdown with non-SingleRecord type, got nil")
+	}
+	if !strings.Contains(err.Error(), "record type") {
+		t.Errorf("error should mention record type, got: %v", err)
+	}
+}
+
+func TestMarkdown_ResolvedContentField_Default(t *testing.T) {
+	t.Parallel()
+	rfd := ingitdb.RecordFileDef{
+		Name:       "{key}.md",
+		Format:     ingitdb.RecordFormatMarkdown,
+		RecordType: ingitdb.SingleRecord,
+	}
+	if got := rfd.ResolvedContentField(); got != ingitdb.DefaultMarkdownContentField {
+		t.Errorf("ResolvedContentField default: got %q, want %q", got, ingitdb.DefaultMarkdownContentField)
+	}
+}
+
+func TestMarkdown_ResolvedContentField_Override(t *testing.T) {
+	t.Parallel()
+	rfd := ingitdb.RecordFileDef{
+		Name:         "{key}.md",
+		Format:       ingitdb.RecordFormatMarkdown,
+		RecordType:   ingitdb.SingleRecord,
+		ContentField: "body",
+	}
+	if got := rfd.ResolvedContentField(); got != "body" {
+		t.Errorf("ResolvedContentField override: got %q, want %q", got, "body")
+	}
+}

--- a/pkg/dalgo2fsingitdb/record_file.go
+++ b/pkg/dalgo2fsingitdb/record_file.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dal-go/dalgo/dal"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/markdown"
 	"gopkg.in/yaml.v3"
 )
 
@@ -23,6 +24,7 @@ func resolveRecordPath(colDef *ingitdb.CollectionDef, recordKey string) string {
 
 // readRecordFromFile reads a YAML or JSON file and returns its content as a map.
 // Returns (nil, false, nil) if the file does not exist.
+// For markdown-format collections use readMarkdownRecord instead.
 func readRecordFromFile(path string, format ingitdb.RecordFormat) (map[string]any, bool, error) {
 	fileContent, err := os.ReadFile(path)
 	if err != nil {
@@ -33,11 +35,11 @@ func readRecordFromFile(path string, format ingitdb.RecordFormat) (map[string]an
 	}
 	var data map[string]any
 	switch format {
-	case "yaml", "yml":
+	case ingitdb.RecordFormatYAML, ingitdb.RecordFormatYML:
 		if err = yaml.Unmarshal(fileContent, &data); err != nil {
 			return nil, false, fmt.Errorf("failed to parse YAML file %s: %w", path, err)
 		}
-	case "json":
+	case ingitdb.RecordFormatJSON:
 		if err = yaml.Unmarshal(fileContent, &data); err != nil {
 			return nil, false, fmt.Errorf("failed to parse JSON file %s: %w", path, err)
 		}
@@ -45,6 +47,82 @@ func readRecordFromFile(path string, format ingitdb.RecordFormat) (map[string]an
 		return nil, false, fmt.Errorf("unsupported record format %q", format)
 	}
 	return data, true, nil
+}
+
+// readMarkdownRecord reads a Markdown record file: parses YAML frontmatter,
+// filters frontmatter keys to columns declared in colDef, and exposes the
+// document body under the configured content_field column name.
+// Returns (nil, false, nil) if the file does not exist.
+func readMarkdownRecord(path string, colDef *ingitdb.CollectionDef) (map[string]any, bool, error) {
+	fileContent, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+	frontmatter, body, parseErr := markdown.Parse(fileContent)
+	if parseErr != nil {
+		return nil, false, fmt.Errorf("failed to parse markdown file %s: %w", path, parseErr)
+	}
+	result := make(map[string]any, len(frontmatter)+1)
+	for key, value := range frontmatter {
+		if _, declared := colDef.Columns[key]; !declared {
+			continue
+		}
+		result[key] = value
+	}
+	contentField := colDef.RecordFile.ResolvedContentField()
+	result[contentField] = string(body)
+	return result, true, nil
+}
+
+// writeMarkdownRecord writes a Markdown record file. The content_field
+// column value is written to the body byte-for-byte; all other columns
+// declared in the schema are written to YAML frontmatter in the order
+// defined by colDef.ColumnsOrder, with alphabetical fallback for columns
+// not in ColumnsOrder. Undeclared keys in data are passed through
+// (appended after declared columns, alphabetically).
+func writeMarkdownRecord(path string, colDef *ingitdb.CollectionDef, data map[string]any) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+	contentField := colDef.RecordFile.ResolvedContentField()
+	body := extractBody(data, contentField)
+	frontmatter := make(map[string]any, len(data))
+	for key, value := range data {
+		if key == contentField {
+			continue
+		}
+		frontmatter[key] = value
+	}
+	content, err := markdown.Serialize(frontmatter, colDef.ColumnsOrder, body)
+	if err != nil {
+		return fmt.Errorf("failed to serialize markdown record: %w", err)
+	}
+	if writeErr := os.WriteFile(path, content, 0o644); writeErr != nil {
+		return fmt.Errorf("failed to write file %s: %w", path, writeErr)
+	}
+	return nil
+}
+
+// extractBody pulls the content field's value out of data and converts it
+// to body bytes. A missing or nil value yields nil (empty body). A string
+// or []byte value is used verbatim. Any other type is rendered as text.
+func extractBody(data map[string]any, contentField string) []byte {
+	raw, ok := data[contentField]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch v := raw.(type) {
+	case string:
+		return []byte(v)
+	case []byte:
+		return v
+	default:
+		return fmt.Appendf(nil, "%v", v)
+	}
 }
 
 // writeRecordToFile marshals data to the specified format and writes it to path.

--- a/pkg/dalgo2fsingitdb/tx_readonly.go
+++ b/pkg/dalgo2fsingitdb/tx_readonly.go
@@ -37,7 +37,16 @@ func (r readonlyTx) Get(ctx context.Context, record dal.Record) error {
 	path := resolveRecordPath(colDef, recordKey)
 	switch colDef.RecordFile.RecordType {
 	case ingitdb.SingleRecord:
-		data, found, err := readRecordFromFile(path, colDef.RecordFile.Format)
+		var (
+			data  map[string]any
+			found bool
+			err   error
+		)
+		if colDef.RecordFile.Format == ingitdb.RecordFormatMarkdown {
+			data, found, err = readMarkdownRecord(path, colDef)
+		} else {
+			data, found, err = readRecordFromFile(path, colDef.RecordFile.Format)
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/dalgo2fsingitdb/tx_readwrite.go
+++ b/pkg/dalgo2fsingitdb/tx_readwrite.go
@@ -44,6 +44,9 @@ func (r readwriteTx) Set(ctx context.Context, record dal.Record) error {
 		allRecords[recordKey] = dalgo2ingitdb.ApplyLocaleToWrite(data, colDef.Columns)
 		return writeMapOfRecordsFile(path, colDef.RecordFile.Format, allRecords)
 	default:
+		if colDef.RecordFile.Format == ingitdb.RecordFormatMarkdown {
+			return writeMarkdownRecord(path, colDef, data)
+		}
 		return writeRecordToFile(path, colDef.RecordFile.Format, data)
 	}
 }
@@ -132,6 +135,9 @@ func (r readwriteTx) Insert(ctx context.Context, record dal.Record, opts ...dal.
 		}
 		record.SetError(nil)
 		data := record.Data().(map[string]any)
+		if colDef.RecordFile.Format == ingitdb.RecordFormatMarkdown {
+			return writeMarkdownRecord(path, colDef, data)
+		}
 		return writeRecordToFile(path, colDef.RecordFile.Format, data)
 	}
 }

--- a/pkg/ingitdb/column_def.go
+++ b/pkg/ingitdb/column_def.go
@@ -18,6 +18,11 @@ type ColumnDef struct {
 	// When writing, this column is stored as-is in the file; if the pair column contains an entry
 	// for the primary locale key, that entry is promoted here and removed from the pair column.
 	Locale string `yaml:"locale,omitempty"`
+	// Format is an optional, free-form hint about the column's logical content
+	// type. Well-known values include `markdown`, `html`, `json`, `jsonl`,
+	// `yaml`, `uri`, `email`, `pdf`. inGitDB does not validate the value;
+	// tooling may use it to choose a renderer or preview strategy.
+	Format string `yaml:"format,omitempty"`
 }
 
 func (v *ColumnDef) Validate() error {

--- a/pkg/ingitdb/constants.go
+++ b/pkg/ingitdb/constants.go
@@ -2,6 +2,21 @@ package ingitdb
 
 type RecordFormat string
 
+// Recognized record file formats. Tooling MUST treat unrecognized values as
+// unsupported. The values are the strings that appear in
+// `record_file.format` in `.collection/definition.yaml`.
+const (
+	RecordFormatYAML     RecordFormat = "yaml"
+	RecordFormatYML      RecordFormat = "yml"
+	RecordFormatJSON     RecordFormat = "json"
+	RecordFormatMarkdown RecordFormat = "markdown"
+)
+
+// DefaultMarkdownContentField is the default name of the column that holds
+// the Markdown body when a collection uses `format: markdown` and does not
+// override `record_file.content_field`.
+const DefaultMarkdownContentField = "$content"
+
 const SchemaDir = ".collection"
 
 // CollectionsDir is the shared-directory layout folder name. When a directory

--- a/pkg/ingitdb/markdown/markdown.go
+++ b/pkg/ingitdb/markdown/markdown.go
@@ -1,0 +1,173 @@
+// Package markdown parses and serializes inGitDB Markdown record files —
+// YAML frontmatter delimited by "---" lines followed by a body. The body is
+// preserved byte-for-byte across round-trips; the writer canonicalizes
+// frontmatter key order to columns_order with alphabetical fallback for
+// columns absent from columns_order, as required by the markdown-records
+// feature spec.
+package markdown
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// delimiter is the line that opens and closes the frontmatter block.
+const delimiter = "---"
+
+// Parse splits a Markdown record into frontmatter and body.
+//
+// When the file's first line is exactly "---" and a matching closing "---"
+// appears on its own line later, the text between is parsed as a YAML
+// mapping and returned as frontmatter; everything after the closing
+// delimiter (including the newline that terminates the closing line) is
+// returned as body, byte-for-byte.
+//
+// When the file does not begin with "---", frontmatter is nil and the entire
+// content is returned as body.
+//
+// A leading "---" with no matching closing delimiter is a malformed
+// frontmatter block and returns an error.
+func Parse(content []byte) (frontmatter map[string]any, body []byte, err error) {
+	open, openLen, hasOpen := findDelimiter(content, 0)
+	if !hasOpen || open != 0 {
+		return nil, content, nil
+	}
+	afterOpen := openLen
+	close, closeLen, hasClose := findDelimiter(content, afterOpen)
+	if !hasClose {
+		return nil, nil, fmt.Errorf("markdown: opening %q delimiter has no matching closing %q delimiter", delimiter, delimiter)
+	}
+	fmBytes := content[afterOpen:close]
+	if len(fmBytes) > 0 {
+		err = yaml.Unmarshal(fmBytes, &frontmatter)
+		if err != nil {
+			return nil, nil, fmt.Errorf("markdown: invalid YAML frontmatter: %w", err)
+		}
+	}
+	if frontmatter == nil {
+		// Document with `---\n---\n` (no keys) is valid; expose empty map.
+		frontmatter = map[string]any{}
+	}
+	body = content[close+closeLen:]
+	return frontmatter, body, nil
+}
+
+// Serialize emits a Markdown record: an opening "---" line, the frontmatter
+// keys in canonical order (columns_order first, then alphabetical for any
+// keys not in columns_order), a closing "---" line, and the body bytes
+// verbatim.
+//
+// When frontmatter is empty (or nil), the output still includes the two
+// "---" lines so the file remains a valid frontmatter document.
+func Serialize(frontmatter map[string]any, columnsOrder []string, body []byte) ([]byte, error) {
+	ordered := orderKeys(frontmatter, columnsOrder)
+	var buf bytes.Buffer
+	buf.WriteString(delimiter)
+	buf.WriteByte('\n')
+	if len(ordered) > 0 {
+		node, err := buildMappingNode(frontmatter, ordered)
+		if err != nil {
+			return nil, fmt.Errorf("markdown: build frontmatter node: %w", err)
+		}
+		fmBytes, marshalErr := yaml.Marshal(node)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("markdown: marshal frontmatter: %w", marshalErr)
+		}
+		buf.Write(fmBytes)
+	}
+	buf.WriteString(delimiter)
+	buf.WriteByte('\n')
+	buf.Write(body)
+	return buf.Bytes(), nil
+}
+
+// findDelimiter returns the byte offset of the next "---" line starting at or
+// after `from`, the length of that line (including its trailing newline), and
+// whether one was found. A delimiter line is a line whose only content
+// before the newline (or EOF) is exactly "---".
+func findDelimiter(content []byte, from int) (offset, lineLen int, found bool) {
+	for i := from; i < len(content); {
+		end := i
+		for end < len(content) && content[end] != '\n' {
+			end++
+		}
+		line := content[i:end]
+		if isDelimiterLine(line) {
+			lineEnd := end
+			if lineEnd < len(content) && content[lineEnd] == '\n' {
+				lineEnd++
+			}
+			return i, lineEnd - i, true
+		}
+		if end == len(content) {
+			return 0, 0, false
+		}
+		i = end + 1
+	}
+	return 0, 0, false
+}
+
+// isDelimiterLine reports whether the (newline-stripped) line bytes match
+// the frontmatter delimiter exactly. Trailing carriage return is tolerated
+// for CRLF files.
+func isDelimiterLine(line []byte) bool {
+	if len(line) > 0 && line[len(line)-1] == '\r' {
+		line = line[:len(line)-1]
+	}
+	return bytes.Equal(line, []byte(delimiter))
+}
+
+// orderKeys returns the keys of `frontmatter` in canonical order:
+//  1. Keys named in `columnsOrder`, in that order, if present in frontmatter.
+//  2. Remaining keys in alphabetical order.
+//
+// Keys named in columnsOrder but absent from frontmatter are skipped (we
+// don't synthesize null entries).
+func orderKeys(frontmatter map[string]any, columnsOrder []string) []string {
+	if len(frontmatter) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(frontmatter))
+	ordered := make([]string, 0, len(frontmatter))
+	for _, k := range columnsOrder {
+		if _, ok := frontmatter[k]; !ok {
+			continue
+		}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		ordered = append(ordered, k)
+	}
+	var rest []string
+	for k := range frontmatter {
+		if seen[k] {
+			continue
+		}
+		rest = append(rest, k)
+	}
+	sort.Strings(rest)
+	ordered = append(ordered, rest...)
+	return ordered
+}
+
+// buildMappingNode constructs a yaml.Node representing a mapping whose keys
+// appear in the order given by `keys`. This is the only reliable way to
+// force key order with gopkg.in/yaml.v3: marshaling a map[string]any does
+// not preserve order.
+func buildMappingNode(frontmatter map[string]any, keys []string) (*yaml.Node, error) {
+	root := &yaml.Node{Kind: yaml.MappingNode}
+	for _, k := range keys {
+		keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: k}
+		valNode := &yaml.Node{}
+		err := valNode.Encode(frontmatter[k])
+		if err != nil {
+			return nil, fmt.Errorf("encode value for key %q: %w", k, err)
+		}
+		root.Content = append(root.Content, keyNode, valNode)
+	}
+	return root, nil
+}

--- a/pkg/ingitdb/markdown/markdown_test.go
+++ b/pkg/ingitdb/markdown/markdown_test.go
@@ -1,0 +1,237 @@
+package markdown
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse_FullDocument(t *testing.T) {
+	t.Parallel()
+	// Date is quoted to keep yaml.v3 from auto-parsing it into a time.Time
+	// per YAML 1.2's timestamp rule.
+	input := []byte("---\ntitle: Hello\ndate: \"2024-01-01\"\ntags: intro\n---\n# Heading\n\nBody text.\n")
+	fm, body, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if fm["title"] != "Hello" {
+		t.Errorf("title: got %v, want %q", fm["title"], "Hello")
+	}
+	if fm["date"] != "2024-01-01" {
+		t.Errorf("date: got %v, want %q", fm["date"], "2024-01-01")
+	}
+	if fm["tags"] != "intro" {
+		t.Errorf("tags: got %v, want %q", fm["tags"], "intro")
+	}
+	want := "# Heading\n\nBody text.\n"
+	if string(body) != want {
+		t.Errorf("body: got %q, want %q", body, want)
+	}
+}
+
+func TestParse_NoFrontmatter(t *testing.T) {
+	t.Parallel()
+	input := []byte("# Just a body\n\nNo frontmatter here.\n")
+	fm, body, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if fm != nil {
+		t.Errorf("frontmatter should be nil, got %v", fm)
+	}
+	if string(body) != string(input) {
+		t.Errorf("body: got %q, want %q", body, input)
+	}
+}
+
+func TestParse_EmptyFrontmatter(t *testing.T) {
+	t.Parallel()
+	input := []byte("---\n---\nbody\n")
+	fm, body, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("frontmatter should be a non-nil empty map")
+	}
+	if len(fm) != 0 {
+		t.Errorf("frontmatter should be empty, got %v", fm)
+	}
+	if string(body) != "body\n" {
+		t.Errorf("body: got %q, want %q", body, "body\n")
+	}
+}
+
+func TestParse_EmptyBody(t *testing.T) {
+	t.Parallel()
+	input := []byte("---\ntitle: X\n---\n")
+	fm, body, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if fm["title"] != "X" {
+		t.Errorf("title: got %v, want %q", fm["title"], "X")
+	}
+	if len(body) != 0 {
+		t.Errorf("body should be empty, got %q", body)
+	}
+}
+
+func TestParse_UnclosedFrontmatter(t *testing.T) {
+	t.Parallel()
+	input := []byte("---\ntitle: Stuck\nbody without closing\n")
+	_, _, err := Parse(input)
+	if err == nil {
+		t.Fatal("expected error for unclosed frontmatter, got nil")
+	}
+	if !strings.Contains(err.Error(), "no matching closing") {
+		t.Errorf("error message should mention missing closing delimiter, got: %v", err)
+	}
+}
+
+func TestParse_InvalidYAML(t *testing.T) {
+	t.Parallel()
+	input := []byte("---\nkey: : invalid\n---\nbody\n")
+	_, _, err := Parse(input)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML frontmatter, got nil")
+	}
+}
+
+func TestParse_DelimiterInBodyIsPreserved(t *testing.T) {
+	t.Parallel()
+	body := "Body line 1\n---\nBody line 3 (after a divider)\n"
+	input := []byte("---\ntitle: X\n---\n" + body)
+	fm, gotBody, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if fm["title"] != "X" {
+		t.Errorf("title: got %v, want %q", fm["title"], "X")
+	}
+	if string(gotBody) != body {
+		t.Errorf("body: got %q, want %q", gotBody, body)
+	}
+}
+
+func TestParse_CRLFLineEndings(t *testing.T) {
+	t.Parallel()
+	input := []byte("---\r\ntitle: X\r\n---\r\nBody.\r\n")
+	fm, body, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if fm["title"] != "X" {
+		t.Errorf("title: got %v, want %q", fm["title"], "X")
+	}
+	if string(body) != "Body.\r\n" {
+		t.Errorf("body: got %q, want %q", body, "Body.\r\n")
+	}
+}
+
+func TestSerialize_RespectsColumnsOrder(t *testing.T) {
+	t.Parallel()
+	fm := map[string]any{
+		"title": "Hello",
+		"date":  "2024-01-01",
+		"tags":  "intro",
+	}
+	out, err := Serialize(fm, []string{"title", "date", "tags"}, []byte("body\n"))
+	if err != nil {
+		t.Fatalf("Serialize returned error: %v", err)
+	}
+	got := string(out)
+	wantPrefix := "---\ntitle: Hello\ndate: \"2024-01-01\"\ntags: intro\n---\nbody\n"
+	if got != wantPrefix {
+		t.Errorf("output mismatch:\n got: %q\nwant: %q", got, wantPrefix)
+	}
+}
+
+func TestSerialize_AlphabeticalFallback(t *testing.T) {
+	t.Parallel()
+	fm := map[string]any{
+		"zeta":  "z",
+		"alpha": "a",
+		"mu":    "m",
+	}
+	// columnsOrder empty -> all keys fall back to alphabetical.
+	out, err := Serialize(fm, nil, []byte(""))
+	if err != nil {
+		t.Fatalf("Serialize returned error: %v", err)
+	}
+	want := "---\nalpha: a\nmu: m\nzeta: z\n---\n"
+	if string(out) != want {
+		t.Errorf("output mismatch:\n got: %q\nwant: %q", out, want)
+	}
+}
+
+func TestSerialize_OrderedThenAlphabetical(t *testing.T) {
+	t.Parallel()
+	fm := map[string]any{
+		"title":  "T",
+		"author": "A",
+		"date":   "D",
+		"zzz":    "Z",
+		"banana": "B",
+	}
+	out, err := Serialize(fm, []string{"title", "date"}, []byte(""))
+	if err != nil {
+		t.Fatalf("Serialize returned error: %v", err)
+	}
+	// title, date (ordered), then alphabetical: author, banana, zzz.
+	want := "---\ntitle: T\ndate: D\nauthor: A\nbanana: B\nzzz: Z\n---\n"
+	if string(out) != want {
+		t.Errorf("output mismatch:\n got: %q\nwant: %q", out, want)
+	}
+}
+
+func TestSerialize_EmptyFrontmatter(t *testing.T) {
+	t.Parallel()
+	out, err := Serialize(map[string]any{}, nil, []byte("just body\n"))
+	if err != nil {
+		t.Fatalf("Serialize returned error: %v", err)
+	}
+	want := "---\n---\njust body\n"
+	if string(out) != want {
+		t.Errorf("output mismatch:\n got: %q\nwant: %q", out, want)
+	}
+}
+
+func TestSerialize_PreservesBodyBytesVerbatim(t *testing.T) {
+	t.Parallel()
+	// Body contains every byte that might tempt a "smart" writer to mangle:
+	// trailing spaces, CRLF, blank lines, leading whitespace.
+	body := []byte("  leading spaces\n\n\nblank lines above\ntrailing tabs\t\t\n\r\nfinal\r\n")
+	out, err := Serialize(map[string]any{"k": "v"}, []string{"k"}, body)
+	if err != nil {
+		t.Fatalf("Serialize returned error: %v", err)
+	}
+	wantSuffix := "---\n" + string(body)
+	if !strings.HasSuffix(string(out), wantSuffix) {
+		t.Errorf("body bytes were modified: output tail = %q, want suffix %q",
+			string(out[len(out)-len(wantSuffix):]), wantSuffix)
+	}
+}
+
+func TestRoundTrip_ParseSerializeParse(t *testing.T) {
+	t.Parallel()
+	original := []byte("---\ntitle: Hello\ndate: \"2024-01-01\"\n---\n# Body\n\nLine.\n")
+	fm, body, err := Parse(original)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	out, err := Serialize(fm, []string{"title", "date"}, body)
+	if err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+	fm2, body2, err := Parse(out)
+	if err != nil {
+		t.Fatalf("re-Parse: %v", err)
+	}
+	if fm2["title"] != fm["title"] || fm2["date"] != fm["date"] {
+		t.Errorf("frontmatter mismatch after round-trip: %v vs %v", fm, fm2)
+	}
+	if string(body2) != string(body) {
+		t.Errorf("body mismatch after round-trip:\n got: %q\nwant: %q", body2, body)
+	}
+}

--- a/pkg/ingitdb/record_file_def.go
+++ b/pkg/ingitdb/record_file_def.go
@@ -24,6 +24,12 @@ type RecordFileDef struct {
 	// "[]map[string]any" - list of records
 	// "map[$record_id]map[$field_name]any" - all records in one file; top-level keys are record IDs, second level is field names
 	RecordType RecordType `yaml:"type"`
+
+	// ContentField is the name of the column that maps to the Markdown body
+	// in a `format: markdown` collection. When empty, the default
+	// (`DefaultMarkdownContentField`, `$content`) is used.
+	// It MUST only be set when Format is `markdown`.
+	ContentField string `yaml:"content_field,omitempty"`
 }
 
 func (rfd RecordFileDef) Validate() error {
@@ -39,7 +45,26 @@ func (rfd RecordFileDef) Validate() error {
 	default:
 		return fmt.Errorf("invalid record type %q", rfd.RecordType)
 	}
+	if rfd.Format == RecordFormatMarkdown {
+		if rfd.RecordType != SingleRecord {
+			return fmt.Errorf("format %q requires record type %q, got %q",
+				RecordFormatMarkdown, SingleRecord, rfd.RecordType)
+		}
+	} else if rfd.ContentField != "" {
+		return fmt.Errorf("content_field is only valid for format %q, got %q",
+			RecordFormatMarkdown, rfd.Format)
+	}
 	return nil
+}
+
+// ResolvedContentField returns the configured content_field name when set,
+// otherwise the default (`$content`). Only meaningful when Format is
+// `markdown`.
+func (rfd RecordFileDef) ResolvedContentField() string {
+	if rfd.ContentField != "" {
+		return rfd.ContentField
+	}
+	return DefaultMarkdownContentField
 }
 
 // RecordsBasePath returns "$records" when record_file.name contains {key},


### PR DESCRIPTION
## Summary

Implements the [markdown-records feature spec](https://github.com/ingitdb/ingitdb/blob/main/spec/features/markdown-records/README.md): collections may now declare `record_file.format: markdown` to store records as `.md` files with YAML frontmatter mapped to declared columns and the document body mapped to a configurable content column (`$content` by default).

- **Schema**: new `RecordFormat*` constants, `RecordFileDef.ContentField`, `ColumnDef.Format`, and validation that rejects invalid combinations (markdown + non-`SingleRecord` type; `content_field` on non-markdown formats).
- **Parser** (`pkg/ingitdb/markdown`): pure `Parse` / `Serialize` functions. Body bytes preserved verbatim; frontmatter key order canonicalized to `columns_order` with alphabetical fallback.
- **Filesystem layer** (`pkg/dalgo2fsingitdb`): markdown dispatch wired into `Get` / `Insert` / `Set`; strict-columns enforcement on read.
- **`time.Time` round-trip works**: a `time.Time` in memory serializes to YAML 1.2 timestamp form on disk and parses back as `time.Time` — same behavior as plain YAML records.

## Example

```yaml
# blog_posts/.collection/definition.yaml
record_file:
  name: "{key}.md"
  format: markdown
  type: map[string]any
  content_field: content    # optional; default is $content

columns:
  title:   { type: string, required: true }
  date:    { type: string }
  tags:    { type: string }
  content: { type: string, format: markdown }
```

```markdown
---
title: Hello World
date: "2024-01-01"
tags: intro
---
# Hello

This is the post body.
```

## Test plan

- [x] `go test ./...` — all green, including:
  - 12 markdown parser tests (`pkg/ingitdb/markdown`)
  - 9 CRUD + validation tests (`pkg/dalgo2fsingitdb/markdown_crud_test.go`):
    - Insert + Get with default `$content`
    - Insert + Get with custom `content_field`
    - Update preserves body when only frontmatter changes
    - Delete removes the file; Get reports `Exists() == false`
    - `time.Time` field round-trip
    - Undeclared frontmatter keys ignored on read
    - Validation rejects `content_field` on non-markdown formats
    - Validation rejects markdown with non-`SingleRecord` types
    - `ResolvedContentField` default + override
- [x] `golangci-lint run` — 0 issues.
- [ ] Manual end-to-end via CLI (`ingitdb create record --id ... --data ...`) — not exercised yet; the file-layer wiring is symmetric with YAML and JSON paths.

## Notes

- Frontmatter key ordering follows the spec: declared `columns_order` first, then alphabetical for declared columns not in `columns_order`. Body bytes are written verbatim.
- The `no-rewrite-without-change` rule from the `storage-format` spec is *not* yet implemented (this PR keeps the existing behavior of always writing on `Set`/`Insert`). Worth a follow-up PR since it applies to all record formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)