### PR TITLE
chore: use dalgo end2end in ingitdb-cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	charm.land/fang/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/charmbracelet/x/term v0.2.2
-	github.com/dal-go/dalgo-end2end-tests v0.0.88
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-github/v88 v88.0.0
 	github.com/ingr-io/ingr-go v0.0.2
@@ -69,7 +68,7 @@ require (
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.18.2 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
-	github.com/dal-go/dalgo v0.44.0
+	github.com/dal-go/dalgo v0.44.2
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/strongo/random v0.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,10 +36,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dal-go/dalgo v0.44.0 h1:jPo+Y1VlqJ0dQKhdIJFcs8thkyIYnsKS3KsIg5baAqc=
-github.com/dal-go/dalgo v0.44.0/go.mod h1:WdTy5jE3v9LjiOeHVkMgHEi8nn0GeImQmjfuuJpYISY=
-github.com/dal-go/dalgo-end2end-tests v0.0.88 h1:6xKtfh5qWvM//jFokws9oZ/FrHwsz9BzGu0ieW/iDnc=
-github.com/dal-go/dalgo-end2end-tests v0.0.88/go.mod h1:GaUtr0ZEDrUTffqxhsU+YuhylrcAmH/qTsYa+REXXco=
+github.com/dal-go/dalgo v0.44.2 h1:+eJG5WTiGcy82jAgJrNzuDhlpyWISDfIAnMJ3l7G7wE=
+github.com/dal-go/dalgo v0.44.2/go.mod h1:HHMUuCMutAlYEblDTVws7jeZs56jvOCbOuxVs6I01tE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/pkg/dalgo2ingitdb/e2e_test.go
+++ b/pkg/dalgo2ingitdb/e2e_test.go
@@ -3,13 +3,13 @@ package dalgo2ingitdb
 import (
 	"testing"
 
-	e2e "github.com/dal-go/dalgo-end2end-tests"
-	"github.com/dal-go/dalgo-end2end-tests/models"
+	e2e "github.com/dal-go/dalgo/end2end"
+	"github.com/dal-go/dalgo/end2end/models"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/config"
 )
 
-// TestDalgoEndToEnd runs the shared dalgo-end2end-tests suite against this
+// TestDalgoEndToEnd runs the shared dalgo end-to-end suite against this
 // driver. It sets up the two collections the suite uses (DalgoE2E_E2ETest1/2)
 // as single-record JSON collections, then delegates to end2end.TestDalgoDB.
 //

--- a/pkg/dalgo2ingitdb/tx_readonly.go
+++ b/pkg/dalgo2ingitdb/tx_readonly.go
@@ -34,7 +34,7 @@ func (r readonlyTx) Options() dal.TransactionOptions { return r.opts }
 
 // Get loads a single record. SingleRecord and MapOfRecords layouts are
 // supported. A missing record sets dal.ErrRecordNotFound on the record AND
-// returns it, per the dalgo Getter contract (dalgo-end2end-tests singleGetTest
+// returns it, per the dalgo Getter contract (dalgo end-to-end singleGetTest
 // checks dal.IsNotFound on the returned error).
 func (r readonlyTx) Get(_ context.Context, record dal.Record) error {
 	colDef, recordKey, err := r.resolveCollection(record.Key())
@@ -122,7 +122,7 @@ func (r readonlyTx) GetMulti(ctx context.Context, records []dal.Record) error {
 	for _, rec := range records {
 		// Per-record not-found is reported via record.SetError (set inside Get),
 		// not as a batch-level error — matching the dalgo GetMulti contract
-		// (dalgo-end2end-tests). Only genuine errors abort the batch.
+		// (dalgo end-to-end suite). Only genuine errors abort the batch.
 		if err := r.Get(ctx, rec); err != nil && !dal.IsNotFound(err) {
 			return err
 		}


### PR DESCRIPTION
Switch pkg/dalgo2ingitdb from the legacy standalone dalgo-end2end-tests module to the in-repo github.com/dal-go/dalgo/end2end package.

Validation:
- go mod tidy
- HOME=/private/tmp GOCACHE=/private/tmp/ingitdb-gocache GOMODCACHE=/private/tmp/ingitdb-gomodcache go test ./pkg/dalgo2ingitdb

Notes:
- The temporary local replace against ../dal-go/dalgo was removed.
- Only the adapter migration files are included in this commit.