### PR TITLE
feat(markdown): integration fixes + exclude_regex for record files

### DIFF
--- a/pkg/dalgo2fsingitdb/markdown_crud_test.go
+++ b/pkg/dalgo2fsingitdb/markdown_crud_test.go
@@ -418,3 +418,101 @@ func TestMarkdown_ResolvedContentField_Override(t *testing.T) {
 		t.Errorf("ResolvedContentField override: got %q, want %q", got, "body")
 	}
 }
+
+func TestMarkdown_ExcludeRegex_QuerySkipsMatching(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeMarkdownDef(t, dir, "")
+	def.Collections["test.notes"].RecordFile.ExcludeRegex = `^README\.md$`
+	db := openTestDB(t, dir, def)
+
+	ctx := context.Background()
+	// Insert a real record.
+	realKey := dal.NewKeyWithID("test.notes", "real")
+	realRec := dal.NewRecordWithData(realKey, map[string]any{
+		"title":                             "Real note",
+		ingitdb.DefaultMarkdownContentField: "body\n",
+	})
+	if err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, realRec)
+	}); err != nil {
+		t.Fatalf("Insert real: %v", err)
+	}
+
+	// Drop a README.md right next to the records. It must NOT be returned
+	// by query.
+	readmePath := filepath.Join(dir, "$records", "README.md")
+	if err := os.WriteFile(readmePath, []byte("# README\nNot a record.\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile README: %v", err)
+	}
+
+	qb := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("test.notes", "")))
+	q := qb.SelectIntoRecord(func() dal.Record {
+		return dal.NewRecordWithData(dal.NewKeyWithID("test.notes", ""), map[string]any{})
+	})
+	var count int
+	err := db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		reader, qerr := tx.ExecuteQueryToRecordsReader(ctx, q)
+		if qerr != nil {
+			return qerr
+		}
+		defer func() { _ = reader.Close() }()
+		for {
+			_, nextErr := reader.Next()
+			if nextErr != nil {
+				break
+			}
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("query returned %d records, want 1 (README.md should be excluded)", count)
+	}
+}
+
+func TestMarkdown_ExcludeRegex_InvalidRegexRejected(t *testing.T) {
+	t.Parallel()
+	rfd := ingitdb.RecordFileDef{
+		Name:         "{key}.md",
+		Format:       ingitdb.RecordFormatMarkdown,
+		RecordType:   ingitdb.SingleRecord,
+		ExcludeRegex: "[unclosed",
+	}
+	err := rfd.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for invalid regex, got nil")
+	}
+	if !strings.Contains(err.Error(), "exclude_regex") {
+		t.Errorf("error should mention exclude_regex, got: %v", err)
+	}
+}
+
+func TestMarkdown_IsExcluded(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		pattern string
+		input   string
+		want    bool
+	}{
+		{"no pattern", "", "README.md", false},
+		{"matches", `^README\.md$`, "README.md", true},
+		{"doesnt match", `^README\.md$`, "prod001.md", false},
+		{"partial match still excludes", `^_`, "_draft.md", true},
+		{"invalid regex returns false (validate catches it elsewhere)", "[unclosed", "any.md", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rfd := ingitdb.RecordFileDef{ExcludeRegex: tc.pattern}
+			if got := rfd.IsExcluded(tc.input); got != tc.want {
+				t.Errorf("IsExcluded(%q) with pattern %q: got %v, want %v",
+					tc.input, tc.pattern, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/dalgo2fsingitdb/record_file.go
+++ b/pkg/dalgo2fsingitdb/record_file.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/dal-go/dalgo/dal"
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/markdown"
 	"gopkg.in/yaml.v3"
@@ -61,20 +62,11 @@ func readMarkdownRecord(path string, colDef *ingitdb.CollectionDef) (map[string]
 		}
 		return nil, false, fmt.Errorf("failed to read file %s: %w", path, err)
 	}
-	frontmatter, body, parseErr := markdown.Parse(fileContent)
+	data, parseErr := dalgo2ingitdb.ParseRecordContentForCollection(fileContent, colDef)
 	if parseErr != nil {
 		return nil, false, fmt.Errorf("failed to parse markdown file %s: %w", path, parseErr)
 	}
-	result := make(map[string]any, len(frontmatter)+1)
-	for key, value := range frontmatter {
-		if _, declared := colDef.Columns[key]; !declared {
-			continue
-		}
-		result[key] = value
-	}
-	contentField := colDef.RecordFile.ResolvedContentField()
-	result[contentField] = string(body)
-	return result, true, nil
+	return data, true, nil
 }
 
 // writeMarkdownRecord writes a Markdown record file. The content_field

--- a/pkg/dalgo2fsingitdb/tx_query.go
+++ b/pkg/dalgo2fsingitdb/tx_query.go
@@ -151,7 +151,16 @@ func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 		if recordKey == "" {
 			continue
 		}
-		data, found, readErr := readRecordFromFile(match, colDef.RecordFile.Format)
+		var (
+			data    map[string]any
+			found   bool
+			readErr error
+		)
+		if colDef.RecordFile.Format == ingitdb.RecordFormatMarkdown {
+			data, found, readErr = readMarkdownRecord(match, colDef)
+		} else {
+			data, found, readErr = readRecordFromFile(match, colDef.RecordFile.Format)
+		}
 		if readErr != nil {
 			return nil, readErr
 		}

--- a/pkg/dalgo2fsingitdb/tx_query.go
+++ b/pkg/dalgo2fsingitdb/tx_query.go
@@ -143,6 +143,9 @@ func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 
 	records := make([]dal.Record, 0, len(matches))
 	for _, match := range matches {
+		if colDef.RecordFile.IsExcluded(filepath.Base(match)) {
+			continue
+		}
 		relPath, relErr := filepath.Rel(basePath, match)
 		if relErr != nil {
 			return nil, relErr

--- a/pkg/dalgo2ghingitdb/tx_readonly.go
+++ b/pkg/dalgo2ghingitdb/tx_readonly.go
@@ -92,7 +92,7 @@ func (r readonlyTx) readSingleRecord(ctx context.Context, recordPath string, col
 	if !found {
 		return nil, false, nil
 	}
-	data, parseErr := dalgo2ingitdb.ParseRecordContent(content, colDef.RecordFile.Format)
+	data, parseErr := dalgo2ingitdb.ParseRecordContentForCollection(content, colDef)
 	if parseErr != nil {
 		return nil, false, parseErr
 	}

--- a/pkg/dalgo2ingitdb/parse.go
+++ b/pkg/dalgo2ingitdb/parse.go
@@ -5,19 +5,22 @@ import (
 	"fmt"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/markdown"
 	"gopkg.in/yaml.v3"
 )
 
 // ParseRecordContent parses record content in YAML or JSON format.
+// For markdown-format collections use ParseRecordContentForCollection,
+// which also has access to the column schema and content-field name.
 func ParseRecordContent(content []byte, format ingitdb.RecordFormat) (map[string]any, error) {
 	var data map[string]any
 	switch format {
-	case "yaml", "yml":
+	case ingitdb.RecordFormatYAML, ingitdb.RecordFormatYML:
 		err := yaml.Unmarshal(content, &data)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse YAML record: %w", err)
 		}
-	case "json":
+	case ingitdb.RecordFormatJSON:
 		err := json.Unmarshal(content, &data)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse JSON record: %w", err)
@@ -26,6 +29,33 @@ func ParseRecordContent(content []byte, format ingitdb.RecordFormat) (map[string
 		return nil, fmt.Errorf("unsupported record format %q", format)
 	}
 	return data, nil
+}
+
+// ParseRecordContentForCollection parses record content using the
+// collection's declared format. For YAML and JSON this is equivalent to
+// ParseRecordContent. For markdown records it parses YAML frontmatter,
+// filters to columns declared in the schema, and exposes the body under
+// the configured content_field column name.
+func ParseRecordContentForCollection(content []byte, colDef *ingitdb.CollectionDef) (map[string]any, error) {
+	if colDef == nil || colDef.RecordFile == nil {
+		return nil, fmt.Errorf("collection definition missing record_file")
+	}
+	if colDef.RecordFile.Format != ingitdb.RecordFormatMarkdown {
+		return ParseRecordContent(content, colDef.RecordFile.Format)
+	}
+	frontmatter, body, err := markdown.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse markdown record: %w", err)
+	}
+	result := make(map[string]any, len(frontmatter)+1)
+	for key, value := range frontmatter {
+		if _, declared := colDef.Columns[key]; !declared {
+			continue
+		}
+		result[key] = value
+	}
+	result[colDef.RecordFile.ResolvedContentField()] = string(body)
+	return result, nil
 }
 
 // ParseMapOfRecordsContent parses content containing a map of ID-keyed records.

--- a/pkg/ingitdb/datavalidator/validator.go
+++ b/pkg/ingitdb/datavalidator/validator.go
@@ -23,7 +23,7 @@ func (sv *simpleValidator) Validate(_ context.Context, _ string, def *ingitdb.De
 
 	// Count records for each collection
 	for collectionKey, colDef := range def.Collections {
-		total, err := countRecords(colDef.DirPath)
+		total, err := countRecords(colDef)
 		if err != nil {
 			// Don't fail validation on count error, just set 0
 			total = 0
@@ -45,15 +45,38 @@ func (sv *simpleValidator) Validate(_ context.Context, _ string, def *ingitdb.De
 // countRecords counts the number of record keys in a collection directory.
 // When a $records/ subdirectory exists (used for per-key record files), it
 // counts entries inside that directory instead of at the collection root.
-func countRecords(collectionPath string) (int, error) {
+func countRecords(colDef *ingitdb.CollectionDef) (int, error) {
+	collectionPath := colDef.DirPath
+	exts := expectedRecordExtensions(colDef)
 	recordsSubDir := filepath.Join(collectionPath, "$records")
 	if info, err := os.Stat(recordsSubDir); err == nil && info.IsDir() {
-		return countEntries(recordsSubDir)
+		return countEntries(recordsSubDir, exts)
 	}
-	return countEntries(collectionPath)
+	return countEntries(collectionPath, exts)
 }
 
-func countEntries(dirPath string) (int, error) {
+// expectedRecordExtensions returns the file extensions that count as record
+// files for this collection.
+//
+// The authoritative source is the collection's `record_file.name` template
+// (e.g. `{key}.md`) — whatever extension it ends with is the single
+// extension that records use. This naturally extends to any future format
+// without needing changes here.
+//
+// When no `RecordFile` is declared (older test fixtures), the legacy
+// permissive set (`.yaml`, `.yml`, `.json`) is returned so existing
+// behavior is preserved.
+func expectedRecordExtensions(colDef *ingitdb.CollectionDef) map[string]struct{} {
+	if colDef.RecordFile != nil && colDef.RecordFile.Name != "" {
+		ext := strings.ToLower(filepath.Ext(colDef.RecordFile.Name))
+		if ext != "" {
+			return map[string]struct{}{ext: {}}
+		}
+	}
+	return map[string]struct{}{".yaml": {}, ".yml": {}, ".json": {}}
+}
+
+func countEntries(dirPath string, exts map[string]struct{}) (int, error) {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return 0, err
@@ -70,11 +93,11 @@ func countEntries(dirPath string) (int, error) {
 		}
 		if entry.IsDir() {
 			seen[name] = struct{}{}
-		} else {
-			ext := strings.ToLower(filepath.Ext(name))
-			if ext == ".yaml" || ext == ".json" {
-				seen[strings.TrimSuffix(name, filepath.Ext(name))] = struct{}{}
-			}
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(name))
+		if _, ok := exts[ext]; ok {
+			seen[strings.TrimSuffix(name, filepath.Ext(name))] = struct{}{}
 		}
 	}
 	return len(seen), nil

--- a/pkg/ingitdb/datavalidator/validator.go
+++ b/pkg/ingitdb/datavalidator/validator.go
@@ -50,9 +50,9 @@ func countRecords(colDef *ingitdb.CollectionDef) (int, error) {
 	exts := expectedRecordExtensions(colDef)
 	recordsSubDir := filepath.Join(collectionPath, "$records")
 	if info, err := os.Stat(recordsSubDir); err == nil && info.IsDir() {
-		return countEntries(recordsSubDir, exts)
+		return countEntries(recordsSubDir, exts, colDef.RecordFile)
 	}
-	return countEntries(collectionPath, exts)
+	return countEntries(collectionPath, exts, colDef.RecordFile)
 }
 
 // expectedRecordExtensions returns the file extensions that count as record
@@ -76,7 +76,7 @@ func expectedRecordExtensions(colDef *ingitdb.CollectionDef) map[string]struct{}
 	return map[string]struct{}{".yaml": {}, ".yml": {}, ".json": {}}
 }
 
-func countEntries(dirPath string, exts map[string]struct{}) (int, error) {
+func countEntries(dirPath string, exts map[string]struct{}, rfd *ingitdb.RecordFileDef) (int, error) {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return 0, err
@@ -89,6 +89,9 @@ func countEntries(dirPath string, exts map[string]struct{}) (int, error) {
 	for _, entry := range entries {
 		name := entry.Name()
 		if strings.HasPrefix(name, ".") || name == "$records" {
+			continue
+		}
+		if rfd != nil && rfd.IsExcluded(name) {
 			continue
 		}
 		if entry.IsDir() {

--- a/pkg/ingitdb/materializer/records_reader_fs.go
+++ b/pkg/ingitdb/materializer/records_reader_fs.go
@@ -79,7 +79,7 @@ func (r FileRecordsReader) ReadRecords(
 			if err != nil {
 				return fmt.Errorf("failed to read record %s: %w", filePath, err)
 			}
-			data, err := dalgo2ingitdb.ParseRecordContent(content, col.RecordFile.Format)
+			data, err := dalgo2ingitdb.ParseRecordContentForCollection(content, col)
 			if err != nil {
 				return fmt.Errorf("failed to parse record %s: %w", filePath, err)
 			}

--- a/pkg/ingitdb/materializer/records_reader_fs.go
+++ b/pkg/ingitdb/materializer/records_reader_fs.go
@@ -75,6 +75,9 @@ func (r FileRecordsReader) ReadRecords(
 			return fmt.Errorf("failed to glob records: %w", err)
 		}
 		for _, filePath := range matches {
+			if col.RecordFile.IsExcluded(filepath.Base(filePath)) {
+				continue
+			}
 			content, err := r.readFile(filePath)
 			if err != nil {
 				return fmt.Errorf("failed to read record %s: %w", filePath, err)

--- a/pkg/ingitdb/record_file_def.go
+++ b/pkg/ingitdb/record_file_def.go
@@ -2,6 +2,7 @@ package ingitdb
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/dal-go/dalgo/dal"
@@ -30,6 +31,16 @@ type RecordFileDef struct {
 	// (`DefaultMarkdownContentField`, `$content`) is used.
 	// It MUST only be set when Format is `markdown`.
 	ContentField string `yaml:"content_field,omitempty"`
+
+	// ExcludeRegex is an optional regular expression applied to the
+	// basename of each candidate record file. Files whose basename matches
+	// MUST be excluded from reads, validation, and record counts.
+	//
+	// Typical use: a record directory that legitimately contains a
+	// README.md or .gitkeep alongside `{key}.md` records can set
+	// `exclude_regex: '^README\.md$'` to keep those auxiliary files from
+	// being treated as records.
+	ExcludeRegex string `yaml:"exclude_regex,omitempty"`
 }
 
 func (rfd RecordFileDef) Validate() error {
@@ -54,7 +65,31 @@ func (rfd RecordFileDef) Validate() error {
 		return fmt.Errorf("content_field is only valid for format %q, got %q",
 			RecordFormatMarkdown, rfd.Format)
 	}
+	if rfd.ExcludeRegex != "" {
+		if _, err := regexp.Compile(rfd.ExcludeRegex); err != nil {
+			return fmt.Errorf("invalid exclude_regex %q: %w", rfd.ExcludeRegex, err)
+		}
+	}
 	return nil
+}
+
+// IsExcluded reports whether a filename's basename matches the configured
+// `exclude_regex`. Files for which IsExcluded returns true MUST be omitted
+// from reads, validation, and record counts.
+//
+// When ExcludeRegex is empty, IsExcluded always returns false. When the
+// regex fails to compile (caller skipped Validate()), IsExcluded returns
+// false rather than panicking — Validate() is the right place to surface
+// compile errors.
+func (rfd RecordFileDef) IsExcluded(filename string) bool {
+	if rfd.ExcludeRegex == "" {
+		return false
+	}
+	re, err := regexp.Compile(rfd.ExcludeRegex)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(filename)
 }
 
 // ResolvedContentField returns the configured content_field name when set,


### PR DESCRIPTION
## Summary

Follow-on work after [#53](https://github.com/ingitdb/ingitdb-cli/pull/53) (which only included the initial markdown commit). Two commits:

### `c9b0ed2` — markdown integration across all reader paths

The initial PR wired markdown into the DALgo filesystem transactions. Several adjacent read paths still assumed yaml/json only and failed for markdown collections:

- `ingitdb validate` reported **0 records** for markdown collections (extension filter hardcoded to `.yaml`/`.json`).
- `ingitdb query` failed with **"unsupported record format \"markdown\""** (format-blind helpers in `tx_query` and the materializer).
- `dalgo2ghingitdb` (GitHub-source reads) had the same blind spot.

Fixes:

- `dalgo2ingitdb.ParseRecordContentForCollection` — schema-aware single entry point that dispatches yaml/json to the existing parser and markdown to the new parser + content-field projection. Shared by `dalgo2fsingitdb`, `dalgo2ghingitdb`, and the materializer.
- `dalgo2fsingitdb/tx_query.go` — dispatch markdown so query works on markdown collections.
- `datavalidator.expectedRecordExtensions` — derive the expected record-file extension from `record_file.name` (the schema's authoritative source) rather than hardcoding. Falls back to legacy permissive set when `RecordFile` is absent (test fixtures).

### `3e68566` — `record_file.exclude_regex`

Adds an optional regex applied to record-file basenames so auxiliary files (README.md, .gitkeep, index.md) sitting alongside records are uniformly omitted from **reads, validation, and counts**.

- `RecordFileDef.ExcludeRegex string` + `IsExcluded(filename) bool` helper.
- `Validate()` compiles the regex and rejects uncompilable patterns.
- Applied in `datavalidator.countEntries`, `tx_query`, and the materializer's records reader.

Tests:
- `TestMarkdown_ExcludeRegex_QuerySkipsMatching` — insert one real record, drop README.md, query returns only the real record.
- `TestMarkdown_ExcludeRegex_InvalidRegexRejected` — uncompilable regex fails schema validation.
- `TestMarkdown_IsExcluded` — table-driven coverage of empty pattern, exact match, no match, partial match, invalid regex.

Spec: <https://github.com/ingitdb/ingitdb/pull/3> documents the four new REQs and acceptance criterion in `record-file-types`.

## End-to-end verification

Against the demo-commerce-ingitdb repo (which converted its products collection to markdown in <https://github.com/ingitdb/demo-commerce-ingitdb/pull/2>):

```
$ go run ./cmd/ingitdb validate --path <demo>
All 30 records are valid for collection: products

$ # drop a README.md inside $records/, then re-run:
$ go run ./cmd/ingitdb validate --path <demo>
All 30 records are valid for collection: products    # README.md not miscounted

$ go run ./cmd/ingitdb query --path <demo> -c products -f '$id' | wc -l
30                                                    # README.md not in results
```

## Test plan

- [x] `go test ./...` — all green (including 12 new markdown parser tests, 9 CRUD tests, 4 new exclude_regex tests).
- [x] `golangci-lint run` — 0 issues.
- [x] CLI end-to-end: `validate`, `read record`, `query -w category_id==phones`, exclude_regex behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)