### PR TITLE
feat(ingr): support INGR records via the official ingr-go library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/ingr-io/ingr-go v0.0.2 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-runewidth v0.0.23 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,10 @@ github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfh
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/ingr-io/ingr-go v0.0.1 h1:xV+R8OI3tDajgYdOHhniNQ3FzeBdt25zEAalBwX/Xx8=
+github.com/ingr-io/ingr-go v0.0.1/go.mod h1:nEGETUdP7aqrxk1dG8gJ8Yjp1wjpufPuCQeZtmznrac=
+github.com/ingr-io/ingr-go v0.0.2 h1:2AfFllqzCe2dCNtxIUo306oYzaZr//YzrVOHd0C73nI=
+github.com/ingr-io/ingr-go v0.0.2/go.mod h1:gb/dGW0qXziCq9iAIgk0yITyWY013w2bhdYiXO0RLuY=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/pkg/dalgo2fsingitdb/ingr_crud_test.go
+++ b/pkg/dalgo2fsingitdb/ingr_crud_test.go
@@ -1,0 +1,322 @@
+package dalgo2fsingitdb
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// makeINGRDef builds a Definition with one MapOfRecords INGR collection
+// rooted at dirPath. INGR is inherently multi-record and uses $ID as the
+// reserved first column, so it pairs naturally with MapOfRecords (keyed by
+// $ID).
+func makeINGRDef(t *testing.T, dirPath string) *ingitdb.Definition {
+	t.Helper()
+	colDef := &ingitdb.CollectionDef{
+		ID:      "test.entries",
+		DirPath: dirPath,
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:       "entries.ingr",
+			Format:     ingitdb.RecordFormatINGR,
+			RecordType: ingitdb.MapOfRecords,
+		},
+		Columns: map[string]*ingitdb.ColumnDef{
+			"sku":   {Type: ingitdb.ColumnTypeString},
+			"name":  {Type: ingitdb.ColumnTypeString},
+			"price": {Type: ingitdb.ColumnTypeFloat},
+		},
+		ColumnsOrder: []string{"sku", "name", "price"},
+	}
+	return &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"test.entries": colDef,
+		},
+	}
+}
+
+func ingrFilePath(dirPath string) string {
+	// MapOfRecords stores all records in a single file at collection root
+	// (no {key} placeholder in the name template, so no $records/ subdir).
+	return filepath.Join(dirPath, "entries.ingr")
+}
+
+func TestINGR_InsertGet(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeINGRDef(t, dir)
+	db := openTestDB(t, dir, def)
+
+	ctx := context.Background()
+	key := dal.NewKeyWithID("test.entries", "e001")
+	data := map[string]any{
+		"sku":   "WIDGET-001",
+		"name":  "Widget",
+		"price": 9.99,
+	}
+	rec := dal.NewRecordWithData(key, data)
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, rec)
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// On-disk: a real INGR file with the project's header line.
+	got, err := os.ReadFile(ingrFilePath(dir))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	gotStr := string(got)
+	if !strings.HasPrefix(gotStr, "# INGR.io | test.entries: ") {
+		t.Errorf("INGR file should start with the standard header line, got prefix: %q",
+			gotStr[:min(len(gotStr), 50)])
+	}
+	if !strings.Contains(gotStr, `"e001"`) {
+		t.Errorf("INGR file should contain $ID value \"e001\", got:\n%s", gotStr)
+	}
+	if !strings.Contains(gotStr, `"WIDGET-001"`) {
+		t.Errorf("INGR file should contain sku value, got:\n%s", gotStr)
+	}
+
+	// Read back via DALgo.
+	readData := map[string]any{}
+	readRec := dal.NewRecordWithData(dal.NewKeyWithID("test.entries", "e001"), readData)
+	err = db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, readRec)
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !readRec.Exists() {
+		t.Fatal("record should exist after Insert")
+	}
+	if readData["sku"] != "WIDGET-001" {
+		t.Errorf("sku: got %v, want %q", readData["sku"], "WIDGET-001")
+	}
+	if readData["name"] != "Widget" {
+		t.Errorf("name: got %v, want %q", readData["name"], "Widget")
+	}
+	if readData["price"] != 9.99 {
+		t.Errorf("price: got %v (%T), want 9.99", readData["price"], readData["price"])
+	}
+	// $ID is stripped from the per-record field map (it's the key, not a field).
+	if _, present := readData["$ID"]; present {
+		t.Errorf("$ID should not appear in per-record field map, got: %v", readData["$ID"])
+	}
+}
+
+func TestINGR_MultipleRecords_RoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeINGRDef(t, dir)
+	db := openTestDB(t, dir, def)
+	ctx := context.Background()
+
+	// Insert three records in mixed order.
+	inserts := []struct {
+		id   string
+		data map[string]any
+	}{
+		{"e003", map[string]any{"sku": "C", "name": "Charlie", "price": 3.30}},
+		{"e001", map[string]any{"sku": "A", "name": "Alpha", "price": 1.10}},
+		{"e002", map[string]any{"sku": "B", "name": "Bravo", "price": 2.20}},
+	}
+	for _, ins := range inserts {
+		err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			return tx.Insert(ctx, dal.NewRecordWithData(
+				dal.NewKeyWithID("test.entries", ins.id), ins.data))
+		})
+		if err != nil {
+			t.Fatalf("Insert %s: %v", ins.id, err)
+		}
+	}
+
+	// Read each back; verify field values survive the multi-record round-trip.
+	for _, ins := range inserts {
+		readData := map[string]any{}
+		readRec := dal.NewRecordWithData(
+			dal.NewKeyWithID("test.entries", ins.id), readData)
+		err := db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+			return tx.Get(ctx, readRec)
+		})
+		if err != nil {
+			t.Fatalf("Get %s: %v", ins.id, err)
+		}
+		if readData["sku"] != ins.data["sku"] {
+			t.Errorf("%s.sku: got %v, want %v", ins.id, readData["sku"], ins.data["sku"])
+		}
+		if readData["name"] != ins.data["name"] {
+			t.Errorf("%s.name: got %v, want %v", ins.id, readData["name"], ins.data["name"])
+		}
+	}
+
+	// On-disk: all three records should appear, sorted by $ID for
+	// deterministic output (e001, e002, e003).
+	got, err := os.ReadFile(ingrFilePath(dir))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	gotStr := string(got)
+	idxA := strings.Index(gotStr, `"e001"`)
+	idxB := strings.Index(gotStr, `"e002"`)
+	idxC := strings.Index(gotStr, `"e003"`)
+	if idxA < 0 || idxB < 0 || idxC < 0 {
+		t.Fatalf("INGR file missing one or more $ID values: a=%d b=%d c=%d\n%s",
+			idxA, idxB, idxC, gotStr)
+	}
+	if idxA >= idxB || idxB >= idxC {
+		t.Errorf("INGR file should list records sorted by $ID; got positions a=%d b=%d c=%d",
+			idxA, idxB, idxC)
+	}
+}
+
+func TestINGR_Update(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeINGRDef(t, dir)
+	db := openTestDB(t, dir, def)
+	ctx := context.Background()
+	key := dal.NewKeyWithID("test.entries", "e001")
+
+	if err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, dal.NewRecordWithData(key, map[string]any{
+			"sku": "A", "name": "Alpha", "price": 1.10,
+		}))
+	}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		cur := map[string]any{}
+		rec := dal.NewRecordWithData(key, cur)
+		if getErr := tx.Get(ctx, rec); getErr != nil {
+			return getErr
+		}
+		cur["name"] = "Alpha (Updated)"
+		cur["price"] = 1.50
+		return tx.Set(ctx, rec)
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	readData := map[string]any{}
+	readRec := dal.NewRecordWithData(dal.NewKeyWithID("test.entries", "e001"), readData)
+	if err := db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, readRec)
+	}); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if readData["name"] != "Alpha (Updated)" {
+		t.Errorf("name: got %v, want %q", readData["name"], "Alpha (Updated)")
+	}
+	if readData["price"] != 1.50 {
+		t.Errorf("price: got %v, want 1.50", readData["price"])
+	}
+	if readData["sku"] != "A" {
+		t.Errorf("sku should be preserved across update: got %v, want %q",
+			readData["sku"], "A")
+	}
+}
+
+func TestINGR_Delete(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := makeINGRDef(t, dir)
+	db := openTestDB(t, dir, def)
+	ctx := context.Background()
+	a := dal.NewKeyWithID("test.entries", "a")
+	b := dal.NewKeyWithID("test.entries", "b")
+
+	for _, k := range []*dal.Key{a, b} {
+		err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			return tx.Insert(ctx, dal.NewRecordWithData(k, map[string]any{
+				"sku": k.ID.(string), "name": "x", "price": 1.0,
+			}))
+		})
+		if err != nil {
+			t.Fatalf("Insert %v: %v", k.ID, err)
+		}
+	}
+
+	// Delete one.
+	if err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Delete(ctx, a)
+	}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// a is gone, b survives.
+	recA := dal.NewRecordWithData(dal.NewKeyWithID("test.entries", "a"), map[string]any{})
+	recB := dal.NewRecordWithData(dal.NewKeyWithID("test.entries", "b"), map[string]any{})
+	if err := db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		if getErr := tx.Get(ctx, recA); getErr != nil {
+			return getErr
+		}
+		return tx.Get(ctx, recB)
+	}); err != nil {
+		t.Fatalf("Get after Delete: %v", err)
+	}
+	if recA.Exists() {
+		t.Error("record a should not exist after Delete")
+	}
+	if !recB.Exists() {
+		t.Error("record b should still exist after deleting a")
+	}
+}
+
+func TestINGR_RejectsSingleRecordType(t *testing.T) {
+	t.Parallel()
+	rfd := ingitdb.RecordFileDef{
+		Name:       "x.ingr",
+		Format:     ingitdb.RecordFormatINGR,
+		RecordType: ingitdb.SingleRecord,
+	}
+	err := rfd.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for ingr + SingleRecord, got nil")
+	}
+	if !strings.Contains(err.Error(), "ingr") {
+		t.Errorf("error should mention ingr format, got: %v", err)
+	}
+}
+
+func TestINGR_RejectsMissingID(t *testing.T) {
+	t.Parallel()
+	// An INGR file with a record that has no $ID column should fail parse
+	// when reshaped into MapOfRecords.
+	dir := t.TempDir()
+	def := makeINGRDef(t, dir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Hand-author a malformed INGR (no $ID column declared).
+	malformed := `# INGR.io | test.entries: sku, name, price
+"X"
+"X-name"
+1.0
+# 1 record
+`
+	if err := os.WriteFile(ingrFilePath(dir), []byte(malformed), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	db := openTestDB(t, dir, def)
+	ctx := context.Background()
+	rec := dal.NewRecordWithData(dal.NewKeyWithID("test.entries", "X"), map[string]any{})
+	err := db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, rec)
+	})
+	if err == nil {
+		t.Fatal("expected error reading INGR without $ID column, got nil")
+	}
+	if !strings.Contains(err.Error(), "$ID") {
+		t.Errorf("error should mention missing $ID, got: %v", err)
+	}
+	_ = errors.Is // keep the import meaningful even if no Is check below
+}

--- a/pkg/dalgo2fsingitdb/record_file.go
+++ b/pkg/dalgo2fsingitdb/record_file.go
@@ -172,27 +172,44 @@ func deleteRecordFile(path string) error {
 // readMapOfRecordsFile reads a file whose top-level keys are record IDs and whose
 // values are field maps (map[$record_id]map[$field_name]any layout).
 // Returns (nil, false, nil) if the file does not exist.
+//
+// Dispatches to dalgo2ingitdb.ParseMapOfRecordsContent which understands
+// every supported format including INGR (where records are read from a
+// list and re-indexed by `$ID`).
 func readMapOfRecordsFile(path string, format ingitdb.RecordFormat) (map[string]map[string]any, bool, error) {
-	raw, found, err := readRecordFromFile(path, format)
-	if err != nil || !found {
-		return nil, found, err
-	}
-	result := make(map[string]map[string]any, len(raw))
-	for id, val := range raw {
-		fields, ok := val.(map[string]any)
-		if !ok {
-			return nil, false, fmt.Errorf("record %q in %s is not a map", id, path)
+	fileContent, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
 		}
-		result[id] = fields
+		return nil, false, fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+	result, parseErr := dalgo2ingitdb.ParseMapOfRecordsContent(fileContent, format)
+	if parseErr != nil {
+		return nil, false, fmt.Errorf("failed to parse records file %s: %w", path, parseErr)
 	}
 	return result, true, nil
 }
 
 // writeMapOfRecordsFile writes a map[$record_id]map[$field_name]any dataset back to a file.
-func writeMapOfRecordsFile(path string, format ingitdb.RecordFormat, data map[string]map[string]any) error {
-	raw := make(map[string]any, len(data))
-	for id, fields := range data {
-		raw[id] = fields
+//
+// For yaml/json/toml the data is written as a top-level ID-keyed mapping
+// using the existing single-record writer. For INGR the data is flattened
+// into a record list with `$ID` injected, written through the ingr-io
+// RecordsWriter; the recordsetName is taken from the collection ID and
+// column order from the collection schema.
+func writeMapOfRecordsFile(path string, colDef *ingitdb.CollectionDef, data map[string]map[string]any) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
-	return writeRecordToFile(path, format, raw)
+	content, err := dalgo2ingitdb.EncodeMapOfRecordsContent(
+		data, colDef.RecordFile.Format, colDef.ID, colDef.ColumnsOrder)
+	if err != nil {
+		return fmt.Errorf("failed to encode records for %s: %w", path, err)
+	}
+	if writeErr := os.WriteFile(path, content, 0o644); writeErr != nil {
+		return fmt.Errorf("failed to write file %s: %w", path, writeErr)
+	}
+	return nil
 }

--- a/pkg/dalgo2fsingitdb/tx_error_test.go
+++ b/pkg/dalgo2fsingitdb/tx_error_test.go
@@ -598,7 +598,15 @@ func TestWriteMapOfRecordsFile_Success(t *testing.T) {
 		"id2": {"field": "value2"},
 	}
 
-	err := writeMapOfRecordsFile(path, "yaml", data)
+	colDef := &ingitdb.CollectionDef{
+		ID: "test",
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:       "test.yaml",
+			Format:     ingitdb.RecordFormatYAML,
+			RecordType: ingitdb.MapOfRecords,
+		},
+	}
+	err := writeMapOfRecordsFile(path, colDef, data)
 	if err != nil {
 		t.Fatalf("writeMapOfRecordsFile: %v", err)
 	}

--- a/pkg/dalgo2fsingitdb/tx_readwrite.go
+++ b/pkg/dalgo2fsingitdb/tx_readwrite.go
@@ -42,7 +42,7 @@ func (r readwriteTx) Set(ctx context.Context, record dal.Record) error {
 			allRecords = make(map[string]map[string]any)
 		}
 		allRecords[recordKey] = dalgo2ingitdb.ApplyLocaleToWrite(data, colDef.Columns)
-		return writeMapOfRecordsFile(path, colDef.RecordFile.Format, allRecords)
+		return writeMapOfRecordsFile(path, colDef, allRecords)
 	default:
 		if colDef.RecordFile.Format == ingitdb.RecordFormatMarkdown {
 			return writeMarkdownRecord(path, colDef, data)
@@ -76,7 +76,7 @@ func (r readwriteTx) Delete(ctx context.Context, key *dal.Key) error {
 			return dal.ErrRecordNotFound
 		}
 		delete(allRecords, recordKey)
-		return writeMapOfRecordsFile(path, colDef.RecordFile.Format, allRecords)
+		return writeMapOfRecordsFile(path, colDef, allRecords)
 	default:
 		return deleteRecordFile(path)
 	}
@@ -124,7 +124,7 @@ func (r readwriteTx) Insert(ctx context.Context, record dal.Record, opts ...dal.
 		record.SetError(nil)
 		data := record.Data().(map[string]any)
 		allRecords[recordKey] = dalgo2ingitdb.ApplyLocaleToWrite(data, colDef.Columns)
-		return writeMapOfRecordsFile(path, colDef.RecordFile.Format, allRecords)
+		return writeMapOfRecordsFile(path, colDef, allRecords)
 	default:
 		_, statErr := os.Stat(path)
 		if statErr == nil {

--- a/pkg/dalgo2ghingitdb/tx_readwrite.go
+++ b/pkg/dalgo2ghingitdb/tx_readwrite.go
@@ -50,11 +50,8 @@ func (r readwriteTx) Set(ctx context.Context, record dal.Record) error {
 			return fmt.Errorf("record data is not map[string]any")
 		}
 		allRecords[recordKey] = dalgo2ingitdb.ApplyLocaleToWrite(data, colDef.Columns)
-		toEncode := make(map[string]any, len(allRecords))
-		for k, v := range allRecords {
-			toEncode[k] = v
-		}
-		encoded, encodeErr := encodeRecordContent(toEncode, colDef.RecordFile.Format)
+		encoded, encodeErr := dalgo2ingitdb.EncodeMapOfRecordsContent(
+			allRecords, colDef.RecordFile.Format, colDef.ID, colDef.ColumnsOrder)
 		if encodeErr != nil {
 			return encodeErr
 		}
@@ -118,11 +115,8 @@ func (r readwriteTx) Insert(ctx context.Context, record dal.Record, opts ...dal.
 			return fmt.Errorf("record data is not map[string]any")
 		}
 		allRecords[recordKey] = dalgo2ingitdb.ApplyLocaleToWrite(data, colDef.Columns)
-		toEncode := make(map[string]any, len(allRecords))
-		for k, v := range allRecords {
-			toEncode[k] = v
-		}
-		encoded, encodeErr := encodeRecordContent(toEncode, colDef.RecordFile.Format)
+		encoded, encodeErr := dalgo2ingitdb.EncodeMapOfRecordsContent(
+			allRecords, colDef.RecordFile.Format, colDef.ID, colDef.ColumnsOrder)
 		if encodeErr != nil {
 			return encodeErr
 		}

--- a/pkg/dalgo2ingitdb/parse.go
+++ b/pkg/dalgo2ingitdb/parse.go
@@ -1,9 +1,12 @@
 package dalgo2ingitdb
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 
+	"github.com/ingr-io/ingr-go/ingr"
 	"github.com/pelletier/go-toml/v2"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
@@ -66,7 +69,17 @@ func ParseRecordContentForCollection(content []byte, colDef *ingitdb.CollectionD
 }
 
 // ParseMapOfRecordsContent parses content containing a map of ID-keyed records.
+//
+// For yaml/json/toml, the file's top-level structure is a mapping from record
+// ID to a per-record field map; we re-shape it into map[string]map[string]any.
+//
+// For INGR, the file is a list of records where the reserved `$ID` column
+// holds each record's key; we read the list and re-index by `$ID`. Records
+// missing `$ID`, or with duplicate `$ID` values, are rejected as malformed.
 func ParseMapOfRecordsContent(content []byte, format ingitdb.RecordFormat) (map[string]map[string]any, error) {
+	if format == ingitdb.RecordFormatINGR {
+		return parseINGRAsMap(content)
+	}
 	raw, err := ParseRecordContent(content, format)
 	if err != nil {
 		return nil, err
@@ -78,6 +91,153 @@ func ParseMapOfRecordsContent(content []byte, format ingitdb.RecordFormat) (map[
 			return nil, fmt.Errorf("record %q is not a map", id)
 		}
 		result[id] = recordFields
+	}
+	return result, nil
+}
+
+// EncodeMapOfRecordsContent serializes a map of ID-keyed records into the
+// declared format. For yaml/json/toml, the data is written as a top-level
+// mapping (record ID -> field map). For INGR, the data is flattened into a
+// list of records (each gets `$ID` injected as the first column) and
+// written via the ingr-io writer.
+//
+// recordsetName is used as the INGR header title (typically the collection
+// ID). It is ignored for non-INGR formats.
+// columnsOrder controls the column order in the INGR header; when empty,
+// columns are emitted in alphabetical order with `$ID` first.
+func EncodeMapOfRecordsContent(data map[string]map[string]any, format ingitdb.RecordFormat, recordsetName string, columnsOrder []string) ([]byte, error) {
+	if format != ingitdb.RecordFormatINGR {
+		// Existing formats: write as a top-level map.
+		raw := make(map[string]any, len(data))
+		for id, fields := range data {
+			raw[id] = fields
+		}
+		return marshalForFormat(raw, format)
+	}
+	return encodeINGRFromMap(data, recordsetName, columnsOrder)
+}
+
+func marshalForFormat(value any, format ingitdb.RecordFormat) ([]byte, error) {
+	switch format {
+	case ingitdb.RecordFormatYAML, ingitdb.RecordFormatYML:
+		out, err := yaml.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal YAML: %w", err)
+		}
+		return out, nil
+	case ingitdb.RecordFormatJSON:
+		out, err := json.MarshalIndent(value, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		return append(out, '\n'), nil
+	case ingitdb.RecordFormatTOML:
+		out, err := toml.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal TOML: %w", err)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported record format %q", format)
+	}
+}
+
+// encodeINGRFromMap flattens an ID-keyed record map into a deterministic
+// list of records and writes it via the ingr-io RecordsWriter.
+func encodeINGRFromMap(data map[string]map[string]any, recordsetName string, columnsOrder []string) ([]byte, error) {
+	// Resolve column order. $ID is always first. Then declared columns_order,
+	// then any remaining keys alphabetically. Same canonical ordering rule
+	// we use for markdown frontmatter.
+	colNames := resolveINGRColumns(data, columnsOrder)
+
+	cols := make([]ingr.ColDef, 0, len(colNames))
+	for _, name := range colNames {
+		cols = append(cols, ingr.ColDef{Name: name})
+	}
+
+	// Sort record IDs for deterministic output.
+	ids := make([]string, 0, len(data))
+	for id := range data {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	records := make([]ingr.Record, 0, len(ids))
+	for _, id := range ids {
+		row := make(map[string]any, len(data[id])+1)
+		for k, v := range data[id] {
+			row[k] = v
+		}
+		row["$ID"] = id
+		records = append(records, ingr.NewMapRecordEntry(id, row))
+	}
+
+	var buf bytes.Buffer
+	w := ingr.NewRecordsWriter(&buf)
+	if _, err := w.WriteHeader(recordsetName, cols); err != nil {
+		return nil, fmt.Errorf("ingr: write header: %w", err)
+	}
+	if _, err := w.WriteRecords(0, records...); err != nil {
+		return nil, fmt.Errorf("ingr: write records: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("ingr: close writer: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func resolveINGRColumns(data map[string]map[string]any, columnsOrder []string) []string {
+	seen := map[string]bool{"$ID": true}
+	ordered := []string{"$ID"}
+	for _, name := range columnsOrder {
+		if name == "$ID" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		ordered = append(ordered, name)
+	}
+	var rest []string
+	for _, fields := range data {
+		for name := range fields {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			rest = append(rest, name)
+		}
+	}
+	sort.Strings(rest)
+	return append(ordered, rest...)
+}
+
+// parseINGRAsMap decodes an INGR file into map[string]map[string]any keyed
+// by the reserved `$ID` column.
+func parseINGRAsMap(content []byte) (map[string]map[string]any, error) {
+	var rows []map[string]any
+	if err := ingr.Unmarshal(content, &rows); err != nil {
+		return nil, fmt.Errorf("failed to parse INGR records: %w", err)
+	}
+	result := make(map[string]map[string]any, len(rows))
+	for i, row := range rows {
+		raw, ok := row["$ID"]
+		if !ok {
+			return nil, fmt.Errorf("INGR record at index %d is missing required $ID column", i)
+		}
+		id, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("INGR record at index %d has non-string $ID value (%T)", i, raw)
+		}
+		if _, dup := result[id]; dup {
+			return nil, fmt.Errorf("INGR record has duplicate $ID %q", id)
+		}
+		fields := make(map[string]any, len(row)-1)
+		for k, v := range row {
+			if k == "$ID" {
+				continue
+			}
+			fields[k] = v
+		}
+		result[id] = fields
 	}
 	return result, nil
 }

--- a/pkg/ingitdb/constants.go
+++ b/pkg/ingitdb/constants.go
@@ -11,6 +11,7 @@ const (
 	RecordFormatJSON     RecordFormat = "json"
 	RecordFormatMarkdown RecordFormat = "markdown"
 	RecordFormatTOML     RecordFormat = "toml"
+	RecordFormatINGR     RecordFormat = "ingr"
 )
 
 // DefaultMarkdownContentField is the default name of the column that holds

--- a/pkg/ingitdb/record_file_def.go
+++ b/pkg/ingitdb/record_file_def.go
@@ -65,6 +65,10 @@ func (rfd RecordFileDef) Validate() error {
 		return fmt.Errorf("content_field is only valid for format %q, got %q",
 			RecordFormatMarkdown, rfd.Format)
 	}
+	if rfd.Format == RecordFormatINGR && rfd.RecordType == SingleRecord {
+		return fmt.Errorf("format %q does not support record type %q (use %q or %q)",
+			RecordFormatINGR, SingleRecord, ListOfRecords, MapOfRecords)
+	}
 	if rfd.ExcludeRegex != "" {
 		if _, err := regexp.Compile(rfd.ExcludeRegex); err != nil {
 			return fmt.Errorf("invalid exclude_regex %q: %w", rfd.ExcludeRegex, err)


### PR DESCRIPTION
## Summary

Adds [INGR (in-Git Records)](https://ingr.io) as a record file format, using the official `github.com/ingr-io/ingr-go` v0.0.2 library released today. A collection opts in via:

\`\`\`yaml
record_file:
  name: entries.ingr
  type: \"map[\$record_id]map[\$field_name]any\"
  format: ingr
\`\`\`

## Why INGR

- **Diff-friendly**: one JSON-encoded value per line; small edits produce small diffs even within batched records.
- **Multi-record per file**: a single file holds many records under one header — useful for collections where per-record file granularity is overkill.
- **Self-describing**: the `# INGR.io | <name>: <cols>` header carries the column list and types.
- **Integrity**: optional sha256 footer (supported by the library).

## Architectural scope

INGR is inherently multi-record. \`RecordFileDef.Validate()\` rejects \`format: ingr\` paired with \`type: map[string]any\` (one file per record).

**Initial implementation scope: \`MapOfRecords\` only** (re-indexes by INGR's reserved \`\$ID\` column on read; injects \`\$ID\` from the key on write). Pure list-shape (\`[]map[string]any\`) would require new DALgo \`ListOfRecords\` plumbing that doesn't exist for *any* format today — orthogonal to INGR and worth a separate piece of work later. Spec notes this explicitly.

## Implementation

- Reader: \`dalgo2ingitdb.ParseMapOfRecordsContent\` dispatches \`ingr\` to a new \`parseINGRAsMap\` using \`ingr.Unmarshal(&[]map[string]any{})\` + re-index. Malformed inputs (missing \`\$ID\`, non-string \`\$ID\`, duplicate \`\$ID\`) are rejected with descriptive errors.
- Writer: new shared \`dalgo2ingitdb.EncodeMapOfRecordsContent\` helper. For yaml/json/toml it serialises the top-level ID-keyed mapping; for INGR it flattens to a deterministic record list (records sorted by \`\$ID\`, columns \`\$ID\` first → \`columns_order\` → alphabetical fallback) and writes via \`ingr.NewRecordsWriter\` with the collection ID as the header title.
- The three \`MapOfRecords\` branches in \`dalgo2ghingitdb/tx_readwrite.go\` were updated to use the new helper too, removing duplicate yaml/json switches.
- \`readMapOfRecordsFile\` (filesystem) was rewritten to delegate to \`ParseMapOfRecordsContent\` so all formats route through the same parser entry point.

## Tests

6 CRUD round-trips in \`pkg/dalgo2fsingitdb/ingr_crud_test.go\`:
- \`TestINGR_InsertGet\` — verifies the on-disk \`# INGR.io | test.entries: ...\` header and quoted \`\$ID\` value.
- \`TestINGR_MultipleRecords_RoundTrip\` — three records inserted in mixed order; output sorted by \`\$ID\`.
- \`TestINGR_Update\` — Set preserves untouched fields across the shared file.
- \`TestINGR_Delete\` — deletes one record; others survive.
- \`TestINGR_RejectsSingleRecordType\` — schema validation rejects \`format: ingr\` + \`type: map[string]any\`.
- \`TestINGR_RejectsMissingID\` — hand-authored INGR without \`\$ID\` column is rejected on read.

## Validation

- \`go test ./...\` — all green.
- \`golangci-lint run\` — 0 issues.

## Spec

Companion: <https://github.com/ingitdb/ingitdb/pull/5> adds \`ingr\` to \`storage-format#req:supported-formats\` and introduces \`record-file-types#req:ingr-multi-record-only\`.

## Dependency note

\`github.com/ingr-io/ingr-go\` v0.0.1 shipped writer-only; the decoder API I integrate against was released as v0.0.2 today. We're depending on a normal versioned release — no \`@main\` pseudo-versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)