### PR TITLE
feat: computed columns (inline Starlark formulas)

### DIFF
--- a/cmd/ingitdb/commands/select_computed_test.go
+++ b/cmd/ingitdb/commands/select_computed_test.go
@@ -1,0 +1,214 @@
+package commands
+
+// specscore: feature/cli/select
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2fsingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"gopkg.in/yaml.v3"
+)
+
+// peopleComputedDef returns a Definition with a `people` collection whose
+// `full_name` column is computed from stored `first_name`/`last_name`.
+func peopleComputedDef(dirPath string) *ingitdb.Definition {
+	return &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"people": {
+				ID:      "people",
+				DirPath: dirPath,
+				RecordFile: &ingitdb.RecordFileDef{
+					Name:       "{key}.yaml",
+					Format:     "yaml",
+					RecordType: ingitdb.SingleRecord,
+				},
+				Columns: map[string]*ingitdb.ColumnDef{
+					"first_name": {Type: ingitdb.ColumnTypeString},
+					"last_name":  {Type: ingitdb.ColumnTypeString},
+					"full_name":  {Type: ingitdb.ColumnTypeString, Formula: `first_name + " " + last_name`},
+				},
+				ColumnsOrder: []string{"first_name", "last_name", "full_name"},
+			},
+		},
+	}
+}
+
+// peopleSelectDeps mirrors selectTestDeps but uses peopleComputedDef so the
+// `people` collection with the computed `full_name` column is available.
+func peopleSelectDeps(t *testing.T, dir string) (
+	func() (string, error),
+	func() (string, error),
+	func(string, ...ingitdb.ReadOption) (*ingitdb.Definition, error),
+	func(string, *ingitdb.Definition) (dal.DB, error),
+	func(...any),
+) {
+	t.Helper()
+	def := peopleComputedDef(dir)
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return dir, nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) { return def, nil }
+	newDB := func(root string, d *ingitdb.Definition) (dal.DB, error) {
+		return dalgo2fsingitdb.NewLocalDBWithDef(root, d)
+	}
+	logf := func(...any) {}
+	return homeDir, getWd, readDef, newDB, logf
+}
+
+// seedPerson writes a YAML file for a person record with only the stored
+// columns (the computed full_name must never be persisted).
+func seedPerson(t *testing.T, dir, key, first, last string) {
+	t.Helper()
+	colDir := filepath.Join(dir, "$records")
+	if err := os.MkdirAll(colDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	out, err := yaml.Marshal(map[string]any{"first_name": first, "last_name": last})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(colDir, key+".yaml"), out, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// AC: filter-on-computed-column — --where on the computed full_name returns
+// only records whose computed value matches, even though full_name is never
+// stored on disk.
+func TestSelect_SetMode_WhereOnComputedColumn(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := peopleSelectDeps(t, dir)
+	seedPerson(t, dir, "ada", "Ada", "Lovelace")
+	seedPerson(t, dir, "alan", "Alan", "Turing")
+
+	stdout, err := runSelectCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people",
+		`--where=full_name == "Ada Lovelace"`,
+		"--format=yaml",
+	)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(stdout, "Ada Lovelace") {
+		t.Errorf("expected the matching computed full_name in output:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "Alan Turing") {
+		t.Errorf("did NOT expect non-matching record in output:\n%s", stdout)
+	}
+}
+
+// AC: order-by-computed-column — order_by on the computed full_name sorts by
+// the computed value, not by any stored column.
+func TestSelect_SetMode_OrderByComputedColumn(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := peopleSelectDeps(t, dir)
+	// Seeded out of full_name order; record keys chosen so $id order differs
+	// from full_name order, proving the sort uses the computed value.
+	seedPerson(t, dir, "z", "Grace", "Hopper")
+	seedPerson(t, dir, "a", "Ada", "Lovelace")
+	seedPerson(t, dir, "m", "Alan", "Turing")
+
+	stdout, err := runSelectCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people",
+		"--order-by=full_name",
+		"--fields=$id,full_name",
+		"--format=csv",
+	)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	idxAda := strings.Index(stdout, "Ada Lovelace")
+	idxAlan := strings.Index(stdout, "Alan Turing")
+	idxGrace := strings.Index(stdout, "Grace Hopper")
+	if idxAda < 0 || idxAlan < 0 || idxGrace < 0 {
+		t.Fatalf("expected all three computed full_name values in output:\n%s", stdout)
+	}
+	// Ascending by full_name: "Ada Lovelace" < "Alan Turing" < "Grace Hopper".
+	if idxAda >= idxAlan || idxAlan >= idxGrace {
+		t.Errorf("rows not ordered by computed full_name asc (Ada<Alan<Grace), got positions Ada@%d Alan@%d Grace@%d:\n%s",
+			idxAda, idxAlan, idxGrace, stdout)
+	}
+}
+
+// peopleBadFormulaDef returns a people definition whose computed column's
+// formula references a missing field, so formula evaluation fails on read.
+func peopleBadFormulaDef(dirPath string, recordType ingitdb.RecordType, name string) *ingitdb.Definition {
+	return &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"people": {
+				ID:      "people",
+				DirPath: dirPath,
+				RecordFile: &ingitdb.RecordFileDef{
+					Name:       name,
+					Format:     "yaml",
+					RecordType: recordType,
+				},
+				Columns: map[string]*ingitdb.ColumnDef{
+					"first_name": {Type: ingitdb.ColumnTypeString},
+					"full_name":  {Type: ingitdb.ColumnTypeString, Formula: `missing_field + "x"`},
+				},
+				ColumnsOrder: []string{"first_name", "full_name"},
+			},
+		},
+	}
+}
+
+// A formula that references a non-existent field surfaces as a query error
+// from the single-records read path (covers the formula error branch).
+func TestSelect_SetMode_ComputedFormulaError_SingleRecords(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := peopleBadFormulaDef(dir, ingitdb.SingleRecord, "{key}.yaml")
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return dir, nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) { return def, nil }
+	newDB := func(root string, d *ingitdb.Definition) (dal.DB, error) {
+		return dalgo2fsingitdb.NewLocalDBWithDef(root, d)
+	}
+	logf := func(...any) {}
+	seedPerson(t, dir, "ada", "Ada", "Lovelace")
+
+	_, err := runSelectCmd(t, homeDir, getWd, readDef, newDB, logf, "--path="+dir, "--from=people")
+	if err == nil {
+		t.Fatal("expected error from failing computed-column formula")
+	}
+	if !strings.Contains(err.Error(), "full_name") {
+		t.Errorf("error should name the failing computed column, got: %v", err)
+	}
+}
+
+// Same error branch on the map-of-records read path.
+func TestSelect_SetMode_ComputedFormulaError_MapOfRecords(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := peopleBadFormulaDef(dir, ingitdb.MapOfRecords, "all.yaml")
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return dir, nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) { return def, nil }
+	newDB := func(root string, d *ingitdb.Definition) (dal.DB, error) {
+		return dalgo2fsingitdb.NewLocalDBWithDef(root, d)
+	}
+	logf := func(...any) {}
+	out, err := yaml.Marshal(map[string]any{"ada": map[string]any{"first_name": "Ada"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "all.yaml"), out, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err = runSelectCmd(t, homeDir, getWd, readDef, newDB, logf, "--path="+dir, "--from=people")
+	if err == nil {
+		t.Fatal("expected error from failing computed-column formula")
+	}
+	if !strings.Contains(err.Error(), "full_name") {
+		t.Errorf("error should name the failing computed column, got: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	go.starlark.net v0.0.0-20260522144826-ec58d4b459e2
 	go.uber.org/mock v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -50,7 +51,6 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+go.starlark.net v0.0.0-20260522144826-ec58d4b459e2 h1:3cIeOhZXLdLHnBoLyKdJu4SEAEuM/av/VFzB5twLo8k=
+go.starlark.net v0.0.0-20260522144826-ec58d4b459e2/go.mod h1:Iue6g6iirlfLoVi/DYCi5/x0h/bAOuWF3dULTKpt2Vo=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=

--- a/pkg/dalgo2fsingitdb/tx_query.go
+++ b/pkg/dalgo2fsingitdb/tx_query.go
@@ -166,8 +166,14 @@ func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 		if !found {
 			continue
 		}
+		// Evaluate computed columns before WHERE/ORDER BY so they can be
+		// filtered and sorted exactly like stored columns.
+		computed, computeErr := dalgo2ingitdb.ApplyFormulasToRead(data, colDef.Columns, colDef.ID, recordKey)
+		if computeErr != nil {
+			return nil, computeErr
+		}
 		key := dal.NewKeyWithID(colDef.ID, recordKey)
-		rec := dal.NewRecordWithData(key, data)
+		rec := dal.NewRecordWithData(key, computed)
 		rec.SetError(nil)
 		records = append(records, rec)
 	}
@@ -187,8 +193,12 @@ func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	records := make([]dal.Record, 0, len(allData))
 	for id, fields := range allData {
 		normalized := dalgo2ingitdb.ApplyLocaleToRead(fields, colDef.Columns)
+		computed, computeErr := dalgo2ingitdb.ApplyFormulasToRead(normalized, colDef.Columns, colDef.ID, id)
+		if computeErr != nil {
+			return nil, computeErr
+		}
 		key := dal.NewKeyWithID(colDef.ID, id)
-		rec := dal.NewRecordWithData(key, normalized)
+		rec := dal.NewRecordWithData(key, computed)
 		rec.SetError(nil)
 		records = append(records, rec)
 	}

--- a/pkg/dalgo2ingitdb/computed_columns.go
+++ b/pkg/dalgo2ingitdb/computed_columns.go
@@ -1,0 +1,50 @@
+package dalgo2ingitdb
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// validateNoStoredComputedValues rejects any record that supplies a value for a
+// computed column (a column with a non-empty Formula). A computed column's value
+// is derived solely from its formula and must never be stored. The presence of
+// the column's key in data is a rejection regardless of the value.
+func (r readwriteTx) validateNoStoredComputedValues(collectionID string, colDef *ingitdb.CollectionDef, recordKey string, data map[string]any) error {
+	for _, field := range orderedComputedColumns(colDef) {
+		if _, ok := data[field]; ok {
+			return fmt.Errorf("dalgo2ingitdb: collection %q record %q column %q is a computed column and cannot be stored", collectionID, recordKey, field)
+		}
+	}
+	return nil
+}
+
+// orderedComputedColumns returns the names of computed columns (Formula != "")
+// in a deterministic order: columns named in ColumnsOrder first, then any
+// remaining computed columns sorted lexicographically.
+func orderedComputedColumns(colDef *ingitdb.CollectionDef) []string {
+	if colDef == nil || len(colDef.Columns) == 0 {
+		return nil
+	}
+	fields := make([]string, 0, len(colDef.Columns))
+	seen := make(map[string]bool, len(colDef.Columns))
+	for _, field := range colDef.ColumnsOrder {
+		column, ok := colDef.Columns[field]
+		if !ok || column == nil || column.Formula == "" {
+			continue
+		}
+		fields = append(fields, field)
+		seen[field] = true
+	}
+	var remaining []string
+	for field, column := range colDef.Columns {
+		if seen[field] || column == nil || column.Formula == "" {
+			continue
+		}
+		remaining = append(remaining, field)
+	}
+	sort.Strings(remaining)
+	fields = append(fields, remaining...)
+	return fields
+}

--- a/pkg/dalgo2ingitdb/computed_columns.go
+++ b/pkg/dalgo2ingitdb/computed_columns.go
@@ -21,9 +21,15 @@ func (r readwriteTx) validateNoStoredComputedValues(collectionID string, colDef 
 }
 
 // orderedComputedColumns returns the names of computed columns (Formula != "")
-// in a deterministic order: columns named in ColumnsOrder first, then any
-// remaining computed columns sorted lexicographically.
+// in deterministic order.
 func orderedComputedColumns(colDef *ingitdb.CollectionDef) []string {
+	return orderedColumns(colDef, func(c *ingitdb.ColumnDef) bool { return c.Formula != "" })
+}
+
+// orderedColumns returns the names of the columns matching pred, in a
+// deterministic order: columns named in ColumnsOrder first, then any remaining
+// matching columns sorted lexicographically.
+func orderedColumns(colDef *ingitdb.CollectionDef, pred func(*ingitdb.ColumnDef) bool) []string {
 	if colDef == nil || len(colDef.Columns) == 0 {
 		return nil
 	}
@@ -31,7 +37,7 @@ func orderedComputedColumns(colDef *ingitdb.CollectionDef) []string {
 	seen := make(map[string]bool, len(colDef.Columns))
 	for _, field := range colDef.ColumnsOrder {
 		column, ok := colDef.Columns[field]
-		if !ok || column == nil || column.Formula == "" {
+		if !ok || column == nil || !pred(column) {
 			continue
 		}
 		fields = append(fields, field)
@@ -39,7 +45,7 @@ func orderedComputedColumns(colDef *ingitdb.CollectionDef) []string {
 	}
 	var remaining []string
 	for field, column := range colDef.Columns {
-		if seen[field] || column == nil || column.Formula == "" {
+		if seen[field] || column == nil || !pred(column) {
 			continue
 		}
 		remaining = append(remaining, field)

--- a/pkg/dalgo2ingitdb/computed_columns_db_test.go
+++ b/pkg/dalgo2ingitdb/computed_columns_db_test.go
@@ -1,0 +1,131 @@
+package dalgo2ingitdb_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/dbschema"
+	"github.com/dal-go/dalgo/ddl"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/validator"
+)
+
+// setupComputedColumnDB creates a "people" collection whose "full_name" column
+// is computed from "first_name" and "last_name".
+func setupComputedColumnDB(t *testing.T) (dal.DB, string) {
+	t.Helper()
+	root := t.TempDir()
+	db, err := dalgo2ingitdb.NewDatabase(root, validator.NewCollectionsReader())
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	modifier := db.(ddl.SchemaModifier)
+	people := dbschema.CollectionDef{
+		Name: "people",
+		Fields: []dbschema.FieldDef{
+			{Name: "first_name", Type: dbschema.String, Nullable: false},
+			{Name: "last_name", Type: dbschema.String, Nullable: false},
+		},
+	}
+	if err := modifier.CreateCollection(context.Background(), people); err != nil {
+		t.Fatalf("CreateCollection people: %v", err)
+	}
+	definition := `record_file:
+    name: "{key}.yaml"
+    format: yaml
+    type: map[string]any
+columns:
+    first_name:
+        type: string
+        required: true
+    last_name:
+        type: string
+        required: true
+    full_name:
+        type: string
+        formula: 'first_name + " " + last_name'
+columns_order:
+    - first_name
+    - last_name
+    - full_name
+`
+	schemaDir := filepath.Join(root, "people", ".collection")
+	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
+		t.Fatalf("mkdir schema dir: %v", err)
+	}
+	definitionPath := filepath.Join(schemaDir, "definition.yaml")
+	if err := os.WriteFile(definitionPath, []byte(definition), 0o644); err != nil {
+		t.Fatalf("write people definition: %v", err)
+	}
+	return db, root
+}
+
+func insertRecord(t *testing.T, db dal.DB, collection, key string, data map[string]any) error {
+	t.Helper()
+	ctx := context.Background()
+	return db.RunReadwriteTransaction(ctx, func(_ context.Context, tx dal.ReadwriteTransaction) error {
+		recordKey := dal.NewKeyWithID(collection, key)
+		record := dal.NewRecordWithData(recordKey, data)
+		return tx.Insert(ctx, record)
+	})
+}
+
+func setRecord(t *testing.T, db dal.DB, collection, key string, data map[string]any) error {
+	t.Helper()
+	ctx := context.Background()
+	return db.RunReadwriteTransaction(ctx, func(_ context.Context, tx dal.ReadwriteTransaction) error {
+		recordKey := dal.NewKeyWithID(collection, key)
+		record := dal.NewRecordWithData(recordKey, data)
+		return tx.Set(ctx, record)
+	})
+}
+
+func peopleRecordPath(root, key string) string {
+	return filepath.Join(root, "people", "$records", key+".yaml")
+}
+
+func TestReadwriteTx_InsertComputedColumnValueFails(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedColumnDB(t)
+	data := map[string]any{"first_name": "Ada", "last_name": "Lovelace", "full_name": "Ada Lovelace"}
+	err := insertRecord(t, db, "people", "ada", data)
+	requireErrorContainsAll(t, err, "people", "ada", "full_name")
+	requireNoRecordFile(t, peopleRecordPath(root, "ada"))
+}
+
+func TestReadwriteTx_SetComputedColumnValueFails(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedColumnDB(t)
+	data := map[string]any{"first_name": "Ada", "last_name": "Lovelace", "full_name": "Ada Lovelace"}
+	err := setRecord(t, db, "people", "ada", data)
+	requireErrorContainsAll(t, err, "people", "ada", "full_name")
+	requireNoRecordFile(t, peopleRecordPath(root, "ada"))
+}
+
+func TestReadwriteTx_InsertWithoutComputedColumnSucceeds(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedColumnDB(t)
+	data := map[string]any{"first_name": "Ada", "last_name": "Lovelace"}
+	if err := insertRecord(t, db, "people", "ada", data); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := os.Stat(peopleRecordPath(root, "ada")); err != nil {
+		t.Fatalf("record file: stat: %v", err)
+	}
+}
+
+func TestReadwriteTx_SetWithoutComputedColumnSucceeds(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedColumnDB(t)
+	data := map[string]any{"first_name": "Ada", "last_name": "Lovelace"}
+	if err := setRecord(t, db, "people", "ada", data); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if _, err := os.Stat(peopleRecordPath(root, "ada")); err != nil {
+		t.Fatalf("record file: stat: %v", err)
+	}
+}

--- a/pkg/dalgo2ingitdb/computed_columns_test.go
+++ b/pkg/dalgo2ingitdb/computed_columns_test.go
@@ -1,0 +1,109 @@
+package dalgo2ingitdb
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+func computedColumnsCollectionDef() *ingitdb.CollectionDef {
+	return &ingitdb.CollectionDef{
+		ID: "people",
+		Columns: map[string]*ingitdb.ColumnDef{
+			"first_name": {Type: ingitdb.ColumnTypeString},
+			"last_name":  {Type: ingitdb.ColumnTypeString},
+			"full_name":  {Type: ingitdb.ColumnTypeString, Formula: `first_name + " " + last_name`},
+		},
+		ColumnsOrder: []string{"first_name", "last_name", "full_name"},
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		found := false
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func TestValidateNoStoredComputedValues_RejectsSuppliedComputedValue(t *testing.T) {
+	t.Parallel()
+	colDef := computedColumnsCollectionDef()
+	r := readwriteTx{}
+	data := map[string]any{"first_name": "Ada", "full_name": "Ada Lovelace"}
+	err := r.validateNoStoredComputedValues("people", colDef, "ada", data)
+	if err == nil {
+		t.Fatal("expected error for stored computed value, got nil")
+	}
+	if !containsAll(err.Error(), "people", "ada", "full_name") {
+		t.Fatalf("error %q must name collection, record key, and column", err.Error())
+	}
+}
+
+func TestValidateNoStoredComputedValues_AllowsAbsentComputedColumn(t *testing.T) {
+	t.Parallel()
+	colDef := computedColumnsCollectionDef()
+	r := readwriteTx{}
+	data := map[string]any{"first_name": "Ada", "last_name": "Lovelace"}
+	if err := r.validateNoStoredComputedValues("people", colDef, "ada", data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateNoStoredComputedValues_RejectsEvenWhenValueEmpty(t *testing.T) {
+	t.Parallel()
+	colDef := computedColumnsCollectionDef()
+	r := readwriteTx{}
+	data := map[string]any{"first_name": "Ada", "full_name": ""}
+	err := r.validateNoStoredComputedValues("people", colDef, "ada", data)
+	if err == nil {
+		t.Fatal("expected error when computed column key present with empty value, got nil")
+	}
+	if !containsAll(err.Error(), "people", "ada", "full_name") {
+		t.Fatalf("error %q must name collection, record key, and column", err.Error())
+	}
+}
+
+func TestValidateNoStoredComputedValues_NilColumns(t *testing.T) {
+	t.Parallel()
+	colDef := &ingitdb.CollectionDef{ID: "empty"}
+	r := readwriteTx{}
+	data := map[string]any{"x": 1}
+	if err := r.validateNoStoredComputedValues("empty", colDef, "k", data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ensure deterministic column iteration does not panic without ColumnsOrder
+func TestValidateNoStoredComputedValues_NoColumnsOrder(t *testing.T) {
+	t.Parallel()
+	colDef := &ingitdb.CollectionDef{
+		ID: "people",
+		Columns: map[string]*ingitdb.ColumnDef{
+			"a":         {Type: ingitdb.ColumnTypeInt},
+			"computed":  {Type: ingitdb.ColumnTypeInt, Formula: "a * 2"},
+			"computed2": {Type: ingitdb.ColumnTypeInt, Formula: "a * 3"},
+		},
+	}
+	r := readwriteTx{}
+	data := map[string]any{"a": 1, "computed": 2, "computed2": 3}
+	err := r.validateNoStoredComputedValues("people", colDef, "k", data)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// the first computed column reported should be the lexicographically first
+	names := []string{"computed", "computed2"}
+	sort.Strings(names)
+	if !containsAll(err.Error(), names[0]) {
+		t.Fatalf("error %q should name a computed column", err.Error())
+	}
+}

--- a/pkg/dalgo2ingitdb/computed_foreign_keys_test.go
+++ b/pkg/dalgo2ingitdb/computed_foreign_keys_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dal-go/dalgo/dal"
 	"github.com/dal-go/dalgo/dbschema"
 	"github.com/dal-go/dalgo/ddl"
+	"github.com/dal-go/dalgo/update"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/validator"
@@ -217,4 +218,287 @@ func TestReadwriteTx_InsertComputedForeignKeyLookupErrorFails(t *testing.T) {
 	err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "bad"})
 	requireErrorContainsAll(t, err, "Insert", "things", "thing-1", "owner_key", "users", "user-bad", "lookup failed")
 	requireNoRecordFile(t, thingRecordPath(root, "thing-1"))
+}
+
+// A corrupt child records file makes readAllRecordsFromDisk fail during the
+// parent-side computed-FK scan, so the delete returns the wrapped scan error.
+func TestReadwriteTx_DeleteComputedForeignKeyScanErrorFails(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	// Corrupt the things records file so the scan's read fails.
+	badPath := thingRecordPath(root, "thing-bad")
+	if err := os.MkdirAll(filepath.Dir(badPath), 0o755); err != nil {
+		t.Fatalf("mkdir things records: %v", err)
+	}
+	if err := os.WriteFile(badPath, []byte("\t: : not yaml :"), 0o644); err != nil {
+		t.Fatalf("write corrupt thing: %v", err)
+	}
+
+	err := deleteComputedForeignKeyRecord(t, db, "users", "user-1")
+	requireErrorContainsAll(t, err, "Delete computed foreign key scan failed", "users", "user-1", "things")
+
+	// The blocked delete is a no-op: the parent must remain on disk.
+	if _, statErr := os.Stat(collectionRecordPath(root, "users", "user-1")); statErr != nil {
+		t.Fatalf("user record file: stat: %v", statErr)
+	}
+}
+
+// A child whose computed foreign key resolves to empty is skipped by the
+// parent-side scan, so deleting an unreferenced parent succeeds while a separate
+// child that resolves to the parent still blocks its delete.
+func TestReadwriteTx_DeleteComputedForeignKeyEmptyChildSkipped(t *testing.T) {
+	t.Parallel()
+	// owner_key derives "" when owner_input is "none" and "user-..." otherwise.
+	formula := `("user-" + owner_input) if owner_input != "none" else ""`
+	db, root := setupComputedForeignKeyDBWith(t, "users", formula, dbschema.String)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner1"}); err != nil {
+		t.Fatalf("insert user-1: %v", err)
+	}
+	if err := insertRecord(t, db, "users", "user-2", map[string]any{"name": "Owner2"}); err != nil {
+		t.Fatalf("insert user-2: %v", err)
+	}
+	// thing-ref's owner_key resolves to user-1.
+	if err := insertRecord(t, db, "things", "thing-ref", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing-ref: %v", err)
+	}
+	// thing-empty's owner_key resolves to "" and so cannot be inserted through the
+	// write path (write validation rejects an empty computed FK); write it to disk
+	// directly so the delete-side scan recomputes its empty key and skips it.
+	if err := os.WriteFile(thingRecordPath(root, "thing-empty"), []byte("owner_input: none\n"), 0o644); err != nil {
+		t.Fatalf("write thing-empty: %v", err)
+	}
+
+	// user-2 is referenced by no thing (thing-empty's FK is skipped), so deleting
+	// it succeeds.
+	if err := deleteComputedForeignKeyRecord(t, db, "users", "user-2"); err != nil {
+		t.Fatalf("delete unreferenced user: %v", err)
+	}
+	requireNoRecordFile(t, collectionRecordPath(root, "users", "user-2"))
+
+	// user-1 is still referenced by thing-ref, so its delete is blocked.
+	err := deleteComputedForeignKeyRecord(t, db, "users", "user-1")
+	requireErrorContainsAll(t, err, "things", "thing-ref", "owner_key", "users", "user-1")
+}
+
+func deleteComputedForeignKeyRecord(t *testing.T, db dal.DB, collection, key string) error {
+	t.Helper()
+	ctx := context.Background()
+	return db.RunReadwriteTransaction(ctx, func(_ context.Context, tx dal.ReadwriteTransaction) error {
+		recordKey := dal.NewKeyWithID(collection, key)
+		return tx.Delete(ctx, recordKey)
+	})
+}
+
+func updateComputedForeignKeyRecord(t *testing.T, db dal.DB, collection, key string, updates []update.Update) error {
+	t.Helper()
+	ctx := context.Background()
+	return db.RunReadwriteTransaction(ctx, func(_ context.Context, tx dal.ReadwriteTransaction) error {
+		recordKey := dal.NewKeyWithID(collection, key)
+		return tx.Update(ctx, recordKey, updates)
+	})
+}
+
+func updateRecordComputedForeignKey(t *testing.T, db dal.DB, collection, key string, current map[string]any, updates []update.Update) error {
+	t.Helper()
+	ctx := context.Background()
+	return db.RunReadwriteTransaction(ctx, func(_ context.Context, tx dal.ReadwriteTransaction) error {
+		recordKey := dal.NewKeyWithID(collection, key)
+		record := dal.NewRecordWithData(recordKey, current)
+		// SetError(nil) marks the record loaded so UpdateRecord can read its Data.
+		record.SetError(nil)
+		return tx.UpdateRecord(ctx, record, updates)
+	})
+}
+
+// AC: foreign-key-parent-delete-detected
+// Deleting a users record still referenced by a things record's computed
+// owner_key is blocked with the reference-error shape: referencing collection
+// things, referencing record key, the owner_key column, and referenced
+// collection users.
+func TestReadwriteTx_DeleteReferencedByComputedForeignKeyFails(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+
+	err := deleteComputedForeignKeyRecord(t, db, "users", "user-1")
+	requireErrorContainsAll(t, err, "things", "thing-1", "owner_key", "users", "user-1")
+
+	// The referenced parent must remain on disk: the blocked delete is a no-op.
+	if _, statErr := os.Stat(collectionRecordPath(root, "users", "user-1")); statErr != nil {
+		t.Fatalf("user record file: stat: %v", statErr)
+	}
+}
+
+// Multiple child records force the deterministic sort comparator to run and the
+// scan to skip non-matching children before reaching the one that resolves to the
+// deleted parent key.
+func TestReadwriteTx_DeleteReferencedByComputedForeignKeyMultipleChildrenFails(t *testing.T) {
+	t.Parallel()
+	db, _ := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner1"}); err != nil {
+		t.Fatalf("insert user-1: %v", err)
+	}
+	if err := insertRecord(t, db, "users", "user-2", map[string]any{"name": "Owner2"}); err != nil {
+		t.Fatalf("insert user-2: %v", err)
+	}
+	// thing-a -> user-2, thing-b -> user-1: two records so the comparator runs and
+	// the first scanned record does not match the deleted key.
+	if err := insertRecord(t, db, "things", "thing-a", map[string]any{"owner_input": "2"}); err != nil {
+		t.Fatalf("insert thing-a: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-b", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing-b: %v", err)
+	}
+
+	err := deleteComputedForeignKeyRecord(t, db, "users", "user-1")
+	requireErrorContainsAll(t, err, "things", "thing-b", "owner_key", "users", "user-1")
+}
+
+// Deleting a users record that no things record's computed owner_key resolves to
+// succeeds: the parent-side scan finds no referencing child.
+func TestReadwriteTx_DeleteNotReferencedByComputedForeignKeySucceeds(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner1"}); err != nil {
+		t.Fatalf("insert user-1: %v", err)
+	}
+	if err := insertRecord(t, db, "users", "user-2", map[string]any{"name": "Owner2"}); err != nil {
+		t.Fatalf("insert user-2: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+
+	// user-2 is referenced by no thing, so its delete succeeds.
+	if err := deleteComputedForeignKeyRecord(t, db, "users", "user-2"); err != nil {
+		t.Fatalf("delete unreferenced user: %v", err)
+	}
+	requireNoRecordFile(t, collectionRecordPath(root, "users", "user-2"))
+}
+
+// AC: foreign-key-parent-rename-detected
+// A key rename has no dedicated code path in this driver: it manifests as the old
+// key ceasing to exist. Removing the old referenced key while a things record
+// still resolves to it triggers the same parent-side scan and is blocked with the
+// reference-error shape.
+func TestReadwriteTx_RenameReferencedByComputedForeignKeyFails(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+
+	// Rename user-1 -> user-renamed: the old key user-1 is removed, which the
+	// thing's computed owner_key still resolves to, so the removal is blocked.
+	err := deleteComputedForeignKeyRecord(t, db, "users", "user-1")
+	requireErrorContainsAll(t, err, "things", "thing-1", "owner_key", "users", "user-1")
+	if _, statErr := os.Stat(collectionRecordPath(root, "users", "user-1")); statErr != nil {
+		t.Fatalf("old user record file: stat: %v", statErr)
+	}
+}
+
+// AC: foreign-key-revalidates-on-input-change
+// Update threads the changed input field through validateComputedWriteForeignKeys
+// so a field-level Update that makes owner_key resolve to a missing parent fails.
+func TestReadwriteTx_UpdateMethodComputedForeignKeyInputToMissingParentFails(t *testing.T) {
+	t.Parallel()
+	db, _ := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+
+	updates := []update.Update{update.ByFieldName("owner_input", "absent")}
+	err := updateComputedForeignKeyRecord(t, db, "things", "thing-1", updates)
+	requireErrorContainsAll(t, err, "Update", "things", "thing-1", "owner_key", "users", "user-absent", "parent record not found")
+
+	data := readForeignKeyRecordData(t, db, "things", "thing-1")
+	if data["owner_input"] != "1" {
+		t.Fatalf("things owner_input = %v, want 1", data["owner_input"])
+	}
+}
+
+func TestReadwriteTx_UpdateMethodComputedForeignKeyInputToExistingParentSucceeds(t *testing.T) {
+	t.Parallel()
+	db, _ := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner1"}); err != nil {
+		t.Fatalf("insert user-1: %v", err)
+	}
+	if err := insertRecord(t, db, "users", "user-2", map[string]any{"name": "Owner2"}); err != nil {
+		t.Fatalf("insert user-2: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+
+	updates := []update.Update{update.ByFieldName("owner_input", "2")}
+	if err := updateComputedForeignKeyRecord(t, db, "things", "thing-1", updates); err != nil {
+		t.Fatalf("update thing: %v", err)
+	}
+	data := readForeignKeyRecordData(t, db, "things", "thing-1")
+	if data["owner_input"] != "2" {
+		t.Fatalf("things owner_input = %v, want 2", data["owner_input"])
+	}
+}
+
+// AC: foreign-key-revalidates-on-input-change
+// UpdateRecord also threads the changed input field through
+// validateComputedWriteForeignKeys, so an UpdateRecord that makes owner_key
+// resolve to a missing parent fails.
+func TestReadwriteTx_UpdateRecordComputedForeignKeyInputToMissingParentFails(t *testing.T) {
+	t.Parallel()
+	db, _ := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+
+	current := map[string]any{"owner_input": "1"}
+	updates := []update.Update{update.ByFieldName("owner_input", "absent")}
+	err := updateRecordComputedForeignKey(t, db, "things", "thing-1", current, updates)
+	requireErrorContainsAll(t, err, "UpdateRecord", "things", "thing-1", "owner_key", "users", "user-absent", "parent record not found")
+
+	data := readForeignKeyRecordData(t, db, "things", "thing-1")
+	if data["owner_input"] != "1" {
+		t.Fatalf("things owner_input = %v, want 1", data["owner_input"])
+	}
+}
+
+func TestReadwriteTx_UpdateRecordComputedForeignKeyInputToExistingParentSucceeds(t *testing.T) {
+	t.Parallel()
+	db, _ := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner1"}); err != nil {
+		t.Fatalf("insert user-1: %v", err)
+	}
+	if err := insertRecord(t, db, "users", "user-2", map[string]any{"name": "Owner2"}); err != nil {
+		t.Fatalf("insert user-2: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+
+	current := map[string]any{"owner_input": "1"}
+	updates := []update.Update{update.ByFieldName("owner_input", "2")}
+	if err := updateRecordComputedForeignKey(t, db, "things", "thing-1", current, updates); err != nil {
+		t.Fatalf("update record thing: %v", err)
+	}
+	data := readForeignKeyRecordData(t, db, "things", "thing-1")
+	if data["owner_input"] != "2" {
+		t.Fatalf("things owner_input = %v, want 2", data["owner_input"])
+	}
 }

--- a/pkg/dalgo2ingitdb/computed_foreign_keys_test.go
+++ b/pkg/dalgo2ingitdb/computed_foreign_keys_test.go
@@ -1,0 +1,220 @@
+package dalgo2ingitdb_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/dbschema"
+	"github.com/dal-go/dalgo/ddl"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/validator"
+)
+
+// setupComputedForeignKeyDB creates a "users" collection and a "things"
+// collection whose computed "owner_key" column derives a foreign key into
+// "users" from the stored "owner_input" field via a formula.
+func setupComputedForeignKeyDB(t *testing.T) (dal.DB, string) {
+	t.Helper()
+	return setupComputedForeignKeyDBWith(t, "users", `"user-" + owner_input`, dbschema.String)
+}
+
+// setupComputedForeignKeyDBWith builds the users/things schema with a
+// configurable foreign-key target collection, formula, and owner_input type so
+// individual tests can exercise the missing-collection, lookup-error, and
+// non-string-key derivation paths.
+func setupComputedForeignKeyDBWith(t *testing.T, fkTarget, formula string, inputType dbschema.Type) (dal.DB, string) {
+	t.Helper()
+	root := t.TempDir()
+	db, err := dalgo2ingitdb.NewDatabase(root, validator.NewCollectionsReader())
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	modifier := db.(ddl.SchemaModifier)
+	users := dbschema.CollectionDef{
+		Name: "users",
+		Fields: []dbschema.FieldDef{
+			{Name: "name", Type: dbschema.String, Nullable: false},
+		},
+	}
+	if err := modifier.CreateCollection(context.Background(), users); err != nil {
+		t.Fatalf("CreateCollection users: %v", err)
+	}
+	things := dbschema.CollectionDef{
+		Name: "things",
+		Fields: []dbschema.FieldDef{
+			{Name: "owner_input", Type: inputType, Nullable: false},
+		},
+	}
+	if err := modifier.CreateCollection(context.Background(), things); err != nil {
+		t.Fatalf("CreateCollection things: %v", err)
+	}
+	inputTypeName := "string"
+	if inputType == dbschema.Int {
+		inputTypeName = "int"
+	}
+	definition := `record_file:
+    name: "{key}.yaml"
+    format: yaml
+    type: map[string]any
+columns:
+    owner_input:
+        type: ` + inputTypeName + `
+        required: true
+    owner_key:
+        type: string
+        formula: '` + formula + `'
+        foreign_key: ` + fkTarget + `
+columns_order:
+    - owner_input
+    - owner_key
+`
+	schemaDir := filepath.Join(root, "things", ".collection")
+	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
+		t.Fatalf("mkdir schema dir: %v", err)
+	}
+	definitionPath := filepath.Join(schemaDir, "definition.yaml")
+	if err := os.WriteFile(definitionPath, []byte(definition), 0o644); err != nil {
+		t.Fatalf("write things definition: %v", err)
+	}
+	return db, root
+}
+
+func thingRecordPath(root, key string) string {
+	return filepath.Join(root, "things", "$records", key+".yaml")
+}
+
+// AC: foreign-key-on-insert-violation
+func TestReadwriteTx_InsertComputedForeignKeyMissingParentFails(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDB(t)
+	data := map[string]any{"owner_input": "absent"}
+	err := insertRecord(t, db, "things", "thing-1", data)
+	requireErrorContainsAll(t, err, "Insert", "things", "thing-1", "owner_key", "users", "user-absent", "parent record not found")
+	requireNoRecordFile(t, thingRecordPath(root, "thing-1"))
+}
+
+func TestReadwriteTx_InsertComputedForeignKeyExistingParentSucceeds(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	data := map[string]any{"owner_input": "1"}
+	if err := insertRecord(t, db, "things", "thing-1", data); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+	if _, err := os.Stat(thingRecordPath(root, "thing-1")); err != nil {
+		t.Fatalf("thing record file: stat: %v", err)
+	}
+}
+
+// AC: foreign-key-revalidates-on-input-change
+// Set backs update: changing the formula input field re-evaluates owner_key and
+// re-validates the derived foreign key, even though owner_key is never written.
+func TestReadwriteTx_UpdateComputedForeignKeyInputToMissingParentFails(t *testing.T) {
+	t.Parallel()
+	db, _ := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+
+	// Set with the changed input field; owner_key (the FK column) is not written.
+	err := setRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "absent"})
+	requireErrorContainsAll(t, err, "Set", "things", "thing-1", "owner_key", "users", "user-absent", "parent record not found")
+
+	data := readForeignKeyRecordData(t, db, "things", "thing-1")
+	if data["owner_input"] != "1" {
+		t.Fatalf("things owner_input = %v, want 1", data["owner_input"])
+	}
+}
+
+func TestReadwriteTx_UpdateComputedForeignKeyInputToExistingParentSucceeds(t *testing.T) {
+	t.Parallel()
+	db, _ := setupComputedForeignKeyDB(t)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner1"}); err != nil {
+		t.Fatalf("insert user-1: %v", err)
+	}
+	if err := insertRecord(t, db, "users", "user-2", map[string]any{"name": "Owner2"}); err != nil {
+		t.Fatalf("insert user-2: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+
+	if err := setRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "2"}); err != nil {
+		t.Fatalf("update thing: %v", err)
+	}
+	data := readForeignKeyRecordData(t, db, "things", "thing-1")
+	if data["owner_input"] != "2" {
+		t.Fatalf("things owner_input = %v, want 2", data["owner_input"])
+	}
+}
+
+func TestReadwriteTx_InsertComputedForeignKeyEvalErrorFails(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDB(t)
+	// owner_input is an int64 here; the formula concatenates a string with an
+	// int, which is a Starlark type error, exercising the eval-error path.
+	data := map[string]any{"owner_input": int64(5)}
+	err := insertRecord(t, db, "things", "thing-1", data)
+	requireErrorContainsAll(t, err, "Insert", "things", "thing-1", "owner_key", "users", "evaluation failed")
+	requireNoRecordFile(t, thingRecordPath(root, "thing-1"))
+}
+
+func TestReadwriteTx_InsertComputedForeignKeyMissingTargetCollectionFails(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDBWith(t, "ghosts", `"user-" + owner_input`, dbschema.String)
+	err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"})
+	requireErrorContainsAll(t, err, "Insert", "things", "thing-1", "owner_key", "ghosts", "configuration error")
+	requireNoRecordFile(t, thingRecordPath(root, "thing-1"))
+}
+
+// Non-string derived key: the formula yields an int64, which is coerced to its
+// decimal string form before the parent lookup, matching stored-FK handling.
+func TestReadwriteTx_InsertComputedForeignKeyIntKeySucceeds(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDBWith(t, "users", `owner_input + 1`, dbschema.Int)
+	if err := insertRecord(t, db, "users", "6", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": int64(5)}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+	if _, err := os.Stat(thingRecordPath(root, "thing-1")); err != nil {
+		t.Fatalf("thing record file: stat: %v", err)
+	}
+}
+
+// Nil derived key: a formula yielding None coerces to an empty key, which never
+// resolves to a parent, so the write fails with the referential-integrity error.
+func TestReadwriteTx_InsertComputedForeignKeyNilKeyFails(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDBWith(t, "users", "None", dbschema.String)
+	err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"})
+	requireErrorContainsAll(t, err, "Insert", "things", "thing-1", "owner_key", "users", "parent record not found")
+	requireNoRecordFile(t, thingRecordPath(root, "thing-1"))
+}
+
+// Lookup error: the resolved parent record file is corrupt, so the existence
+// check returns an error rather than a clean found/not-found result.
+func TestReadwriteTx_InsertComputedForeignKeyLookupErrorFails(t *testing.T) {
+	t.Parallel()
+	db, root := setupComputedForeignKeyDB(t)
+	corruptPath := collectionRecordPath(root, "users", "user-bad")
+	if err := os.MkdirAll(filepath.Dir(corruptPath), 0o755); err != nil {
+		t.Fatalf("mkdir users records: %v", err)
+	}
+	if err := os.WriteFile(corruptPath, []byte("\t: : not yaml :"), 0o644); err != nil {
+		t.Fatalf("write corrupt parent: %v", err)
+	}
+	err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "bad"})
+	requireErrorContainsAll(t, err, "Insert", "things", "thing-1", "owner_key", "users", "user-bad", "lookup failed")
+	requireNoRecordFile(t, thingRecordPath(root, "thing-1"))
+}

--- a/pkg/dalgo2ingitdb/foreign_keys.go
+++ b/pkg/dalgo2ingitdb/foreign_keys.go
@@ -21,6 +21,11 @@ func (r readwriteTx) validateWriteForeignKeys(operation, childCollection string,
 		if parentCollection == "" {
 			continue
 		}
+		// Computed foreign keys are never stored; they are validated separately
+		// by validateComputedWriteForeignKeys from the evaluated formula.
+		if column.Formula != "" {
+			continue
+		}
 		value, ok := data[field]
 		empty := !ok
 		if ok {
@@ -46,6 +51,57 @@ func (r readwriteTx) validateWriteForeignKeys(operation, childCollection string,
 		}
 	}
 	return nil
+}
+
+// validateComputedWriteForeignKeys enforces referential integrity for computed
+// foreign-key columns (columns with both ForeignKey and Formula set). The
+// foreign-key value is never stored, so it is derived by evaluating the column's
+// formula from the payload's stored fields and validated against the referenced
+// collection exactly as a stored foreign key is. It runs on every write, so an
+// update that changes an input field of the formula is re-validated even though
+// the computed column itself was not written.
+func (r readwriteTx) validateComputedWriteForeignKeys(operation, childCollection string, childDef *ingitdb.CollectionDef, recordKey string, data map[string]any) error {
+	// r.def is guaranteed non-nil here: validateWriteForeignKeys runs first on
+	// every Set/Insert and returns a configuration error when r.def is nil and
+	// any foreign-key column (computed columns included) is present.
+	for _, field := range orderedComputedColumns(childDef) {
+		column := childDef.Columns[field]
+		parentCollection := column.ForeignKey
+		if parentCollection == "" {
+			continue
+		}
+		result, err := ingitdb.EvaluateFormula(column.Formula, data)
+		if err != nil {
+			return fmt.Errorf("dalgo2ingitdb: %s computed foreign key evaluation failed: collection %q record %q column %q references collection %q: %w", operation, childCollection, recordKey, field, parentCollection, err)
+		}
+		parentKey := computedForeignKeyString(result)
+		parentDef, ok := r.def.Collections[parentCollection]
+		if !ok {
+			return fmt.Errorf("dalgo2ingitdb: %s configuration error: collection %q record %q column %q references missing foreign_key collection %q", operation, childCollection, recordKey, field, parentCollection)
+		}
+		exists, err := foreignKeyTargetExists(parentDef, parentKey)
+		if err != nil {
+			return fmt.Errorf("dalgo2ingitdb: %s computed foreign key lookup failed: collection %q record %q column %q references collection %q key %q: %w", operation, childCollection, recordKey, field, parentCollection, parentKey, err)
+		}
+		if !exists {
+			return fmt.Errorf("dalgo2ingitdb: %s computed foreign key violation: collection %q record %q column %q references collection %q key %q: parent record not found", operation, childCollection, recordKey, field, parentCollection, parentKey)
+		}
+	}
+	return nil
+}
+
+// computedForeignKeyString coerces an evaluated formula result into the string
+// key form used to look up the referenced record. EvaluateFormula yields
+// string, int64, bool, float64, or nil; foreign keys are strings or integer
+// keys, so this matches the stored-FK key handling (fmt's default formatting).
+func computedForeignKeyString(result any) string {
+	if result == nil {
+		return ""
+	}
+	if s, ok := result.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", result)
 }
 
 func (r readwriteTx) validateDeleteForeignKeys(parentCollection, parentKey string) error {

--- a/pkg/dalgo2ingitdb/foreign_keys.go
+++ b/pkg/dalgo2ingitdb/foreign_keys.go
@@ -201,32 +201,14 @@ func (r readwriteTx) validateDeleteComputedForeignKeys(parentCollection, parentK
 	return nil
 }
 
+// orderedForeignKeyFields returns the names of stored foreign-key columns
+// (ForeignKey set, Formula empty) in deterministic order. Computed foreign keys
+// are never stored and are handled separately by the computed-FK validators, so
+// they are excluded here.
 func orderedForeignKeyFields(colDef *ingitdb.CollectionDef) []string {
-	if colDef == nil || len(colDef.Columns) == 0 {
-		return nil
-	}
-	fields := make([]string, 0, len(colDef.Columns))
-	seen := make(map[string]bool, len(colDef.Columns))
-	for _, field := range colDef.ColumnsOrder {
-		column, ok := colDef.Columns[field]
-		// Computed foreign keys (Formula set) are never stored; they are handled
-		// separately by the computed-FK validators, so exclude them here.
-		if !ok || column == nil || column.ForeignKey == "" || column.Formula != "" {
-			continue
-		}
-		fields = append(fields, field)
-		seen[field] = true
-	}
-	var remaining []string
-	for field, column := range colDef.Columns {
-		if seen[field] || column == nil || column.ForeignKey == "" || column.Formula != "" {
-			continue
-		}
-		remaining = append(remaining, field)
-	}
-	sort.Strings(remaining)
-	fields = append(fields, remaining...)
-	return fields
+	return orderedColumns(colDef, func(c *ingitdb.ColumnDef) bool {
+		return c.ForeignKey != "" && c.Formula == ""
+	})
 }
 
 func orderedCollectionIDs(collections map[string]*ingitdb.CollectionDef) []string {

--- a/pkg/dalgo2ingitdb/foreign_keys.go
+++ b/pkg/dalgo2ingitdb/foreign_keys.go
@@ -21,11 +21,6 @@ func (r readwriteTx) validateWriteForeignKeys(operation, childCollection string,
 		if parentCollection == "" {
 			continue
 		}
-		// Computed foreign keys are never stored; they are validated separately
-		// by validateComputedWriteForeignKeys from the evaluated formula.
-		if column.Formula != "" {
-			continue
-		}
 		value, ok := data[field]
 		empty := !ok
 		if ok {
@@ -153,6 +148,59 @@ func (r readwriteTx) validateDeleteForeignKeys(parentCollection, parentKey strin
 	return nil
 }
 
+// validateDeleteComputedForeignKeys mirrors validateDeleteForeignKeys for
+// computed foreign keys. Computed FK values are never stored, so each child
+// collection that declares a COMPUTED foreign key referencing parentCollection is
+// scanned in full (no index): readAllRecordsFromDisk recomputes every child
+// record's formula on read, populating the computed column, and if a recomputed
+// key equals parentKey the delete (or rename, which manifests as a delete of the
+// old key) is blocked with a reference-error-shape error naming the referencing
+// collection, the referencing record key, the computed column, and the referenced
+// collection.
+func (r readwriteTx) validateDeleteComputedForeignKeys(parentCollection, parentKey string) error {
+	// r.def is guaranteed non-nil here: Delete runs validateDeleteForeignKeys
+	// first, which guards r.def == nil before this function is ever reached.
+	childCollections := orderedCollectionIDs(r.def.Collections)
+	for _, childCollection := range childCollections {
+		childDef := r.def.Collections[childCollection]
+		fields := computedForeignKeyFieldsReferencing(childDef, parentCollection)
+		if len(fields) == 0 {
+			continue
+		}
+
+		records, err := readAllRecordsFromDisk(childDef)
+		if err != nil {
+			return fmt.Errorf("dalgo2ingitdb: Delete computed foreign key scan failed for parent collection %q key %q child collection %q: %w", parentCollection, parentKey, childCollection, err)
+		}
+
+		sort.SliceStable(records, func(i, j int) bool {
+			left := fmt.Sprintf("%v", records[i].Key().ID)
+			right := fmt.Sprintf("%v", records[j].Key().ID)
+			return left < right
+		})
+
+		for _, record := range records {
+			childKey := fmt.Sprintf("%v", record.Key().ID)
+			// readAllRecordsFromDisk always builds records via
+			// dal.NewRecordWithData with a map[string]any, so Data() is always a map.
+			data, _ := record.Data().(map[string]any)
+
+			for _, field := range fields {
+				value, ok := data[field]
+				if !ok || isEmptyForeignKeyValue(value) {
+					continue
+				}
+				derivedKey := computedForeignKeyString(value)
+				if derivedKey == parentKey {
+					return fmt.Errorf("dalgo2ingitdb: Delete computed foreign key violation: parent collection %q key %q is referenced by child collection %q record %q column %q", parentCollection, parentKey, childCollection, childKey, field)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 func orderedForeignKeyFields(colDef *ingitdb.CollectionDef) []string {
 	if colDef == nil || len(colDef.Columns) == 0 {
 		return nil
@@ -161,7 +209,9 @@ func orderedForeignKeyFields(colDef *ingitdb.CollectionDef) []string {
 	seen := make(map[string]bool, len(colDef.Columns))
 	for _, field := range colDef.ColumnsOrder {
 		column, ok := colDef.Columns[field]
-		if !ok || column == nil || column.ForeignKey == "" {
+		// Computed foreign keys (Formula set) are never stored; they are handled
+		// separately by the computed-FK validators, so exclude them here.
+		if !ok || column == nil || column.ForeignKey == "" || column.Formula != "" {
 			continue
 		}
 		fields = append(fields, field)
@@ -169,7 +219,7 @@ func orderedForeignKeyFields(colDef *ingitdb.CollectionDef) []string {
 	}
 	var remaining []string
 	for field, column := range colDef.Columns {
-		if seen[field] || column == nil || column.ForeignKey == "" {
+		if seen[field] || column == nil || column.ForeignKey == "" || column.Formula != "" {
 			continue
 		}
 		remaining = append(remaining, field)
@@ -194,6 +244,21 @@ func orderedCollectionIDs(collections map[string]*ingitdb.CollectionDef) []strin
 
 func foreignKeyFieldsReferencing(colDef *ingitdb.CollectionDef, parentCollection string) []string {
 	fields := orderedForeignKeyFields(colDef)
+	matchingFields := make([]string, 0, len(fields))
+	for _, field := range fields {
+		column := colDef.Columns[field]
+		if column.ForeignKey == parentCollection {
+			matchingFields = append(matchingFields, field)
+		}
+	}
+	return matchingFields
+}
+
+// computedForeignKeyFieldsReferencing returns the computed foreign-key columns
+// (both Formula and ForeignKey set) of colDef that reference parentCollection, in
+// the deterministic order produced by orderedComputedColumns.
+func computedForeignKeyFieldsReferencing(colDef *ingitdb.CollectionDef, parentCollection string) []string {
+	fields := orderedComputedColumns(colDef)
 	matchingFields := make([]string, 0, len(fields))
 	for _, field := range fields {
 		column := colDef.Columns[field]

--- a/pkg/dalgo2ingitdb/formula.go
+++ b/pkg/dalgo2ingitdb/formula.go
@@ -1,0 +1,84 @@
+package dalgo2ingitdb
+
+import (
+	"fmt"
+	"maps"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// ApplyFormulasToRead computes the value of every computed column (one with a
+// non-empty Formula) and adds it to the returned map, coerced to the column's
+// declared type. The stored fields in data are used as the formula's variable
+// bindings. The input map is not mutated; a clone is returned.
+//
+// A runtime evaluation error, or a result that cannot be coerced to the
+// declared type, aborts with an error naming the collection, record key, and
+// column. No partial result is returned in that case.
+func ApplyFormulasToRead(data map[string]any, cols map[string]*ingitdb.ColumnDef, collectionID, recordKey string) (map[string]any, error) {
+	if len(cols) == 0 {
+		return data, nil
+	}
+	result := maps.Clone(data)
+	for colName, colDef := range cols {
+		if colDef.Formula == "" {
+			continue
+		}
+		raw, err := ingitdb.EvaluateFormula(colDef.Formula, data)
+		if err != nil {
+			return nil, fmt.Errorf("collection %q record %q column %q: %w", collectionID, recordKey, colName, err)
+		}
+		coerced, err := coerceFormulaResult(raw, colDef.Type)
+		if err != nil {
+			return nil, fmt.Errorf("collection %q record %q column %q: %w", collectionID, recordKey, colName, err)
+		}
+		result[colName] = coerced
+	}
+	return result, nil
+}
+
+// coerceFormulaResult coerces a formula evaluation result (string, bool, int64,
+// float64, or nil) to the column's declared type. A result whose Go type cannot
+// represent the declared type yields an error.
+func coerceFormulaResult(v any, colType ingitdb.ColumnType) (any, error) {
+	switch colType {
+	case ingitdb.ColumnTypeString:
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("cannot coerce %T to string", v)
+		}
+		return s, nil
+	case ingitdb.ColumnTypeInt:
+		switch n := v.(type) {
+		case int64:
+			return n, nil
+		case float64:
+			i := int64(n)
+			if float64(i) != n {
+				return nil, fmt.Errorf("cannot coerce non-integral float %v to int", n)
+			}
+			return i, nil
+		default:
+			return nil, fmt.Errorf("cannot coerce %T to int", v)
+		}
+	case ingitdb.ColumnTypeFloat:
+		switch n := v.(type) {
+		case float64:
+			return n, nil
+		case int64:
+			return float64(n), nil
+		default:
+			return nil, fmt.Errorf("cannot coerce %T to float", v)
+		}
+	case ingitdb.ColumnTypeBool:
+		b, ok := v.(bool)
+		if !ok {
+			return nil, fmt.Errorf("cannot coerce %T to bool", v)
+		}
+		return b, nil
+	case ingitdb.ColumnTypeAny:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("computed columns do not support type %q", colType)
+	}
+}

--- a/pkg/dalgo2ingitdb/formula.go
+++ b/pkg/dalgo2ingitdb/formula.go
@@ -3,6 +3,7 @@ package dalgo2ingitdb
 import (
 	"fmt"
 	"maps"
+	"sort"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
@@ -10,20 +11,32 @@ import (
 // ApplyFormulasToRead computes the value of every computed column (one with a
 // non-empty Formula) and adds it to the returned map, coerced to the column's
 // declared type. The stored fields in data are used as the formula's variable
-// bindings. The input map is not mutated; a clone is returned.
+// bindings.
+//
+// When the collection has no computed columns the input map is returned
+// unchanged (not cloned); otherwise a clone is returned with the computed
+// values added, so the input is never mutated. Computed columns are evaluated
+// in deterministic (sorted) order so that, when more than one formula errors,
+// the surfaced error is reproducible.
 //
 // A runtime evaluation error, or a result that cannot be coerced to the
 // declared type, aborts with an error naming the collection, record key, and
 // column. No partial result is returned in that case.
 func ApplyFormulasToRead(data map[string]any, cols map[string]*ingitdb.ColumnDef, collectionID, recordKey string) (map[string]any, error) {
-	if len(cols) == 0 {
+	computedNames := make([]string, 0, len(cols))
+	for colName, colDef := range cols {
+		if colDef.Formula != "" {
+			computedNames = append(computedNames, colName)
+		}
+	}
+	if len(computedNames) == 0 {
 		return data, nil
 	}
+	sort.Strings(computedNames)
+
 	result := maps.Clone(data)
-	for colName, colDef := range cols {
-		if colDef.Formula == "" {
-			continue
-		}
+	for _, colName := range computedNames {
+		colDef := cols[colName]
 		raw, err := ingitdb.EvaluateFormula(colDef.Formula, data)
 		if err != nil {
 			return nil, fmt.Errorf("collection %q record %q column %q: %w", collectionID, recordKey, colName, err)

--- a/pkg/dalgo2ingitdb/formula_read_test.go
+++ b/pkg/dalgo2ingitdb/formula_read_test.go
@@ -1,0 +1,161 @@
+package dalgo2ingitdb_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/validator"
+)
+
+// setupFormulaDB creates a temp project with a "people" SingleRecord/YAML
+// collection that declares two computed columns: a string full_name and an
+// int safe_ratio (qty / divisor). It returns the dal.DB and project root.
+func setupFormulaDB(t *testing.T) (dal.DB, string) {
+	t.Helper()
+	root := t.TempDir()
+	db, err := dalgo2ingitdb.NewDatabase(root, validator.NewCollectionsReader())
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	defDir := filepath.Join(root, "people", ".collection")
+	if err := os.MkdirAll(defDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", defDir, err)
+	}
+	def := `id: people
+record_file:
+  name: "{key}.yaml"
+  format: yaml
+  type: map[string]any
+columns:
+  first_name:
+    type: string
+  last_name:
+    type: string
+  qty:
+    type: int
+  divisor:
+    type: int
+  full_name:
+    type: string
+    formula: 'first_name + " " + last_name'
+  safe_ratio:
+    type: int
+    formula: 'qty / divisor'
+`
+	defPath := filepath.Join(defDir, "definition.yaml")
+	if err := os.WriteFile(defPath, []byte(def), 0o644); err != nil {
+		t.Fatalf("write %s: %v", defPath, err)
+	}
+	dir := filepath.Join(root, ".ingitdb")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	regPath := filepath.Join(dir, "root-collections.yaml")
+	if err := os.WriteFile(regPath, []byte("people: people\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", regPath, err)
+	}
+	return db, root
+}
+
+func writePersonRecord(t *testing.T, root, key, content string) {
+	t.Helper()
+	dir := filepath.Join(root, "people", "$records")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, key+".yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestDB_Get_ComputesFormulaColumns verifies the read path computes and
+// coerces formula columns: full_name (string) and safe_ratio (int).
+func TestDB_Get_ComputesFormulaColumns(t *testing.T) {
+	t.Parallel()
+	db, root := setupFormulaDB(t)
+	writePersonRecord(t, root, "ada", "first_name: Ada\nlast_name: Lovelace\nqty: 12\ndivisor: 4\n")
+
+	rec := dal.NewRecordWithData(dal.NewKeyWithID("people", "ada"), map[string]any{})
+	if err := db.Get(context.Background(), rec); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	data := rec.Data().(map[string]any)
+	if data["full_name"] != "Ada Lovelace" {
+		t.Errorf("full_name: got %v, want 'Ada Lovelace'", data["full_name"])
+	}
+	if data["safe_ratio"] != int64(3) {
+		t.Errorf("safe_ratio: got %v (%T), want int64(3)", data["safe_ratio"], data["safe_ratio"])
+	}
+}
+
+// TestDB_Get_FormulaRuntimeErrorFailsRead verifies a runtime formula error
+// (division by zero) aborts the read with an error naming collection, key,
+// and column, and no partial row is exposed.
+func TestDB_Get_FormulaRuntimeErrorFailsRead(t *testing.T) {
+	t.Parallel()
+	db, root := setupFormulaDB(t)
+	writePersonRecord(t, root, "bad", "first_name: Bob\nlast_name: Zero\nqty: 5\ndivisor: 0\n")
+
+	rec := dal.NewRecordWithData(dal.NewKeyWithID("people", "bad"), map[string]any{})
+	err := db.Get(context.Background(), rec)
+	if err == nil {
+		t.Fatal("expected read to fail on division by zero")
+	}
+	for _, want := range []string{"people", "bad", "safe_ratio"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// TestDB_Query_ComputesFormulaColumns exercises the query read path so the
+// formula wiring in executeQueryToRecordsReader is covered end-to-end.
+func TestDB_Query_ComputesFormulaColumns(t *testing.T) {
+	t.Parallel()
+	db, root := setupFormulaDB(t)
+	writePersonRecord(t, root, "ada", "first_name: Ada\nlast_name: Lovelace\nqty: 12\ndivisor: 4\n")
+
+	query := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithData(dal.NewKeyWithID("people", ""), map[string]any{})
+		})
+	reader, err := db.ExecuteQueryToRecordsReader(context.Background(), query)
+	if err != nil {
+		t.Fatalf("ExecuteQueryToRecordsReader: %v", err)
+	}
+	rec, err := reader.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	data := rec.Data().(map[string]any)
+	if data["full_name"] != "Ada Lovelace" {
+		t.Errorf("full_name: got %v, want 'Ada Lovelace'", data["full_name"])
+	}
+}
+
+// TestDB_Query_FormulaRuntimeErrorFailsRead covers the query-path error
+// branch when a formula fails at runtime.
+func TestDB_Query_FormulaRuntimeErrorFailsRead(t *testing.T) {
+	t.Parallel()
+	db, root := setupFormulaDB(t)
+	writePersonRecord(t, root, "bad", "first_name: Bob\nlast_name: Zero\nqty: 5\ndivisor: 0\n")
+
+	query := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithData(dal.NewKeyWithID("people", ""), map[string]any{})
+		})
+	_, err := db.ExecuteQueryToRecordsReader(context.Background(), query)
+	if err == nil {
+		t.Fatal("expected query to fail on division by zero")
+	}
+	if !strings.Contains(err.Error(), "safe_ratio") {
+		t.Errorf("error %q missing 'safe_ratio'", err.Error())
+	}
+}

--- a/pkg/dalgo2ingitdb/formula_test.go
+++ b/pkg/dalgo2ingitdb/formula_test.go
@@ -1,0 +1,399 @@
+package dalgo2ingitdb
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// makeFormulaMapTx builds a readonlyTx for a MapOfRecords "scores" collection
+// whose schema declares a computed int column "doubled" = score * 2 and a
+// computed int "ratio" = score / divisor. It mirrors makeMapOfRecordsTx but
+// attaches formula columns so the MapOfRecords read path exercises formula
+// computation and its error branch.
+func makeFormulaMapTx(t *testing.T, root string) (readonlyTx, *ingitdb.CollectionDef) {
+	t.Helper()
+	colDef := &ingitdb.CollectionDef{
+		ID:      "scores",
+		DirPath: filepath.Join(root, "scores"),
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:       "scores.yaml",
+			Format:     ingitdb.RecordFormatYAML,
+			RecordType: ingitdb.MapOfRecords,
+		},
+		Columns: map[string]*ingitdb.ColumnDef{
+			"score":   {Type: ingitdb.ColumnTypeInt},
+			"divisor": {Type: ingitdb.ColumnTypeInt},
+			"doubled": {Type: ingitdb.ColumnTypeInt, Formula: "score * 2"},
+			"ratio":   {Type: ingitdb.ColumnTypeInt, Formula: "score / divisor"},
+		},
+	}
+	tx := readonlyTx{
+		db: &Database{projectPath: root},
+		def: &ingitdb.Definition{Collections: map[string]*ingitdb.CollectionDef{
+			"scores": colDef,
+		}},
+	}
+	return tx, colDef
+}
+
+func writeScoresFile(t *testing.T, colDef *ingitdb.CollectionDef, content string) {
+	t.Helper()
+	if err := os.MkdirAll(colDef.DirPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	p := filepath.Join(colDef.DirPath, "scores.yaml")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestReadonlyTx_Get_MapOfRecords_ComputesFormula(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	tx, colDef := makeFormulaMapTx(t, root)
+	writeScoresFile(t, colDef, "alice:\n  score: 5\n  divisor: 5\n")
+
+	rec := dal.NewRecordWithData(dal.NewKeyWithID("scores", "alice"), map[string]any{})
+	if err := tx.Get(context.Background(), rec); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	data := rec.Data().(map[string]any)
+	if data["doubled"] != int64(10) {
+		t.Errorf("doubled: got %v, want int64(10)", data["doubled"])
+	}
+}
+
+func TestReadonlyTx_Get_MapOfRecords_FormulaError(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	tx, colDef := makeFormulaMapTx(t, root)
+	writeScoresFile(t, colDef, "alice:\n  score: 5\n  divisor: 0\n")
+
+	rec := dal.NewRecordWithData(dal.NewKeyWithID("scores", "alice"), map[string]any{})
+	err := tx.Get(context.Background(), rec)
+	if err == nil {
+		t.Fatal("expected formula runtime error (division by zero)")
+	}
+	for _, want := range []string{"scores", "alice", "ratio"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestReadAllMapOfRecords_FormulaError(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	_, colDef := makeFormulaMapTx(t, root)
+	writeScoresFile(t, colDef, "alice:\n  score: 5\n  divisor: 0\n")
+
+	_, err := readAllMapOfRecords(colDef)
+	if err == nil {
+		t.Fatal("expected formula runtime error from readAllMapOfRecords")
+	}
+	if !strings.Contains(err.Error(), "ratio") {
+		t.Errorf("error %q missing 'ratio'", err.Error())
+	}
+}
+
+func TestReadAllMapOfRecords_ComputesFormula(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	_, colDef := makeFormulaMapTx(t, root)
+	writeScoresFile(t, colDef, "alice:\n  score: 5\n  divisor: 5\n")
+
+	records, err := readAllMapOfRecords(colDef)
+	if err != nil {
+		t.Fatalf("readAllMapOfRecords: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	data := records[0].Data().(map[string]any)
+	if data["doubled"] != int64(10) {
+		t.Errorf("doubled: got %v, want int64(10)", data["doubled"])
+	}
+}
+
+func TestApplyFormulasToRead_FullNameString(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"full_name": {Type: ingitdb.ColumnTypeString, Formula: `first_name + " " + last_name`},
+	}
+	data := map[string]any{"first_name": "Ada", "last_name": "Lovelace"}
+
+	result, err := ApplyFormulasToRead(data, cols, "people", "ada")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["full_name"] != "Ada Lovelace" {
+		t.Fatalf("expected full_name='Ada Lovelace', got %v", result["full_name"])
+	}
+	// The input map must not be mutated.
+	if _, has := data["full_name"]; has {
+		t.Fatal("expected input data not to be mutated")
+	}
+}
+
+func TestApplyFormulasToRead_IntTotal(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"total": {Type: ingitdb.ColumnTypeInt, Formula: "qty * price"},
+	}
+	data := map[string]any{"qty": 3, "price": 4}
+
+	result, err := ApplyFormulasToRead(data, cols, "orders", "o1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, ok := result["total"].(int64)
+	if !ok {
+		t.Fatalf("expected total int64, got %T", result["total"])
+	}
+	if got != 12 {
+		t.Fatalf("expected total=12, got %d", got)
+	}
+}
+
+func TestApplyFormulasToRead_IntFromIntegralFloat(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"half": {Type: ingitdb.ColumnTypeInt, Formula: "a / b"},
+	}
+	data := map[string]any{"a": 10, "b": 2}
+
+	result, err := ApplyFormulasToRead(data, cols, "c", "k")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["half"] != int64(5) {
+		t.Fatalf("expected half=5, got %v (%T)", result["half"], result["half"])
+	}
+}
+
+func TestApplyFormulasToRead_IntFromNonIntegralFloatFails(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"x": {Type: ingitdb.ColumnTypeInt, Formula: "a / b"},
+	}
+	data := map[string]any{"a": 7, "b": 2}
+
+	_, err := ApplyFormulasToRead(data, cols, "coll", "rec")
+	if err == nil {
+		t.Fatal("expected error for non-integral float into int")
+	}
+	for _, want := range []string{"coll", "rec", "x"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestApplyFormulasToRead_FloatFromFloat(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"ratio": {Type: ingitdb.ColumnTypeFloat, Formula: "a / b"},
+	}
+	data := map[string]any{"a": 7, "b": 2}
+
+	result, err := ApplyFormulasToRead(data, cols, "c", "k")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["ratio"] != 3.5 {
+		t.Fatalf("expected ratio=3.5, got %v", result["ratio"])
+	}
+}
+
+func TestApplyFormulasToRead_FloatFromInt(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"f": {Type: ingitdb.ColumnTypeFloat, Formula: "a + b"},
+	}
+	data := map[string]any{"a": 2, "b": 3}
+
+	result, err := ApplyFormulasToRead(data, cols, "c", "k")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["f"] != float64(5) {
+		t.Fatalf("expected f=5.0, got %v (%T)", result["f"], result["f"])
+	}
+}
+
+func TestApplyFormulasToRead_Bool(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"adult": {Type: ingitdb.ColumnTypeBool, Formula: "age >= 18"},
+	}
+	data := map[string]any{"age": 21}
+
+	result, err := ApplyFormulasToRead(data, cols, "c", "k")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["adult"] != true {
+		t.Fatalf("expected adult=true, got %v", result["adult"])
+	}
+}
+
+func TestApplyFormulasToRead_Any(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"v": {Type: ingitdb.ColumnTypeAny, Formula: `"hi"`},
+	}
+	data := map[string]any{}
+
+	result, err := ApplyFormulasToRead(data, cols, "c", "k")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["v"] != "hi" {
+		t.Fatalf("expected v='hi', got %v", result["v"])
+	}
+}
+
+func TestApplyFormulasToRead_CoercionMismatch(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"name": {Type: ingitdb.ColumnTypeString, Formula: "1 + 2"},
+	}
+	data := map[string]any{}
+
+	_, err := ApplyFormulasToRead(data, cols, "coll", "rec")
+	if err == nil {
+		t.Fatal("expected coercion mismatch error")
+	}
+	for _, want := range []string{"coll", "rec", "name"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestApplyFormulasToRead_RuntimeError(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"q": {Type: ingitdb.ColumnTypeInt, Formula: "a / b"},
+	}
+	data := map[string]any{"a": 1, "b": 0}
+
+	_, err := ApplyFormulasToRead(data, cols, "nums", "row7")
+	if err == nil {
+		t.Fatal("expected runtime error for division by zero")
+	}
+	for _, want := range []string{"nums", "row7", "q"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestApplyFormulasToRead_NoComputedColumnsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"first_name": {Type: ingitdb.ColumnTypeString},
+	}
+	data := map[string]any{"first_name": "Ada"}
+
+	result, err := ApplyFormulasToRead(data, cols, "people", "ada")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["first_name"] != "Ada" {
+		t.Fatalf("expected first_name unchanged, got %v", result["first_name"])
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected exactly one field, got %d", len(result))
+	}
+}
+
+func TestApplyFormulasToRead_EmptyCols(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"x": 1}
+	result, err := ApplyFormulasToRead(data, nil, "c", "k")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["x"] != 1 {
+		t.Fatalf("expected x=1, got %v", result["x"])
+	}
+}
+
+func TestApplyFormulasToRead_FloatCoercionMismatch(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"f": {Type: ingitdb.ColumnTypeFloat, Formula: `"str"`},
+	}
+	data := map[string]any{}
+
+	_, err := ApplyFormulasToRead(data, cols, "c", "k")
+	if err == nil {
+		t.Fatal("expected float coercion mismatch error")
+	}
+}
+
+func TestApplyFormulasToRead_BoolCoercionMismatch(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"b": {Type: ingitdb.ColumnTypeBool, Formula: "1"},
+	}
+	data := map[string]any{}
+
+	_, err := ApplyFormulasToRead(data, cols, "c", "k")
+	if err == nil {
+		t.Fatal("expected bool coercion mismatch error")
+	}
+}
+
+func TestApplyFormulasToRead_UnsupportedColumnType(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"d": {Type: ingitdb.ColumnTypeDate, Formula: `"x"`},
+	}
+	data := map[string]any{}
+
+	_, err := ApplyFormulasToRead(data, cols, "c", "k")
+	if err == nil {
+		t.Fatal("expected error for unsupported computed-column type")
+	}
+	if !strings.Contains(err.Error(), "do not support type") {
+		t.Fatalf("error %q missing expected cause", err.Error())
+	}
+}
+
+func TestApplyFormulasToRead_IntCoercionMismatch(t *testing.T) {
+	t.Parallel()
+
+	cols := map[string]*ingitdb.ColumnDef{
+		"i": {Type: ingitdb.ColumnTypeInt, Formula: `"str"`},
+	}
+	data := map[string]any{}
+
+	_, err := ApplyFormulasToRead(data, cols, "c", "k")
+	if err == nil {
+		t.Fatal("expected int coercion mismatch error")
+	}
+}

--- a/pkg/dalgo2ingitdb/query.go
+++ b/pkg/dalgo2ingitdb/query.go
@@ -106,8 +106,13 @@ func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 		if !found {
 			continue
 		}
+		normalized := ApplyLocaleToRead(data, colDef.Columns)
+		computed, computeErr := ApplyFormulasToRead(normalized, colDef.Columns, colDef.ID, recordKey)
+		if computeErr != nil {
+			return nil, computeErr
+		}
 		key := dal.NewKeyWithID(colDef.ID, recordKey)
-		rec := dal.NewRecordWithData(key, ApplyLocaleToRead(data, colDef.Columns))
+		rec := dal.NewRecordWithData(key, computed)
 		rec.SetError(nil)
 		records = append(records, rec)
 	}
@@ -123,8 +128,12 @@ func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	records := make([]dal.Record, 0, len(allData))
 	for id, fields := range allData {
 		normalized := ApplyLocaleToRead(fields, colDef.Columns)
+		computed, computeErr := ApplyFormulasToRead(normalized, colDef.Columns, colDef.ID, id)
+		if computeErr != nil {
+			return nil, computeErr
+		}
 		key := dal.NewKeyWithID(colDef.ID, id)
-		rec := dal.NewRecordWithData(key, normalized)
+		rec := dal.NewRecordWithData(key, computed)
 		rec.SetError(nil)
 		records = append(records, rec)
 	}

--- a/pkg/dalgo2ingitdb/tx_readonly.go
+++ b/pkg/dalgo2ingitdb/tx_readonly.go
@@ -60,7 +60,13 @@ func (r readonlyTx) Get(_ context.Context, record dal.Record) error {
 			return dal.ErrRecordNotFound
 		}
 		record.SetError(nil)
-		if err := dalrecord.MapToData(record.Data(), ApplyLocaleToRead(data, colDef.Columns)); err != nil {
+		normalized := ApplyLocaleToRead(data, colDef.Columns)
+		computed, computeErr := ApplyFormulasToRead(normalized, colDef.Columns, colDef.ID, recordKey)
+		if computeErr != nil {
+			record.SetError(computeErr)
+			return computeErr
+		}
+		if err := dalrecord.MapToData(record.Data(), computed); err != nil {
 			record.SetError(err)
 			return err
 		}
@@ -77,7 +83,13 @@ func (r readonlyTx) Get(_ context.Context, record dal.Record) error {
 			return dal.ErrRecordNotFound
 		}
 		record.SetError(nil)
-		if err := dalrecord.MapToData(record.Data(), ApplyLocaleToRead(recordData, colDef.Columns)); err != nil {
+		normalized := ApplyLocaleToRead(recordData, colDef.Columns)
+		computed, computeErr := ApplyFormulasToRead(normalized, colDef.Columns, colDef.ID, recordKey)
+		if computeErr != nil {
+			record.SetError(computeErr)
+			return computeErr
+		}
+		if err := dalrecord.MapToData(record.Data(), computed); err != nil {
 			record.SetError(err)
 			return err
 		}

--- a/pkg/dalgo2ingitdb/tx_readwrite.go
+++ b/pkg/dalgo2ingitdb/tx_readwrite.go
@@ -166,6 +166,9 @@ func (r readwriteTx) Delete(_ context.Context, key *dal.Key) error {
 		if err := r.validateDeleteForeignKeys(collectionID, recordKey); err != nil {
 			return err
 		}
+		if err := r.validateDeleteComputedForeignKeys(collectionID, recordKey); err != nil {
+			return err
+		}
 	}
 	path := resolveRecordPath(colDef, recordKey)
 	switch colDef.RecordFile.RecordType {
@@ -213,12 +216,22 @@ func (r readwriteTx) Update(ctx context.Context, key *dal.Key, updates []update.
 	if err := applyUpdates(data, updates); err != nil {
 		return err
 	}
-	colDef, _, err := r.resolveCollection(key)
+	colDef, recordKey, err := r.resolveCollection(key)
 	if err != nil {
 		return err
 	}
+	// Get injects computed-column values into data; they must never be written
+	// back. Strip them so the subsequent Set does not reject the record. The
+	// computed foreign key is re-derived from its input fields by
+	// validateComputedWriteForeignKeys below regardless of this removal.
+	for _, field := range orderedComputedColumns(colDef) {
+		delete(data, field)
+	}
 	collectionID := key.Collection()
 	if err := r.validateWriteForeignKeys("Update", collectionID, colDef, data); err != nil {
+		return err
+	}
+	if err := r.validateComputedWriteForeignKeys("Update", collectionID, colDef, recordKey, data); err != nil {
 		return err
 	}
 	return r.Set(ctx, dal.NewRecordWithData(key, data))
@@ -238,12 +251,15 @@ func (r readwriteTx) UpdateRecord(ctx context.Context, record dal.Record, update
 		return err
 	}
 	key := record.Key()
-	colDef, _, err := r.resolveCollection(key)
+	colDef, recordKey, err := r.resolveCollection(key)
 	if err != nil {
 		return err
 	}
 	collectionID := key.Collection()
 	if err := r.validateWriteForeignKeys("UpdateRecord", collectionID, colDef, data); err != nil {
+		return err
+	}
+	if err := r.validateComputedWriteForeignKeys("UpdateRecord", collectionID, colDef, recordKey, data); err != nil {
 		return err
 	}
 	return r.Set(ctx, record)

--- a/pkg/dalgo2ingitdb/tx_readwrite.go
+++ b/pkg/dalgo2ingitdb/tx_readwrite.go
@@ -40,6 +40,9 @@ func (r readwriteTx) Set(_ context.Context, record dal.Record) error {
 		return err
 	}
 	collectionID := key.Collection()
+	if err := r.validateNoStoredComputedValues(collectionID, colDef, recordKey, data); err != nil {
+		return err
+	}
 	if err := r.validateWriteForeignKeys("Set", collectionID, colDef, data); err != nil {
 		return err
 	}
@@ -92,6 +95,9 @@ func (r readwriteTx) Insert(_ context.Context, record dal.Record, _ ...dal.Inser
 		return err
 	}
 	collectionID := key.Collection()
+	if err := r.validateNoStoredComputedValues(collectionID, colDef, recordKey, data); err != nil {
+		return err
+	}
 	if err := r.validateWriteForeignKeys("Insert", collectionID, colDef, data); err != nil {
 		return err
 	}

--- a/pkg/dalgo2ingitdb/tx_readwrite.go
+++ b/pkg/dalgo2ingitdb/tx_readwrite.go
@@ -46,6 +46,9 @@ func (r readwriteTx) Set(_ context.Context, record dal.Record) error {
 	if err := r.validateWriteForeignKeys("Set", collectionID, colDef, data); err != nil {
 		return err
 	}
+	if err := r.validateComputedWriteForeignKeys("Set", collectionID, colDef, recordKey, data); err != nil {
+		return err
+	}
 	path := resolveRecordPath(colDef, recordKey)
 	switch colDef.RecordFile.RecordType {
 	case ingitdb.SingleRecord:
@@ -99,6 +102,9 @@ func (r readwriteTx) Insert(_ context.Context, record dal.Record, _ ...dal.Inser
 		return err
 	}
 	if err := r.validateWriteForeignKeys("Insert", collectionID, colDef, data); err != nil {
+		return err
+	}
+	if err := r.validateComputedWriteForeignKeys("Insert", collectionID, colDef, recordKey, data); err != nil {
 		return err
 	}
 	path := resolveRecordPath(colDef, recordKey)

--- a/pkg/ingitdb/collection_def.go
+++ b/pkg/ingitdb/collection_def.go
@@ -67,6 +67,11 @@ func (v *CollectionDef) Validate() error {
 		if err := col.Validate(); err != nil {
 			return fmt.Errorf("invalid column '%s': %w", id, err)
 		}
+		if col.Formula != "" {
+			if err := validateComputedColumn(v.ID, id, col, v.Columns); err != nil {
+				return err
+			}
+		}
 	}
 	for i, colName := range v.ColumnsOrder {
 		if _, ok := v.Columns[colName]; !ok {

--- a/pkg/ingitdb/column_def.go
+++ b/pkg/ingitdb/column_def.go
@@ -23,6 +23,11 @@ type ColumnDef struct {
 	// `yaml`, `uri`, `email`, `pdf`. inGitDB does not validate the value;
 	// tooling may use it to choose a renderer or preview strategy.
 	Format string `yaml:"format,omitempty"`
+	// Formula declares this column as a computed (virtual) column. When set,
+	// it must be a single Starlark expression that references only stored
+	// (non-computed) sibling fields. Computed columns support only the
+	// string, int, float, bool, and any declared types.
+	Formula string `yaml:"formula,omitempty"`
 }
 
 func (v *ColumnDef) Validate() error {

--- a/pkg/ingitdb/column_def.go
+++ b/pkg/ingitdb/column_def.go
@@ -27,6 +27,10 @@ type ColumnDef struct {
 	// it must be a single Starlark expression that references only stored
 	// (non-computed) sibling fields. Computed columns support only the
 	// string, int, float, bool, and any declared types.
+	//
+	// Note: Starlark's `/` operator is float division, so for an int column
+	// use integer division `//` (e.g. `total // count`) — `a / b` yields a
+	// float and fails coercion into an int column unless the result is whole.
 	Formula string `yaml:"formula,omitempty"`
 }
 

--- a/pkg/ingitdb/column_formula.go
+++ b/pkg/ingitdb/column_formula.go
@@ -1,0 +1,54 @@
+package ingitdb
+
+import (
+	"fmt"
+	"slices"
+
+	"go.starlark.net/syntax"
+)
+
+// computedColumnTypes lists the declared column types supported for computed
+// (formula) columns in this Feature.
+var computedColumnTypes = []ColumnType{
+	ColumnTypeString,
+	ColumnTypeInt,
+	ColumnTypeFloat,
+	ColumnTypeBool,
+	ColumnTypeAny,
+}
+
+// validateComputedColumn validates a column whose Formula is non-empty.
+// It enforces that:
+//   - the declared Type is one of the supported computed-column types,
+//   - the Formula parses as a single Starlark expression, and
+//   - the Formula references only stored (non-computed) sibling columns.
+//
+// Errors name the collection and the column to aid diagnosis.
+func validateComputedColumn(collectionID, colName string, col *ColumnDef, columns map[string]*ColumnDef) error {
+	if !slices.Contains(computedColumnTypes, col.Type) {
+		return fmt.Errorf("collection '%s': computed column '%s' has unsupported type '%s': computed columns support only string, int, float, bool, and any",
+			collectionID, colName, col.Type)
+	}
+
+	var opts syntax.FileOptions
+	expr, err := opts.ParseExpr(colName, col.Formula, 0)
+	if err != nil {
+		return fmt.Errorf("collection '%s': invalid formula for column '%s': %w", collectionID, colName, err)
+	}
+
+	var refErr error
+	syntax.Walk(expr, func(n syntax.Node) bool {
+		ident, ok := n.(*syntax.Ident)
+		if !ok {
+			return true
+		}
+		sibling, exists := columns[ident.Name]
+		if exists && sibling.Formula != "" {
+			refErr = fmt.Errorf("collection '%s': formula for column '%s' references computed column '%s': a formula may reference only stored fields",
+				collectionID, colName, ident.Name)
+			return false
+		}
+		return true
+	})
+	return refErr
+}

--- a/pkg/ingitdb/column_formula_eval.go
+++ b/pkg/ingitdb/column_formula_eval.go
@@ -2,11 +2,31 @@ package ingitdb
 
 import (
 	"fmt"
+	"maps"
 	"math"
+	"sync"
 
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 )
+
+// maxFormulaSteps caps the number of Starlark execution steps a single formula
+// evaluation may take. It is a safety ceiling against pathological expressions
+// (e.g. a comprehension over a large range) that could otherwise hang or
+// exhaust memory while computing a column on read. Legitimate single-record
+// formulas use a few dozen steps; this ceiling is far above any real formula
+// yet bounds abuse.
+const maxFormulaSteps = 1_000_000
+
+// formulaResultVar is the synthetic global the compiled program assigns the
+// formula's value to. The name is deliberately unlikely to collide with a
+// real stored field.
+const formulaResultVar = "__ingitdb_formula_result__"
+
+// formulaProgramCache memoises compiled Starlark programs keyed by formula
+// source, so a formula is parsed and compiled once rather than on every record
+// read. Programs are immutable and safe to Init concurrently.
+var formulaProgramCache sync.Map // map[string]*starlark.Program
 
 // EvaluateFormula evaluates a computed-column formula as a single Starlark
 // expression in a deterministic, side-effect-free sandbox.
@@ -20,29 +40,61 @@ import (
 // The sandbox exposes no network, filesystem, clock, or randomness, and
 // installs no load() loader, so evaluation has zero side effects and is
 // deterministic: identical formula and fields always yield identical output.
+// Evaluation is bounded by maxFormulaSteps. The compiled program is cached, so
+// repeated reads of the same formula do not re-parse it.
 func EvaluateFormula(formula string, fields map[string]any) (any, error) {
-	env := make(starlark.StringDict, len(fields)+formulaBuiltinCount)
-	for name, raw := range fields {
-		v, err := goToStarlark(raw)
-		if err != nil {
-			return nil, fmt.Errorf("field '%s': %w", name, err)
-		}
-		env[name] = v
+	prog, err := compileFormula(formula)
+	if err != nil {
+		return nil, err
 	}
-	addFormulaBuiltins(env)
+
+	// Start from a clone of Starlark's universe so the standard deterministic
+	// builtins (len, min, max, native string methods, ...) remain available,
+	// add the curated numeric helpers, then bind the record's fields last so a
+	// field shadows a same-named builtin.
+	predeclared := maps.Clone(starlark.Universe)
+	addFormulaBuiltins(predeclared)
+	for name, raw := range fields {
+		v, convErr := goToStarlark(raw)
+		if convErr != nil {
+			return nil, fmt.Errorf("field '%s': %w", name, convErr)
+		}
+		predeclared[name] = v
+	}
 
 	thread := &starlark.Thread{
 		Name: "formula",
 		// Route print to a no-op so a reachable print() has no side effect.
 		Print: func(_ *starlark.Thread, _ string) {},
 	}
+	thread.SetMaxExecutionSteps(maxFormulaSteps)
 
-	var opts syntax.FileOptions
-	result, err := starlark.EvalOptions(&opts, thread, "formula", formula, env)
+	globals, err := prog.Init(thread, predeclared)
 	if err != nil {
 		return nil, err
 	}
-	return starlarkToGo(result)
+	// The compiled program is a single assignment to formulaResultVar, so a
+	// successful Init always binds it.
+	return starlarkToGo(globals[formulaResultVar])
+}
+
+// compileFormula returns the cached compiled program for a formula, compiling
+// and memoising it on first use. The formula is wrapped as a single assignment
+// so its value is readable from the program's globals after Init. Every free
+// identifier is treated as predeclared, making the compiled program independent
+// of any particular record's fields and therefore safe to cache by source.
+func compileFormula(formula string) (*starlark.Program, error) {
+	if cached, ok := formulaProgramCache.Load(formula); ok {
+		return cached.(*starlark.Program), nil
+	}
+	src := formulaResultVar + " = (" + formula + ")\n"
+	var opts syntax.FileOptions
+	_, prog, err := starlark.SourceProgramOptions(&opts, "formula", src, func(string) bool { return true })
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := formulaProgramCache.LoadOrStore(formula, prog)
+	return actual.(*starlark.Program), nil
 }
 
 // goToStarlark converts a supported Go value into its Starlark equivalent.
@@ -104,10 +156,6 @@ func starlarkToGo(v starlark.Value) (any, error) {
 		return nil, fmt.Errorf("unsupported result type %s", v.Type())
 	}
 }
-
-// formulaBuiltinCount is the number of bare builtins addFormulaBuiltins adds,
-// used only to pre-size the environment map.
-const formulaBuiltinCount = 4
 
 // addFormulaBuiltins installs the curated, deterministic numeric helpers as
 // bare top-level names: abs, round, floor, and ceil. Starlark's universe

--- a/pkg/ingitdb/column_formula_eval.go
+++ b/pkg/ingitdb/column_formula_eval.go
@@ -1,0 +1,174 @@
+package ingitdb
+
+import (
+	"fmt"
+	"math"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+// EvaluateFormula evaluates a computed-column formula as a single Starlark
+// expression in a deterministic, side-effect-free sandbox.
+//
+// Each entry of fields is bound as a top-level variable available to the
+// expression. Supported Go input types are string, bool, int, int8, int16,
+// int32, int64, uint, uint8, uint16, uint32, uint64, float32, and float64.
+// The result is converted back to a Go-native value: string, bool, int64, or
+// float64. A nil field value or a None result maps to/from Go nil.
+//
+// The sandbox exposes no network, filesystem, clock, or randomness, and
+// installs no load() loader, so evaluation has zero side effects and is
+// deterministic: identical formula and fields always yield identical output.
+func EvaluateFormula(formula string, fields map[string]any) (any, error) {
+	env := make(starlark.StringDict, len(fields)+formulaBuiltinCount)
+	for name, raw := range fields {
+		v, err := goToStarlark(raw)
+		if err != nil {
+			return nil, fmt.Errorf("field '%s': %w", name, err)
+		}
+		env[name] = v
+	}
+	addFormulaBuiltins(env)
+
+	thread := &starlark.Thread{
+		Name: "formula",
+		// Route print to a no-op so a reachable print() has no side effect.
+		Print: func(_ *starlark.Thread, _ string) {},
+	}
+
+	var opts syntax.FileOptions
+	result, err := starlark.EvalOptions(&opts, thread, "formula", formula, env)
+	if err != nil {
+		return nil, err
+	}
+	return starlarkToGo(result)
+}
+
+// goToStarlark converts a supported Go value into its Starlark equivalent.
+func goToStarlark(v any) (starlark.Value, error) {
+	switch t := v.(type) {
+	case nil:
+		return starlark.None, nil
+	case bool:
+		return starlark.Bool(t), nil
+	case string:
+		return starlark.String(t), nil
+	case int:
+		return starlark.MakeInt64(int64(t)), nil
+	case int8:
+		return starlark.MakeInt64(int64(t)), nil
+	case int16:
+		return starlark.MakeInt64(int64(t)), nil
+	case int32:
+		return starlark.MakeInt64(int64(t)), nil
+	case int64:
+		return starlark.MakeInt64(t), nil
+	case uint:
+		return starlark.MakeUint64(uint64(t)), nil
+	case uint8:
+		return starlark.MakeUint64(uint64(t)), nil
+	case uint16:
+		return starlark.MakeUint64(uint64(t)), nil
+	case uint32:
+		return starlark.MakeUint64(uint64(t)), nil
+	case uint64:
+		return starlark.MakeUint64(t), nil
+	case float32:
+		return starlark.Float(float64(t)), nil
+	case float64:
+		return starlark.Float(t), nil
+	default:
+		return nil, fmt.Errorf("unsupported field type %T", v)
+	}
+}
+
+// starlarkToGo converts a Starlark result value into a Go-native value.
+func starlarkToGo(v starlark.Value) (any, error) {
+	switch t := v.(type) {
+	case starlark.NoneType:
+		return nil, nil
+	case starlark.Bool:
+		return bool(t), nil
+	case starlark.String:
+		return string(t), nil
+	case starlark.Int:
+		i, ok := t.Int64()
+		if !ok {
+			return nil, fmt.Errorf("integer result %s does not fit in int64", t.String())
+		}
+		return i, nil
+	case starlark.Float:
+		return float64(t), nil
+	default:
+		return nil, fmt.Errorf("unsupported result type %s", v.Type())
+	}
+}
+
+// formulaBuiltinCount is the number of bare builtins addFormulaBuiltins adds,
+// used only to pre-size the environment map.
+const formulaBuiltinCount = 4
+
+// addFormulaBuiltins installs the curated, deterministic numeric helpers as
+// bare top-level names: abs, round, floor, and ceil. Starlark's universe
+// already provides len, min, max, and the native string methods; no
+// IO-capable or non-deterministic module is exposed.
+func addFormulaBuiltins(env starlark.StringDict) {
+	env["abs"] = starlark.NewBuiltin("abs", formulaAbs)
+	env["round"] = starlark.NewBuiltin("round", formulaRound)
+	env["floor"] = starlark.NewBuiltin("floor", formulaFloor)
+	env["ceil"] = starlark.NewBuiltin("ceil", formulaCeil)
+}
+
+// formulaAbs returns the absolute value, preserving int vs float.
+func formulaAbs(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var x starlark.Value
+	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &x); err != nil {
+		return nil, err
+	}
+	switch t := x.(type) {
+	case starlark.Int:
+		if t.Sign() < 0 {
+			return zeroInt.Sub(t), nil
+		}
+		return t, nil
+	case starlark.Float:
+		return starlark.Float(math.Abs(float64(t))), nil
+	default:
+		return nil, fmt.Errorf("%s: got %s, want int or float", b.Name(), x.Type())
+	}
+}
+
+// formulaRound rounds to the nearest integer and returns an int.
+func formulaRound(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return floatUnaryToInt(b, args, kwargs, math.Round)
+}
+
+// formulaFloor returns the greatest integer <= x as an int.
+func formulaFloor(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return floatUnaryToInt(b, args, kwargs, math.Floor)
+}
+
+// formulaCeil returns the least integer >= x as an int.
+func formulaCeil(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return floatUnaryToInt(b, args, kwargs, math.Ceil)
+}
+
+// zeroInt is a reusable zero used to negate integers without allocation churn.
+var zeroInt = starlark.MakeInt(0)
+
+// floatUnaryToInt applies fn to an int-or-float argument and returns an int.
+func floatUnaryToInt(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple, fn func(float64) float64) (starlark.Value, error) {
+	var x starlark.Value
+	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &x); err != nil {
+		return nil, err
+	}
+	switch t := x.(type) {
+	case starlark.Int:
+		return t, nil
+	case starlark.Float:
+		return starlark.NumberToInt(starlark.Float(fn(float64(t))))
+	default:
+		return nil, fmt.Errorf("%s: got %s, want int or float", b.Name(), x.Type())
+	}
+}

--- a/pkg/ingitdb/column_formula_eval_test.go
+++ b/pkg/ingitdb/column_formula_eval_test.go
@@ -389,3 +389,15 @@ func TestEvaluateFormulaIntOverflowResult(t *testing.T) {
 		t.Fatal("expected error for int64 overflow result")
 	}
 }
+
+// TestEvaluateFormulaStepLimit ensures a pathological expression (a comprehension
+// over a large range) is bounded by the execution-step ceiling and fails rather
+// than hanging or exhausting memory while computing a column on read.
+func TestEvaluateFormulaStepLimit(t *testing.T) {
+	t.Parallel()
+
+	_, err := EvaluateFormula("len([0 for _ in range(5000000)])", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error: a pathological comprehension must hit the step limit")
+	}
+}

--- a/pkg/ingitdb/column_formula_eval_test.go
+++ b/pkg/ingitdb/column_formula_eval_test.go
@@ -1,0 +1,391 @@
+package ingitdb
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEvaluateFormula(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		formula string
+		fields  map[string]any
+		want    any
+	}{
+		{
+			name:    "simple field reference",
+			formula: "name",
+			fields:  map[string]any{"name": "ada"},
+			want:    "ada",
+		},
+		{
+			name:    "arithmetic",
+			formula: "a + b * 2",
+			fields:  map[string]any{"a": int64(3), "b": int64(4)},
+			want:    int64(11),
+		},
+		// String helpers (REQ:builtin-helpers).
+		{
+			name:    "string strip",
+			formula: "s.strip()",
+			fields:  map[string]any{"s": "  hi  "},
+			want:    "hi",
+		},
+		{
+			name:    "string lower",
+			formula: "s.lower()",
+			fields:  map[string]any{"s": "ABC"},
+			want:    "abc",
+		},
+		{
+			name:    "string upper",
+			formula: "s.upper()",
+			fields:  map[string]any{"s": "abc"},
+			want:    "ABC",
+		},
+		{
+			name:    "string replace",
+			formula: "s.replace('a', 'o')",
+			fields:  map[string]any{"s": "banana"},
+			want:    "bonono",
+		},
+		{
+			name:    "string split then index",
+			formula: "s.split(',')[1]",
+			fields:  map[string]any{"s": "a,b,c"},
+			want:    "b",
+		},
+		{
+			name:    "string startswith",
+			formula: "s.startswith('ab')",
+			fields:  map[string]any{"s": "abc"},
+			want:    true,
+		},
+		{
+			name:    "string endswith",
+			formula: "s.endswith('bc')",
+			fields:  map[string]any{"s": "abc"},
+			want:    true,
+		},
+		// Universe functions.
+		{
+			name:    "len",
+			formula: "len(s)",
+			fields:  map[string]any{"s": "hello"},
+			want:    int64(5),
+		},
+		{
+			name:    "min",
+			formula: "min(a, b)",
+			fields:  map[string]any{"a": int64(3), "b": int64(1)},
+			want:    int64(1),
+		},
+		{
+			name:    "max",
+			formula: "max(a, b)",
+			fields:  map[string]any{"a": int64(3), "b": int64(1)},
+			want:    int64(3),
+		},
+		// Bare math helpers (REQ:builtin-helpers).
+		{
+			name:    "abs of negative int",
+			formula: "abs(x)",
+			fields:  map[string]any{"x": int64(-7)},
+			want:    int64(7),
+		},
+		{
+			name:    "abs of positive int",
+			formula: "abs(x)",
+			fields:  map[string]any{"x": int64(7)},
+			want:    int64(7),
+		},
+		{
+			name:    "abs of negative float",
+			formula: "abs(x)",
+			fields:  map[string]any{"x": -2.5},
+			want:    2.5,
+		},
+		{
+			name:    "round float to int",
+			formula: "round(x)",
+			fields:  map[string]any{"x": 4.4},
+			want:    int64(4),
+		},
+		{
+			name:    "round of int is unchanged",
+			formula: "round(x)",
+			fields:  map[string]any{"x": int64(7)},
+			want:    int64(7),
+		},
+		{
+			name:    "floor float to int",
+			formula: "floor(x)",
+			fields:  map[string]any{"x": 4.9},
+			want:    int64(4),
+		},
+		{
+			name:    "floor of int is unchanged",
+			formula: "floor(x)",
+			fields:  map[string]any{"x": int64(7)},
+			want:    int64(7),
+		},
+		{
+			name:    "ceil float to int",
+			formula: "ceil(x)",
+			fields:  map[string]any{"x": 4.1},
+			want:    int64(5),
+		},
+		{
+			name:    "ceil of int is unchanged",
+			formula: "ceil(x)",
+			fields:  map[string]any{"x": int64(7)},
+			want:    int64(7),
+		},
+		// AC: builtin-string-helper-available.
+		// Spec phrases this "when the record is read"; read-path wiring is a
+		// later task, so it is verified here at the evaluator level.
+		{
+			name:    "AC builtin-string-helper-available",
+			formula: "first_name.strip().upper()",
+			fields:  map[string]any{"first_name": " ada "},
+			want:    "ADA",
+		},
+		// AC: builtin-math-helper-available.
+		// Spec phrases this "when the record is read"; verified here at the
+		// evaluator level. Integer coercion to the declared column type is a
+		// later task, so we assert the numeric result equals 5.
+		{
+			name:    "AC builtin-math-helper-available",
+			formula: "round(score)",
+			fields:  map[string]any{"score": 4.6},
+			want:    int64(5),
+		},
+		// Result type conversions.
+		{
+			name:    "bool result",
+			formula: "a == b",
+			fields:  map[string]any{"a": int64(1), "b": int64(1)},
+			want:    true,
+		},
+		{
+			name:    "float result",
+			formula: "x / 2.0",
+			fields:  map[string]any{"x": 5.0},
+			want:    2.5,
+		},
+		// None round-trips to Go nil (input nil and None result).
+		{
+			name:    "nil field round-trips to None then back to nil",
+			formula: "x",
+			fields:  map[string]any{"x": nil},
+			want:    nil,
+		},
+		// Input type conversions for each supported Go type.
+		{
+			name:    "input bool",
+			formula: "b",
+			fields:  map[string]any{"b": true},
+			want:    true,
+		},
+		{
+			name:    "input int",
+			formula: "x + 1",
+			fields:  map[string]any{"x": int(2)},
+			want:    int64(3),
+		},
+		{
+			name:    "input int8",
+			formula: "x + 1",
+			fields:  map[string]any{"x": int8(2)},
+			want:    int64(3),
+		},
+		{
+			name:    "input int16",
+			formula: "x + 1",
+			fields:  map[string]any{"x": int16(2)},
+			want:    int64(3),
+		},
+		{
+			name:    "input int32",
+			formula: "x + 1",
+			fields:  map[string]any{"x": int32(2)},
+			want:    int64(3),
+		},
+		{
+			name:    "input int64",
+			formula: "x + 1",
+			fields:  map[string]any{"x": int64(2)},
+			want:    int64(3),
+		},
+		{
+			name:    "input uint",
+			formula: "x + 1",
+			fields:  map[string]any{"x": uint(2)},
+			want:    int64(3),
+		},
+		{
+			name:    "input uint8",
+			formula: "x + 1",
+			fields:  map[string]any{"x": uint8(2)},
+			want:    int64(3),
+		},
+		{
+			name:    "input uint16",
+			formula: "x + 1",
+			fields:  map[string]any{"x": uint16(2)},
+			want:    int64(3),
+		},
+		{
+			name:    "input uint32",
+			formula: "x + 1",
+			fields:  map[string]any{"x": uint32(2)},
+			want:    int64(3),
+		},
+		{
+			name:    "input uint64",
+			formula: "x + 1",
+			fields:  map[string]any{"x": uint64(2)},
+			want:    int64(3),
+		},
+		{
+			name:    "input float32",
+			formula: "x + 0.5",
+			fields:  map[string]any{"x": float32(2.0)},
+			want:    2.5,
+		},
+		{
+			name:    "input float64",
+			formula: "x + 0.5",
+			fields:  map[string]any{"x": float64(2.0)},
+			want:    2.5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := EvaluateFormula(tt.formula, tt.fields)
+			if err != nil {
+				t.Fatalf("EvaluateFormula(%q) returned error: %v", tt.formula, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("EvaluateFormula(%q) = %#v, want %#v", tt.formula, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEvaluateFormulaDeterministic asserts AC: deterministic-evaluation —
+// evaluating the same formula and fields twice returns identical output.
+func TestEvaluateFormulaDeterministic(t *testing.T) {
+	t.Parallel()
+
+	formula := "first_name.strip().upper() + str(round(score))"
+	fields := map[string]any{"first_name": " ada ", "score": 4.6}
+
+	first, err := EvaluateFormula(formula, fields)
+	if err != nil {
+		t.Fatalf("first eval error: %v", err)
+	}
+	second, err := EvaluateFormula(formula, fields)
+	if err != nil {
+		t.Fatalf("second eval error: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("non-deterministic: first=%#v second=%#v", first, second)
+	}
+}
+
+// TestEvaluateFormulaSandbox asserts AC: deterministic-evaluation's sandbox
+// clause — no clock, randomness, network, filesystem, or load() is reachable.
+func TestEvaluateFormulaSandbox(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		formula string
+	}{
+		{name: "time module absent", formula: "time.now()"},
+		{name: "random module absent", formula: "random.random()"},
+		{name: "math module absent (only bare helpers exposed)", formula: "math.pi"},
+		{name: "open is absent", formula: "open('/etc/passwd')"},
+		{name: "load is not a callable", formula: "load('x', 'y')"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := EvaluateFormula(tt.formula, nil)
+			if err == nil {
+				t.Fatalf("expected error for %q (IO/non-deterministic access must be absent)", tt.formula)
+			}
+		})
+	}
+}
+
+// TestEvaluateFormulaRuntimeError ensures a runtime failure returns an error
+// instead of panicking.
+func TestEvaluateFormulaRuntimeError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		formula string
+		fields  map[string]any
+	}{
+		{name: "unknown identifier", formula: "missing", fields: nil},
+		{name: "division by zero", formula: "1 // 0", fields: nil},
+		{name: "type error in helper", formula: "round(s)", fields: map[string]any{"s": "x"}},
+		{name: "abs on string", formula: "abs(s)", fields: map[string]any{"s": "x"}},
+		{name: "abs wrong arg count", formula: "abs()", fields: nil},
+		{name: "round wrong arg count", formula: "round()", fields: nil},
+		{name: "syntax error", formula: "1 +", fields: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := EvaluateFormula(tt.formula, tt.fields)
+			if err == nil {
+				t.Fatalf("expected error for %q", tt.formula)
+			}
+		})
+	}
+}
+
+// TestEvaluateFormulaUnsupportedFieldType ensures an unsupported Go input type
+// returns an error.
+func TestEvaluateFormulaUnsupportedFieldType(t *testing.T) {
+	t.Parallel()
+
+	fields := map[string]any{"x": []int{1, 2}}
+	_, err := EvaluateFormula("x", fields)
+	if err == nil {
+		t.Fatal("expected error for unsupported field type")
+	}
+}
+
+// TestEvaluateFormulaUnsupportedResultType ensures a result type with no Go
+// mapping returns an error rather than panicking. A list literal result is
+// not convertible.
+func TestEvaluateFormulaUnsupportedResultType(t *testing.T) {
+	t.Parallel()
+
+	_, err := EvaluateFormula("[1, 2, 3]", nil)
+	if err == nil {
+		t.Fatal("expected error for unsupported result type")
+	}
+}
+
+// TestEvaluateFormulaIntOverflowResult ensures an integer result that does not
+// fit in int64 returns an error rather than silently truncating.
+func TestEvaluateFormulaIntOverflowResult(t *testing.T) {
+	t.Parallel()
+
+	_, err := EvaluateFormula("x * x", map[string]any{"x": int64(1) << 62})
+	if err == nil {
+		t.Fatal("expected error for int64 overflow result")
+	}
+}

--- a/pkg/ingitdb/column_formula_test.go
+++ b/pkg/ingitdb/column_formula_test.go
@@ -1,0 +1,138 @@
+package ingitdb
+
+import (
+	"strings"
+	"testing"
+)
+
+func collectionWithColumns(columns map[string]*ColumnDef) *CollectionDef {
+	return &CollectionDef{
+		ID:      "people",
+		Columns: columns,
+		RecordFile: &RecordFileDef{
+			Format:     "JSON",
+			Name:       "{key}.json",
+			RecordType: SingleRecord,
+		},
+	}
+}
+
+func TestValidateComputedColumn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		columns map[string]*ColumnDef
+		wantErr []string // substrings that must all be present; empty => expect success
+	}{
+		{
+			name: "valid_single_expression",
+			columns: map[string]*ColumnDef{
+				"first_name": {Type: ColumnTypeString},
+				"last_name":  {Type: ColumnTypeString},
+				"full_name":  {Type: ColumnTypeString, Formula: "first_name + ' ' + last_name"},
+			},
+		},
+		{
+			name: "type_string",
+			columns: map[string]*ColumnDef{
+				"a":      {Type: ColumnTypeString},
+				"result": {Type: ColumnTypeString, Formula: "a"},
+			},
+		},
+		{
+			name: "type_int",
+			columns: map[string]*ColumnDef{
+				"a":      {Type: ColumnTypeInt},
+				"result": {Type: ColumnTypeInt, Formula: "a + 1"},
+			},
+		},
+		{
+			name: "type_float",
+			columns: map[string]*ColumnDef{
+				"a":      {Type: ColumnTypeFloat},
+				"result": {Type: ColumnTypeFloat, Formula: "a * 2.0"},
+			},
+		},
+		{
+			name: "type_bool",
+			columns: map[string]*ColumnDef{
+				"a":      {Type: ColumnTypeInt},
+				"result": {Type: ColumnTypeBool, Formula: "a > 0"},
+			},
+		},
+		{
+			name: "type_any",
+			columns: map[string]*ColumnDef{
+				"a":      {Type: ColumnTypeString},
+				"result": {Type: ColumnTypeAny, Formula: "a"},
+			},
+		},
+		{
+			name: "references_stored_sibling_accepted",
+			columns: map[string]*ColumnDef{
+				"first_name": {Type: ColumnTypeString},
+				"greeting":   {Type: ColumnTypeString, Formula: "'Hi ' + first_name"},
+			},
+		},
+		{
+			name: "syntax_error_incomplete_expression",
+			columns: map[string]*ColumnDef{
+				"first_name": {Type: ColumnTypeString},
+				"full_name":  {Type: ColumnTypeString, Formula: "first_name +"},
+			},
+			wantErr: []string{"people", "full_name", "invalid formula"},
+		},
+		{
+			name: "statement_body_rejected",
+			columns: map[string]*ColumnDef{
+				"x": {Type: ColumnTypeInt, Formula: "x = 1"},
+			},
+			wantErr: []string{"people", "x", "invalid formula"},
+		},
+		{
+			name: "unsupported_type_datetime",
+			columns: map[string]*ColumnDef{
+				"a":         {Type: ColumnTypeString},
+				"timestamp": {Type: ColumnTypeDateTime, Formula: "a"},
+			},
+			wantErr: []string{"people", "timestamp", "unsupported type"},
+		},
+		{
+			name: "references_computed_sibling_rejected",
+			columns: map[string]*ColumnDef{
+				"first_name": {Type: ColumnTypeString},
+				"last_name":  {Type: ColumnTypeString},
+				"full_name":  {Type: ColumnTypeString, Formula: "first_name + ' ' + last_name"},
+				"greeting":   {Type: ColumnTypeString, Formula: "'Hi ' + full_name"},
+			},
+			wantErr: []string{"people", "greeting", "full_name", "stored fields"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			def := collectionWithColumns(tt.columns)
+			err := def.Validate()
+
+			if len(tt.wantErr) == 0 {
+				if err != nil {
+					t.Fatalf("expected no error, got %s", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %v, got nil", tt.wantErr)
+			}
+			errMsg := err.Error()
+			for _, want := range tt.wantErr {
+				if !strings.Contains(errMsg, want) {
+					t.Fatalf("expected error to contain %q, got %q", want, errMsg)
+				}
+			}
+		})
+	}
+}

--- a/pkg/ingitdb/datavalidator/validator.go
+++ b/pkg/ingitdb/datavalidator/validator.go
@@ -266,6 +266,14 @@ func validateRecordData(
 ) []ingitdb.ValidationError {
 	var errors []ingitdb.ValidationError
 	for fieldName, columnDef := range colDef.Columns {
+		if columnDef.Formula != "" {
+			if _, present := data[fieldName]; present {
+				message := fmt.Sprintf("computed column %q must not be stored", fieldName)
+				validationErr := newValidationError(collectionKey, filePath, recordKey, fieldName, message, nil)
+				errors = append(errors, validationErr)
+			}
+			continue
+		}
 		value, ok := data[fieldName]
 		if !ok || value == nil {
 			if columnDef.Required {

--- a/pkg/ingitdb/datavalidator/validator_test.go
+++ b/pkg/ingitdb/datavalidator/validator_test.go
@@ -514,6 +514,111 @@ func TestValidate_RecordSchemaViolations(t *testing.T) {
 	}
 }
 
+func TestValidate_StoredComputedColumnRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	colDir := filepath.Join(dir, "people")
+	recordsDir := filepath.Join(colDir, "$records")
+	if err := os.MkdirAll(recordsDir, 0o755); err != nil {
+		t.Fatalf("setup: mkdir: %v", err)
+	}
+	recordPath := filepath.Join(recordsDir, "ada.yaml")
+	if err := os.WriteFile(recordPath, []byte("first_name: Ada\nlast_name: Lovelace\nfull_name: Ada Lovelace\n"), 0o644); err != nil {
+		t.Fatalf("setup: write record: %v", err)
+	}
+
+	def := &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"people": {
+				ID:      "people",
+				DirPath: colDir,
+				RecordFile: &ingitdb.RecordFileDef{
+					Name:       "{key}.yaml",
+					Format:     ingitdb.RecordFormatYAML,
+					RecordType: ingitdb.SingleRecord,
+				},
+				Columns: map[string]*ingitdb.ColumnDef{
+					"first_name": {Type: ingitdb.ColumnTypeString},
+					"last_name":  {Type: ingitdb.ColumnTypeString},
+					"full_name":  {Type: ingitdb.ColumnTypeString, Formula: `first_name + " " + last_name`},
+				},
+			},
+		},
+	}
+
+	v := NewValidator()
+	result, err := v.Validate(context.Background(), dir, def)
+	if err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	errors := result.Errors()
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 validation error, got %d: %v", len(errors), errors)
+	}
+	validationErr := errors[0]
+	if validationErr.CollectionID != "people" {
+		t.Fatalf("expected collection people, got %q", validationErr.CollectionID)
+	}
+	if validationErr.FieldName != "full_name" {
+		t.Fatalf("expected field full_name, got %q", validationErr.FieldName)
+	}
+	if !strings.Contains(validationErr.Error(), "full_name") {
+		t.Fatalf("expected error to name full_name, got: %v", validationErr)
+	}
+	passed, total := result.GetRecordCounts("people")
+	if passed != 0 || total != 1 {
+		t.Fatalf("expected 0/1 record counts, got %d/%d", passed, total)
+	}
+}
+
+func TestValidate_CleanRecordWithoutComputedColumnPasses(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	colDir := filepath.Join(dir, "people")
+	recordsDir := filepath.Join(colDir, "$records")
+	if err := os.MkdirAll(recordsDir, 0o755); err != nil {
+		t.Fatalf("setup: mkdir: %v", err)
+	}
+	recordPath := filepath.Join(recordsDir, "ada.yaml")
+	if err := os.WriteFile(recordPath, []byte("first_name: Ada\nlast_name: Lovelace\n"), 0o644); err != nil {
+		t.Fatalf("setup: write record: %v", err)
+	}
+
+	def := &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"people": {
+				ID:      "people",
+				DirPath: colDir,
+				RecordFile: &ingitdb.RecordFileDef{
+					Name:       "{key}.yaml",
+					Format:     ingitdb.RecordFormatYAML,
+					RecordType: ingitdb.SingleRecord,
+				},
+				Columns: map[string]*ingitdb.ColumnDef{
+					"first_name": {Type: ingitdb.ColumnTypeString},
+					"last_name":  {Type: ingitdb.ColumnTypeString},
+					"full_name":  {Type: ingitdb.ColumnTypeString, Formula: `first_name + " " + last_name`},
+				},
+			},
+		},
+	}
+
+	v := NewValidator()
+	result, err := v.Validate(context.Background(), dir, def)
+	if err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if result.HasErrors() {
+		t.Fatalf("expected no validation errors, got: %v", result.Errors())
+	}
+	passed, total := result.GetRecordCounts("people")
+	if passed != 1 || total != 1 {
+		t.Fatalf("expected 1/1 record counts, got %d/%d", passed, total)
+	}
+}
+
 func TestExpectedRecordExtensions_NoRecordFile(t *testing.T) {
 	t.Parallel()
 

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -42,6 +42,7 @@ This directory tracks the SpecScore feature specifications for the **ingitdb-cli
 | [dalgo2ingitdb-dbschema-ddl-coverage](dalgo2ingitdb-dbschema-ddl-coverage/README.md) | Draft | TODO: Add description. |
 | [dalgo2ingitdb-referential-integrity](dalgo2ingitdb-referential-integrity/README.md) | Approved | DALgo write transactions enforce existing `foreign_key` metadata on Set, Insert, Update, and Delete. |
 | [record-key](record-key/README.md) | Draft | Umbrella for canonical record identity behavior across schema validation, storage paths, writes, and CLI key surfaces. |
+| [computed-columns](computed-columns/README.md) | Approved | TODO: Add description. |
 
 ## Feature Summaries
 

--- a/spec/features/computed-columns/README.md
+++ b/spec/features/computed-columns/README.md
@@ -1,0 +1,257 @@
+# Feature: Computed Columns (Inline Starlark Formulas)
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=request-change) |
+**Status:** Approved
+**Date:** 2026-06-02
+**Owner:** alexander.trakhimenok@gmail.com
+**Source Ideas:** scripted-formulas-and-views
+**Supersedes:** —
+
+## Summary
+
+Lets a schema author add an inline Starlark formula to a collection column so its
+value is computed from the record's other fields at read time, rather than stored.
+It serves schema authors who want derived values (full names, labels, simple
+arithmetic) that stay in sync with their source fields and never drift in git.
+
+## Problem
+
+inGitDB columns today are purely stored: every value lives in the record file and
+must be kept in sync by hand. There is no way to say "this column is `first_name`
+plus `last_name`" or "this label is derived from two other fields." Authors either
+duplicate data across fields (drift risk) or compute it in external tooling
+(inconsistent across consumers). The schema needs a first-class, sandboxed,
+deterministic way to derive a column's value from sibling fields, reusing inGitDB's
+existing read-time transformation pipeline (`ApplyLocaleToRead`).
+
+## Behavior
+
+A computed column is an ordinary `ColumnDef` that carries a non-empty `formula`
+attribute holding one inline Starlark expression. The value is derived, never stored:
+it is produced by the embedded Starlark interpreter from the record's stored fields
+and coerced to the column's declared type. It is evaluated on read for output,
+filtering, and sorting; and evaluated at write time from the `insert`/`update`
+payload for foreign-key checks. It is never written to record files.
+
+### Declaring a computed column
+
+#### REQ: declare-formula
+
+A `ColumnDef` MAY declare an optional `formula` string. A column whose `formula`
+is non-empty is a *computed column*. The `formula` MUST be a single valid Starlark
+expression; a parse error, or a body containing statements rather than one
+expression, MUST be reported as a schema validation error naming the collection and
+column.
+
+#### REQ: reject-stored-value
+
+A computed column's value MUST NOT be sourced from storage. If a record file, or an
+`insert`/`update` payload, supplies a value for a computed column, the operation
+MUST fail with a validation/write error identifying the collection, record key, and
+column. The computed value is the only source of truth for that column.
+
+#### REQ: stored-fields-only
+
+For this Feature, a formula MAY reference only stored (non-computed) sibling fields
+of the same record. A formula that references another computed column MUST be
+rejected as a schema validation error. (Chained computed columns — a formula
+referencing another computed column — are deferred to a future Feature.)
+
+### Evaluating formulas
+
+#### REQ: evaluate-on-read
+
+For every record read from a collection, each computed column's value MUST be
+produced by evaluating its `formula` before the record is returned to the caller,
+in the same read-time transformation stage as `ApplyLocaleToRead`.
+
+#### REQ: sandboxed-deterministic
+
+The formula MUST be evaluated by the embedded Starlark interpreter with the record's
+stored fields bound as variables, in a sandbox that exposes no network, filesystem,
+clock, or randomness. Given identical record input and identical schema, evaluation
+MUST always yield identical output.
+
+#### REQ: builtin-helpers
+
+Formulas MUST have access to a curated set of deterministic, side-effect-free helper
+functions: Starlark's native string methods (including `.strip()`, `.lower()`,
+`.upper()`, `.replace()`, `.split()`, `.startswith()`, `.endswith()`), the universe
+functions `len`, `min`, and `max`, and a numeric helper set providing at least `abs`,
+`round`, `floor`, and `ceil`. Every exposed helper MUST be pure and deterministic; the
+interpreter MUST NOT expose any helper that accesses the network, filesystem, clock,
+or randomness, and MUST NOT load any module providing such capabilities. Helper
+coverage MAY be extended later, but only with functions meeting this same
+determinism-and-no-IO bar.
+
+#### REQ: coerce-to-type
+
+The evaluated result MUST be coerced to the column's declared `ColumnType`. The MVP
+supports coercion to `string`, `int`, `float`, `bool`, and `any`. A declared type
+outside that set on a computed column MUST be rejected as a schema validation error.
+
+### Error handling
+
+#### REQ: fail-loud
+
+If a formula raises a runtime error, or its result cannot be coerced to the declared
+type, the read/materialization MUST abort with an error identifying the collection,
+record key, column, and underlying cause. The system MUST NOT emit a partial row or
+silently null the offending cell.
+
+### Query and reference integration
+
+#### REQ: usable-in-filter-and-sort
+
+Because computed columns are evaluated before query operations, a computed column
+MUST be usable in `--where` predicates and `order_by` exactly as a stored column is.
+
+#### REQ: reference-error-shape
+
+Every referential-integrity error this Feature raises for a computed foreign key MUST
+report a consistent set of fields — the *reference-error shape*: the referencing
+collection, the referencing record key, the computed foreign-key column, and the
+referenced collection. All foreign-key acceptance criteria assert this shape.
+
+#### REQ: foreign-key-support
+
+A computed column MAY declare `foreign_key`. Enforcement rides the existing
+write-time referential-integrity path: on `insert`/`update`, the column's formula is
+evaluated from the payload's stored fields and the derived value is validated against
+the referenced collection, exactly as a stored foreign key is. A derived value that
+does not resolve to an existing record in the target collection MUST be rejected with
+a referential-integrity error in the reference-error shape (REQ:reference-error-shape).
+
+#### REQ: foreign-key-revalidate-on-input-change
+
+A computed foreign-key column is never written directly, so an `update` MUST NOT
+skip its foreign-key check based on which columns were supplied: the check MUST be
+re-run for every computed foreign key on the record being updated. (Revalidating all
+computed foreign keys on every update is a conforming implementation; no formula
+dependency analysis is required.)
+
+#### REQ: foreign-key-parent-side
+
+Deleting or renaming a record that a computed foreign key references MUST be detected.
+Because the referencing value is derived and not stored, the system MUST scan the
+referencing collection and recompute each computed foreign key to find records that
+resolve to the affected key, then reject the operation with a referential-integrity
+error. (A derived-value index to avoid the full scan is a future performance
+optimization, out of scope for this Feature.)
+
+## Acceptance Criteria
+
+### AC: formula-declared-and-computed (verifies REQ:declare-formula, REQ:evaluate-on-read)
+
+**Given** a collection `people` whose `definition.yaml` declares a `string` column `full_name` with `formula: 'first_name + " " + last_name'`
+**When** a record with `first_name: "Ada"` and `last_name: "Lovelace"` is read via `select`
+**Then** the returned record's `full_name` equals `"Ada Lovelace"`
+
+### AC: formula-syntax-error (verifies REQ:declare-formula)
+
+**Given** a column declaring `formula: 'first_name +'` (not a complete Starlark expression)
+**When** the schema is loaded or validated
+**Then** validation fails with an error naming the collection and the `full_name` column
+
+### AC: reject-stored-computed-value (verifies REQ:reject-stored-value)
+
+**Given** a computed column `full_name`
+**When** an `insert` (or a record file under validation) supplies a `full_name` value
+**Then** the operation fails with an error naming the collection, record key, and `full_name` column
+
+### AC: reject-chained-computed-reference (verifies REQ:stored-fields-only)
+
+**Given** a computed column `greeting` whose formula references another computed column `full_name`
+**When** the schema is loaded or validated
+**Then** validation fails with an error stating a formula may reference only stored fields
+
+### AC: deterministic-evaluation (verifies REQ:sandboxed-deterministic)
+
+**Given** any record and a computed column
+**When** the column's formula is evaluated twice for the same input
+**Then** both evaluations return byte-identical output and no network, filesystem, clock, or randomness is accessible to the formula
+
+### AC: type-coercion-success (verifies REQ:coerce-to-type)
+
+**Given** an `int` column `total` with `formula: 'qty * price'` and a record with `qty: 3`, `price: 4`
+**When** the record is read
+**Then** `total` equals integer `12`
+
+### AC: unsupported-type-rejected (verifies REQ:coerce-to-type)
+
+**Given** a computed column declared with type `datetime`
+**When** the schema is loaded or validated
+**Then** validation fails because computed columns support only `string`, `int`, `float`, `bool`, and `any` in this Feature
+
+### AC: runtime-error-fails-read (verifies REQ:fail-loud)
+
+**Given** a computed `int` column whose formula divides by a field that is zero for some record
+**When** that record is read
+**Then** the read aborts with an error naming the collection, record key, and column, and no partial row is emitted
+
+### AC: filter-on-computed-column (verifies REQ:usable-in-filter-and-sort)
+
+**Given** the `people` collection with computed `full_name`
+**When** `select` is run with `--where 'full_name == "Ada Lovelace"'`
+**Then** only records whose computed `full_name` equals `"Ada Lovelace"` are returned
+
+### AC: order-by-computed-column (verifies REQ:usable-in-filter-and-sort)
+
+**Given** the `people` collection with computed `full_name`
+**When** `select` is run with `order_by full_name asc`
+**Then** the returned records are ordered by their computed `full_name`
+
+### AC: foreign-key-on-insert-violation (verifies REQ:foreign-key-support, REQ:reference-error-shape)
+
+**Given** a computed column `owner_key` declaring `foreign_key` to collection `users`, whose formula yields a key absent from `users`
+**When** a record is inserted into `things` whose input fields make `owner_key` resolve to that absent key
+**Then** the `insert` fails with a referential-integrity error in the reference-error shape — naming referencing collection `things`, the referencing record key, the `owner_key` column, and referenced collection `users`
+
+### AC: foreign-key-revalidates-on-input-change (verifies REQ:foreign-key-revalidate-on-input-change, REQ:reference-error-shape)
+
+**Given** a record whose computed `owner_key` currently resolves to an existing `users` record
+**When** an `update` changes an input field of the formula so `owner_key` would resolve to a non-existent `users` record
+**Then** the `update` fails with a referential-integrity error in the reference-error shape, even though the `owner_key` column was not directly written
+
+### AC: foreign-key-parent-delete-detected (verifies REQ:foreign-key-parent-side, REQ:reference-error-shape)
+
+**Given** a `users` record referenced by some `things` record's computed `owner_key`
+**When** that `users` record is deleted
+**Then** the delete fails with a referential-integrity error in the reference-error shape — naming referencing collection `things`, the referencing record key, the `owner_key` column, and referenced collection `users`
+
+### AC: foreign-key-parent-rename-detected (verifies REQ:foreign-key-parent-side, REQ:reference-error-shape)
+
+**Given** a `users` record referenced by some `things` record's computed `owner_key`
+**When** that `users` record's key is renamed, so the old key no longer exists
+**Then** the rename fails with a referential-integrity error in the reference-error shape — naming referencing collection `things`, the referencing record key, the `owner_key` column, and referenced collection `users`
+
+### AC: builtin-string-helper-available (verifies REQ:builtin-helpers)
+
+**Given** a `string` column `display` with `formula: 'first_name.strip().upper()'` and a record with `first_name: " ada "`
+**When** the record is read
+**Then** the returned `display` equals `"ADA"`
+
+### AC: builtin-math-helper-available (verifies REQ:builtin-helpers)
+
+**Given** an `int` column `rounded` with `formula: 'round(score)'` and a record with `score: 4.6`
+**When** the record is read
+**Then** the returned `rounded` equals integer `5`
+
+## Rehearse Integration
+
+Every AC is testable through a concrete surface — CLI `select`/`insert` output,
+`validate` errors, or pure-function formula evaluation — so one Rehearse Scenario
+stub per AC is scaffolded under `_tests/`, each carrying a `## TODO` checklist for its
+pending state. The foreign-key ACs depend on the referential-integrity engine.
+
+## Open Questions
+
+- The initial helper set (REQ:builtin-helpers) covers common string and numeric
+  needs; which further helpers (e.g. date parsing, formatting) graduate from
+  "nice-to-have" to required will be driven by real formulas in use.
+- Temporal (`date`/`time`/`datetime`) and `map[locale]string` types are intentionally
+  rejected for computed columns in this Feature (see REQ:coerce-to-type). A future
+  Feature adding them must decide which representation a formula returns.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/features/computed-columns/_recap/229d97e.md
+++ b/spec/features/computed-columns/_recap/229d97e.md
@@ -1,0 +1,320 @@
+```yaml
+feature: computed-columns
+revision: 229d97e
+verify_revision: 48eb004
+drift:
+  - ac: computed-columns#ac:formula-declared-and-computed
+    verdict: no-drift
+    narrative: "ApplyFormulasToRead evaluates the formula and coerces to string, wired into Get/Query read sites; tests assert full_name == 'Ada Lovelace'."
+  - ac: computed-columns#ac:formula-syntax-error
+    verdict: no-drift
+    narrative: "validateComputedColumn parses via ParseExpr during schema validation; 'first_name +' fails naming collection (v.ID) and full_name column."
+  - ac: computed-columns#ac:reject-stored-computed-value
+    verdict: no-drift
+    narrative: "Both write path (validateNoStoredComputedValues) and datavalidator reject a supplied value for a computed column, naming collection, record key, and column."
+  - ac: computed-columns#ac:reject-chained-computed-reference
+    verdict: no-drift
+    narrative: "validateComputedColumn rejects a formula referencing a computed sibling with the exact spec-named error 'a formula may reference only stored fields'."
+  - ac: computed-columns#ac:deterministic-evaluation
+    verdict: no-drift
+    narrative: "EvaluateFormula is a stateless Starlark eval with no time/random/math module, no load() loader, no-op Print; determinism and sandbox tests pass."
+  - ac: computed-columns#ac:type-coercion-success
+    verdict: no-drift
+    narrative: "coerceFormulaResult coerces qty*price to ColumnTypeInt int64(12); TestApplyFormulasToRead_IntTotal encodes the AC literally and passes."
+  - ac: computed-columns#ac:unsupported-type-rejected
+    verdict: no-drift
+    narrative: "computedColumnTypes excludes datetime; a datetime computed column fails Validate() with an 'unsupported type' error; test covers it."
+  - ac: computed-columns#ac:runtime-error-fails-read
+    verdict: no-drift
+    narrative: "ApplyFormulasToRead returns nil map + error naming collection/record/column on divide-by-zero; error returned before MapToData so no partial row."
+  - ac: computed-columns#ac:filter-on-computed-column
+    verdict: no-drift
+    narrative: "tx_query.go evaluates computed columns before WHERE; the select test filters full_name == 'Ada Lovelace' and returns only the match."
+  - ac: computed-columns#ac:order-by-computed-column
+    verdict: no-drift
+    narrative: "Computed columns evaluated on read before ORDER BY; test seeds keys out of order and asserts ascending sort by the computed value."
+  - ac: computed-columns#ac:foreign-key-on-insert-violation
+    verdict: no-drift
+    narrative: "Insert calls validateComputedWriteForeignKeys; an absent derived owner_key yields a reference-error-shape violation naming things, record, owner_key, users."
+  - ac: computed-columns#ac:foreign-key-revalidates-on-input-change
+    verdict: no-drift
+    narrative: "Update/UpdateRecord re-derive owner_key from changed input fields and validate against users on every write; computed column never written; tests green."
+  - ac: computed-columns#ac:foreign-key-parent-delete-detected
+    verdict: no-drift
+    narrative: "Delete gates removal via validateDeleteComputedForeignKeys, recomputing child computed FKs and blocking with an error naming things, record, owner_key, users."
+  - ac: computed-columns#ac:foreign-key-parent-rename-detected
+    verdict: no-drift
+    narrative: "Driver models rename as old-key removal (Delete); the delete-side scan blocks it with all four reference-error identifiers — a faithful interpretation."
+  - ac: computed-columns#ac:builtin-string-helper-available
+    verdict: no-drift
+    narrative: "EvaluateFormula binds string fields as native starlark.String; first_name.strip().upper() on ' ada ' yields 'ADA'; exact test passes."
+  - ac: computed-columns#ac:builtin-math-helper-available
+    verdict: no-drift
+    narrative: "Bare round builtin (math.Round + NumberToInt) → starlark.Int → int64(5); read path coerceFormulaResult(ColumnTypeInt) returns integer 5."
+```
+
+# Recap Report — computed-columns @ 229d97e
+
+Drift analysis of all 16 acceptance criteria against the delivered code, compared to verify report `48eb004.md`. **All 16: no-drift.** 0 spec-tighter, 0 code-tighter, 0 contradiction, 0 unmapped, 0 errored.
+
+## AC: formula-declared-and-computed
+
+**Drift verdict:** no-drift
+
+**Narrative:** `ApplyFormulasToRead` evaluates `first_name + " " + last_name`, coerces to string, and is wired into Get/Query read sites; tests assert `full_name == "Ada Lovelace"`, exactly matching the AC.
+
+**Verify verdict:** pass
+
+**Verify justification:** ApplyFormulasToRead evaluates the formula on read, coerces to string; read-path test asserts full_name == "Ada Lovelace".
+
+**Commits:**
+- bdaa495 — feat(dalgo2ingitdb): compute computed columns on read with coercion
+
+**Evidence:**
+- pkg/dalgo2ingitdb/formula.go, formula_read_test.go
+- pkg/dalgo2ingitdb/query.go, tx_readonly.go (read-site wiring)
+
+## AC: formula-syntax-error
+
+**Drift verdict:** no-drift
+
+**Narrative:** `validateComputedColumn` parses the formula via Starlark `ParseExpr` during schema validation; `first_name +` fails naming the collection (`v.ID`) and the `full_name` column.
+
+**Verify verdict:** pass
+
+**Verify justification:** validateComputedColumn parses via Starlark ParseExpr; 'first_name +' fails naming collection and column.
+
+**Commits:**
+- bae1c4b — feat(ingitdb): add formula attribute and computed-column validation
+
+**Evidence:**
+- pkg/ingitdb/column_formula.go, collection_def.go, column_formula_test.go
+
+## AC: reject-stored-computed-value
+
+**Drift verdict:** no-drift
+
+**Narrative:** Both the write path (`validateNoStoredComputedValues` in Set/Insert) and the file-validation path (`datavalidator`) reject any supplied value for a computed column, each naming collection, record key, and column.
+
+**Verify verdict:** pass
+
+**Verify justification:** validateNoStoredComputedValues (Set/Insert) and datavalidator both reject a supplied computed value naming collection, record key, and column.
+
+**Commits:**
+- cb7252c — feat(dalgo2ingitdb): reject stored values for computed columns
+
+**Evidence:**
+- pkg/dalgo2ingitdb/computed_columns.go, tx_readwrite.go
+- pkg/ingitdb/datavalidator/validator.go
+
+## AC: reject-chained-computed-reference
+
+**Drift verdict:** no-drift
+
+**Narrative:** `validateComputedColumn` (called during schema validation) rejects a formula referencing a computed sibling with the exact spec-named error "a formula may reference only stored fields".
+
+**Verify verdict:** pass
+
+**Verify justification:** validateComputedColumn rejects formulas referencing a computed sibling with "a formula may reference only stored fields".
+
+**Commits:**
+- bae1c4b — feat(ingitdb): add formula attribute and computed-column validation
+
+**Evidence:**
+- pkg/ingitdb/column_formula.go, collection_def.go
+
+## AC: deterministic-evaluation
+
+**Drift verdict:** no-drift
+
+**Narrative:** `EvaluateFormula` is a stateless Starlark eval with no time/random/math module, no `load()` loader, and a no-op `Print`; determinism (evaluate-twice) and sandbox (time/random/open/load all error) tests pass.
+
+**Verify verdict:** pass
+
+**Verify justification:** EvaluateFormula is a pure Starlark sandbox (no loader, no-op print, no time/random/math/open); determinism and sandbox tests pass.
+
+**Commits:**
+- a863490 — feat(ingitdb): add sandboxed deterministic formula evaluator
+
+**Evidence:**
+- pkg/ingitdb/column_formula_eval.go, column_formula_eval_test.go
+
+## AC: type-coercion-success
+
+**Drift verdict:** no-drift
+
+**Narrative:** `coerceFormulaResult` coerces `qty * price` to `ColumnTypeInt` → `int64(12)`; `TestApplyFormulasToRead_IntTotal` encodes the AC literally and passes.
+
+**Verify verdict:** pass
+
+**Verify justification:** coerceFormulaResult maps qty*price to ColumnTypeInt int64(12); test matches the AC.
+
+**Commits:**
+- bdaa495 — feat(dalgo2ingitdb): compute computed columns on read with coercion
+
+**Evidence:**
+- pkg/dalgo2ingitdb/formula.go, formula_test.go
+
+## AC: unsupported-type-rejected
+
+**Drift verdict:** no-drift
+
+**Narrative:** `computedColumnTypes` excludes `datetime`; a `datetime` computed column fails `Validate()` with an "unsupported type" error; a test covers it.
+
+**Verify verdict:** pass
+
+**Verify justification:** validateComputedColumn rejects datetime (type not in {string,int,float,bool,any}).
+
+**Commits:**
+- bae1c4b — feat(ingitdb): add formula attribute and computed-column validation
+
+**Evidence:**
+- pkg/ingitdb/column_formula.go, column_type.go, column_formula_test.go
+
+## AC: runtime-error-fails-read
+
+**Drift verdict:** no-drift
+
+**Narrative:** `ApplyFormulasToRead` returns a nil map plus an error naming collection/record/column on a divide-by-zero; the error is returned before `MapToData`, so no partial row is emitted.
+
+**Verify verdict:** pass
+
+**Verify justification:** ApplyFormulasToRead returns nil map + error naming collection/record/column on divide-by-zero; no partial row.
+
+**Commits:**
+- bdaa495 — feat(dalgo2ingitdb): compute computed columns on read with coercion
+
+**Evidence:**
+- pkg/dalgo2ingitdb/formula.go, tx_readonly.go, query.go, formula_read_test.go
+
+## AC: filter-on-computed-column
+
+**Drift verdict:** no-drift
+
+**Narrative:** `tx_query.go` evaluates computed columns (`ApplyFormulasToRead`) before applying WHERE; the select test filters `full_name == "Ada Lovelace"` and returns only the match.
+
+**Verify verdict:** pass
+
+**Verify justification:** tx_query.go evaluates computed columns before WHERE; test returns only the matching computed full_name.
+
+**Commits:**
+- 28860cf — fix(dalgo2fsingitdb): evaluate computed columns in the CLI read path
+
+**Evidence:**
+- pkg/dalgo2fsingitdb/tx_query.go
+- cmd/ingitdb/commands/select_computed_test.go
+
+## AC: order-by-computed-column
+
+**Drift verdict:** no-drift
+
+**Narrative:** Computed columns are evaluated on read before ORDER BY; the test seeds record keys out of `full_name` order and asserts ascending sort by the computed value.
+
+**Verify verdict:** pass
+
+**Verify justification:** computed columns evaluated before ORDER BY; test seeds keys out of order and asserts sort by computed value.
+
+**Commits:**
+- 28860cf — fix(dalgo2fsingitdb): evaluate computed columns in the CLI read path
+
+**Evidence:**
+- pkg/dalgo2fsingitdb/tx_query.go
+- cmd/ingitdb/commands/select_computed_test.go
+
+## AC: foreign-key-on-insert-violation
+
+**Drift verdict:** no-drift
+
+**Narrative:** `Insert` calls `validateComputedWriteForeignKeys`; an absent derived `owner_key` yields a reference-error-shape violation naming `things`, record key, `owner_key`, and `users`.
+
+**Verify verdict:** pass
+
+**Verify justification:** validateComputedWriteForeignKeys (Insert) blocks an absent derived key with reference-error-shape error naming things, record, owner_key, users.
+
+**Commits:**
+- 7d8c89e — feat(dalgo2ingitdb): enforce foreign keys for computed columns on write
+
+**Evidence:**
+- pkg/dalgo2ingitdb/foreign_keys.go, tx_readwrite.go, computed_foreign_keys_test.go
+
+## AC: foreign-key-revalidates-on-input-change
+
+**Drift verdict:** no-drift
+
+**Narrative:** `Update`/`UpdateRecord` re-derive `owner_key` from changed input fields and validate against `users` on every write; computed columns are stripped before the backing `Set`, so `owner_key` is never written; tests green at HEAD.
+
+**Verify verdict:** pass
+
+**Verify justification:** Computed FK re-validated on every write (Set backs update; Update/UpdateRecord also wired); input change to a missing parent fails without owner_key written.
+
+**Commits:**
+- 7d8c89e — feat(dalgo2ingitdb): enforce foreign keys for computed columns on write
+
+**Evidence:**
+- pkg/dalgo2ingitdb/tx_readwrite.go (Update/UpdateRecord), foreign_keys.go, computed_foreign_keys_test.go
+
+## AC: foreign-key-parent-delete-detected
+
+**Drift verdict:** no-drift
+
+**Narrative:** `Delete` gates removal via `validateDeleteComputedForeignKeys`, which recomputes child computed FKs and blocks with an error naming child collection `things`, child record key, `owner_key`, and parent `users`.
+
+**Verify verdict:** pass
+
+**Verify justification:** validateDeleteComputedForeignKeys (Delete) scans/recomputes child computed FKs and blocks naming things, record, owner_key, users.
+
+**Commits:**
+- e43cdff — feat(dalgo2ingitdb): enforce parent-side FKs for computed columns
+
+**Evidence:**
+- pkg/dalgo2ingitdb/foreign_keys.go, tx_readwrite.go, computed_foreign_keys_test.go
+
+## AC: foreign-key-parent-rename-detected
+
+**Drift verdict:** no-drift
+
+**Narrative:** The driver models a key rename as removal of the old key (a Delete); the delete-side computed-FK scan blocks it with all four reference-error identifiers — a faithful interpretation of "the old key no longer exists". Verified by the rename test.
+
+**Verify verdict:** pass
+
+**Verify justification:** Rename manifests as old-key removal; the delete-side computed-FK scan blocks it with the reference-error shape.
+
+**Commits:**
+- e43cdff — feat(dalgo2ingitdb): enforce parent-side FKs for computed columns
+
+**Evidence:**
+- pkg/dalgo2ingitdb/foreign_keys.go, tx_readwrite.go
+- pkg/dalgo2ingitdb/computed_foreign_keys_test.go (TestReadwriteTx_RenameReferencedByComputedForeignKeyFails)
+
+## AC: builtin-string-helper-available
+
+**Drift verdict:** no-drift
+
+**Narrative:** `EvaluateFormula` binds string fields as native `starlark.String`, exposing `.strip()`/`.upper()`; `first_name.strip().upper()` on `" ada "` yields `"ADA"`; an exact test passes at HEAD.
+
+**Verify verdict:** pass
+
+**Verify justification:** EvaluateFormula binds string fields exposing native Starlark methods; strip().upper() on " ada " yields "ADA".
+
+**Commits:**
+- a863490 — feat(ingitdb): add sandboxed deterministic formula evaluator
+
+**Evidence:**
+- pkg/ingitdb/column_formula_eval.go, column_formula_eval_test.go
+
+## AC: builtin-math-helper-available
+
+**Drift verdict:** no-drift
+
+**Narrative:** The bare `round` builtin (`math.Round` + `NumberToInt`) yields a `starlark.Int` → Go `int64(5)`; the read path `coerceFormulaResult(ColumnTypeInt)` returns integer `5`.
+
+**Verify verdict:** pass
+
+**Verify justification:** Bare round builtin (floatUnaryToInt + math.Round) yields int64(5) for round(4.6).
+
+**Commits:**
+- a863490 — feat(ingitdb): add sandboxed deterministic formula evaluator
+
+**Evidence:**
+- pkg/ingitdb/column_formula_eval.go (formulaRound/floatUnaryToInt, starlarkToGo)
+- pkg/dalgo2ingitdb/formula.go (coerceFormulaResult on read)

--- a/spec/features/computed-columns/_recap/README.md
+++ b/spec/features/computed-columns/_recap/README.md
@@ -1,0 +1,16 @@
+# Recap Reports — computed-columns
+
+Per-run recap reports produced by `specstudio:recap`. Each report is named `<sha>.md` where `<sha>` is the abbreviated git SHA of `HEAD` at run time. Each row records which verify report the recap was compared against (`Verify revision`) so reviewers can trace the drift gate end-to-end.
+
+## Contents
+
+| Report | Run revision | Verify revision | Drift summary |
+|---|---|---|---|
+| [229d97e.md](229d97e.md) | 229d97e | 48eb004 | 16 no-drift, 0 spec-tighter, 0 code-tighter, 0 contradiction, 0 unmapped, 0 errored |
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/index-specification*

--- a/spec/features/computed-columns/_tests/README.md
+++ b/spec/features/computed-columns/_tests/README.md
@@ -1,0 +1,36 @@
+# Rehearse Scenarios: Computed Columns
+
+**Status:** Draft
+**Date:** 2026-06-02
+**Owner:** alexander.trakhimenok@gmail.com
+
+Pending Rehearse Scenario stubs for the [computed-columns](../README.md) Feature.
+One stub per acceptance criterion; each carries a `## TODO` checklist until wired up.
+
+## Contents
+
+| Scenario | Verifies REQ |
+|----------|--------------|
+| [formula-declared-and-computed](declare-formula-formula-declared-and-computed.md) | declare-formula, evaluate-on-read |
+| [formula-syntax-error](declare-formula-formula-syntax-error.md) | declare-formula |
+| [reject-stored-computed-value](reject-stored-value-reject-stored-computed-value.md) | reject-stored-value |
+| [reject-chained-computed-reference](stored-fields-only-reject-chained-computed-reference.md) | stored-fields-only |
+| [deterministic-evaluation](sandboxed-deterministic-deterministic-evaluation.md) | sandboxed-deterministic |
+| [type-coercion-success](coerce-to-type-type-coercion-success.md) | coerce-to-type |
+| [unsupported-type-rejected](coerce-to-type-unsupported-type-rejected.md) | coerce-to-type |
+| [runtime-error-fails-read](fail-loud-runtime-error-fails-read.md) | fail-loud |
+| [filter-on-computed-column](usable-in-filter-and-sort-filter-on-computed-column.md) | usable-in-filter-and-sort |
+| [order-by-computed-column](usable-in-filter-and-sort-order-by-computed-column.md) | usable-in-filter-and-sort |
+| [foreign-key-on-insert-violation](foreign-key-support-foreign-key-on-insert-violation.md) | foreign-key-support |
+| [foreign-key-revalidates-on-input-change](foreign-key-revalidate-on-input-change-foreign-key-revalidates-on-input-change.md) | foreign-key-revalidate-on-input-change |
+| [foreign-key-parent-delete-detected](foreign-key-parent-side-foreign-key-parent-delete-detected.md) | foreign-key-parent-side |
+| [foreign-key-parent-rename-detected](foreign-key-parent-side-foreign-key-parent-rename-detected.md) | foreign-key-parent-side |
+| [builtin-string-helper-available](builtin-helpers-builtin-string-helper-available.md) | builtin-helpers |
+| [builtin-math-helper-available](builtin-helpers-builtin-math-helper-available.md) | builtin-helpers |
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/scenarios-index-specification*

--- a/spec/features/computed-columns/_tests/builtin-helpers-builtin-math-helper-available.md
+++ b/spec/features/computed-columns/_tests/builtin-helpers-builtin-math-helper-available.md
@@ -1,0 +1,22 @@
+# Scenario: builtin-math-helper-available
+
+**Validates:** [computed-columns#req:builtin-helpers](../README.md#req-builtin-helpers)
+
+## Steps
+
+GIVEN an int column rounded with formula 'round(score)' and a record with score 4.6
+WHEN the record is read
+THEN rounded equals integer 5
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/builtin-helpers-builtin-string-helper-available.md
+++ b/spec/features/computed-columns/_tests/builtin-helpers-builtin-string-helper-available.md
@@ -1,0 +1,22 @@
+# Scenario: builtin-string-helper-available
+
+**Validates:** [computed-columns#req:builtin-helpers](../README.md#req-builtin-helpers)
+
+## Steps
+
+GIVEN a string column display with formula 'first_name.strip().upper()' and a record with first_name ' ada '
+WHEN the record is read
+THEN display equals "ADA"
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/coerce-to-type-type-coercion-success.md
+++ b/spec/features/computed-columns/_tests/coerce-to-type-type-coercion-success.md
@@ -1,0 +1,22 @@
+# Scenario: type-coercion-success
+
+**Validates:** [computed-columns#req:coerce-to-type](../README.md#req-coerce-to-type)
+
+## Steps
+
+GIVEN an int column total with formula 'qty * price' and a record with qty 3 and price 4
+WHEN the record is read
+THEN total equals integer 12
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/coerce-to-type-unsupported-type-rejected.md
+++ b/spec/features/computed-columns/_tests/coerce-to-type-unsupported-type-rejected.md
@@ -1,0 +1,22 @@
+# Scenario: unsupported-type-rejected
+
+**Validates:** [computed-columns#req:coerce-to-type](../README.md#req-coerce-to-type)
+
+## Steps
+
+GIVEN a computed column declared with type datetime
+WHEN the schema is loaded or validated
+THEN validation fails because computed columns support only string, int, float, bool, and any
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/declare-formula-formula-declared-and-computed.md
+++ b/spec/features/computed-columns/_tests/declare-formula-formula-declared-and-computed.md
@@ -1,0 +1,22 @@
+# Scenario: formula-declared-and-computed
+
+**Validates:** [computed-columns#req:declare-formula](../README.md#req-declare-formula)
+
+## Steps
+
+GIVEN a people collection with a string column full_name and formula 'first_name + " " + last_name'
+WHEN a record with first_name Ada and last_name Lovelace is read via select
+THEN the returned full_name equals "Ada Lovelace"
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/declare-formula-formula-syntax-error.md
+++ b/spec/features/computed-columns/_tests/declare-formula-formula-syntax-error.md
@@ -1,0 +1,22 @@
+# Scenario: formula-syntax-error
+
+**Validates:** [computed-columns#req:declare-formula](../README.md#req-declare-formula)
+
+## Steps
+
+GIVEN a column declaring formula 'first_name +' which is not a complete Starlark expression
+WHEN the schema is loaded or validated
+THEN validation fails naming the collection and the full_name column
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/fail-loud-runtime-error-fails-read.md
+++ b/spec/features/computed-columns/_tests/fail-loud-runtime-error-fails-read.md
@@ -1,0 +1,22 @@
+# Scenario: runtime-error-fails-read
+
+**Validates:** [computed-columns#req:fail-loud](../README.md#req-fail-loud)
+
+## Steps
+
+GIVEN a computed int column whose formula divides by a field that is zero for some record
+WHEN that record is read
+THEN the read aborts naming the collection, record key, and column, and no partial row is emitted
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/foreign-key-parent-side-foreign-key-parent-delete-detected.md
+++ b/spec/features/computed-columns/_tests/foreign-key-parent-side-foreign-key-parent-delete-detected.md
@@ -1,0 +1,22 @@
+# Scenario: foreign-key-parent-delete-detected
+
+**Validates:** [computed-columns#req:foreign-key-parent-side](../README.md#req-foreign-key-parent-side)
+
+## Steps
+
+GIVEN a users record referenced by some record's computed owner_key
+WHEN that users record is deleted
+THEN the delete fails with a referential-integrity error naming the referencing collection, referencing record key, and owner_key column
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/foreign-key-parent-side-foreign-key-parent-rename-detected.md
+++ b/spec/features/computed-columns/_tests/foreign-key-parent-side-foreign-key-parent-rename-detected.md
@@ -1,0 +1,22 @@
+# Scenario: foreign-key-parent-rename-detected
+
+**Validates:** [computed-columns#req:foreign-key-parent-side](../README.md#req-foreign-key-parent-side)
+
+## Steps
+
+GIVEN a users record referenced by some things record's computed owner_key
+WHEN that users record's key is renamed so the old key no longer exists
+THEN the rename fails with a referential-integrity error in the reference-error shape naming things, the referencing key, owner_key, and users
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/foreign-key-revalidate-on-input-change-foreign-key-revalidates-on-input-change.md
+++ b/spec/features/computed-columns/_tests/foreign-key-revalidate-on-input-change-foreign-key-revalidates-on-input-change.md
@@ -1,0 +1,22 @@
+# Scenario: foreign-key-revalidates-on-input-change
+
+**Validates:** [computed-columns#req:foreign-key-revalidate-on-input-change](../README.md#req-foreign-key-revalidate-on-input-change)
+
+## Steps
+
+GIVEN a record whose computed owner_key currently resolves to an existing users record
+WHEN an update changes an input field so owner_key would resolve to a non-existent users record
+THEN the update fails with a referential-integrity error even though owner_key was not directly written
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/foreign-key-support-foreign-key-on-insert-violation.md
+++ b/spec/features/computed-columns/_tests/foreign-key-support-foreign-key-on-insert-violation.md
@@ -1,0 +1,22 @@
+# Scenario: foreign-key-on-insert-violation
+
+**Validates:** [computed-columns#req:foreign-key-support](../README.md#req-foreign-key-support)
+
+## Steps
+
+GIVEN a computed column owner_key with foreign_key to users whose formula yields a key absent from users
+WHEN a record is inserted whose input fields make owner_key resolve to that absent key
+THEN the insert fails with a referential-integrity error naming the record key and owner_key column
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/reject-stored-value-reject-stored-computed-value.md
+++ b/spec/features/computed-columns/_tests/reject-stored-value-reject-stored-computed-value.md
@@ -1,0 +1,22 @@
+# Scenario: reject-stored-computed-value
+
+**Validates:** [computed-columns#req:reject-stored-value](../README.md#req-reject-stored-value)
+
+## Steps
+
+GIVEN a computed column full_name
+WHEN an insert or a record file under validation supplies a full_name value
+THEN the operation fails naming the collection, record key, and full_name column
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/sandboxed-deterministic-deterministic-evaluation.md
+++ b/spec/features/computed-columns/_tests/sandboxed-deterministic-deterministic-evaluation.md
@@ -1,0 +1,22 @@
+# Scenario: deterministic-evaluation
+
+**Validates:** [computed-columns#req:sandboxed-deterministic](../README.md#req-sandboxed-deterministic)
+
+## Steps
+
+GIVEN any record and a computed column
+WHEN the formula is evaluated twice for the same input
+THEN both evaluations return byte-identical output and no network, filesystem, clock, or randomness is reachable
+
+## Detected Surface
+
+pure-function
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/stored-fields-only-reject-chained-computed-reference.md
+++ b/spec/features/computed-columns/_tests/stored-fields-only-reject-chained-computed-reference.md
@@ -1,0 +1,22 @@
+# Scenario: reject-chained-computed-reference
+
+**Validates:** [computed-columns#req:stored-fields-only](../README.md#req-stored-fields-only)
+
+## Steps
+
+GIVEN a computed column greeting whose formula references another computed column full_name
+WHEN the schema is loaded or validated
+THEN validation fails stating a formula may reference only stored fields
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/usable-in-filter-and-sort-filter-on-computed-column.md
+++ b/spec/features/computed-columns/_tests/usable-in-filter-and-sort-filter-on-computed-column.md
@@ -1,0 +1,22 @@
+# Scenario: filter-on-computed-column
+
+**Validates:** [computed-columns#req:usable-in-filter-and-sort](../README.md#req-usable-in-filter-and-sort)
+
+## Steps
+
+GIVEN the people collection with computed full_name
+WHEN select is run with --where 'full_name == "Ada Lovelace"'
+THEN only records whose computed full_name equals "Ada Lovelace" are returned
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_tests/usable-in-filter-and-sort-order-by-computed-column.md
+++ b/spec/features/computed-columns/_tests/usable-in-filter-and-sort-order-by-computed-column.md
@@ -1,0 +1,22 @@
+# Scenario: order-by-computed-column
+
+**Validates:** [computed-columns#req:usable-in-filter-and-sort](../README.md#req-usable-in-filter-and-sort)
+
+## Steps
+
+GIVEN the people collection with computed full_name
+WHEN select is run with order_by full_name asc
+THEN the returned records are ordered by their computed full_name
+
+## Detected Surface
+
+cli
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/computed-columns/_verify/48eb004.md
+++ b/spec/features/computed-columns/_verify/48eb004.md
@@ -1,0 +1,268 @@
+```yaml
+feature: computed-columns
+revision: 48eb004
+verdicts:
+  - ac: computed-columns#ac:formula-declared-and-computed
+    verdict: pass
+    justification: "ApplyFormulasToRead evaluates first_name + ' ' + last_name on read, coerces to string; read-path test asserts full_name == 'Ada Lovelace' and passes."
+  - ac: computed-columns#ac:formula-syntax-error
+    verdict: pass
+    justification: "validateComputedColumn parses via Starlark ParseExpr; 'first_name +' fails naming collection 'people' and column 'full_name'; test passes."
+  - ac: computed-columns#ac:reject-stored-computed-value
+    verdict: pass
+    justification: "validateNoStoredComputedValues (Set/Insert) and datavalidator both reject a supplied computed value naming collection, record key, and column; tests pass."
+  - ac: computed-columns#ac:reject-chained-computed-reference
+    verdict: pass
+    justification: "validateComputedColumn rejects formulas referencing a computed sibling with 'a formula may reference only stored fields'; test passes."
+  - ac: computed-columns#ac:deterministic-evaluation
+    verdict: pass
+    justification: "EvaluateFormula is a pure Starlark sandbox (no loader, no-op print, no time/random/math/open); determinism and sandbox tests pass."
+  - ac: computed-columns#ac:type-coercion-success
+    verdict: pass
+    justification: "coerceFormulaResult maps qty*price to ColumnTypeInt int64(12); TestApplyFormulasToRead_IntTotal matches the AC and passes."
+  - ac: computed-columns#ac:unsupported-type-rejected
+    verdict: pass
+    justification: "validateComputedColumn rejects datetime (type not in {string,int,float,bool,any}); ColumnTypeDateTime test passes."
+  - ac: computed-columns#ac:runtime-error-fails-read
+    verdict: pass
+    justification: "ApplyFormulasToRead returns nil map + error 'collection %q record %q column %q' on divide-by-zero; no partial row; tests pass."
+  - ac: computed-columns#ac:filter-on-computed-column
+    verdict: pass
+    justification: "tx_query.go evaluates computed columns before WHERE; TestSelect_SetMode_WhereOnComputedColumn returns only the matching computed full_name and passes."
+  - ac: computed-columns#ac:order-by-computed-column
+    verdict: pass
+    justification: "tx_query.go evaluates computed columns before ORDER BY; TestSelect_SetMode_OrderByComputedColumn (keys seeded out of order) asserts sort by computed value and passes."
+  - ac: computed-columns#ac:foreign-key-on-insert-violation
+    verdict: pass
+    justification: "validateComputedWriteForeignKeys (Insert) blocks an absent derived key with reference-error-shape error (things, record, owner_key, users); test passes."
+  - ac: computed-columns#ac:foreign-key-revalidates-on-input-change
+    verdict: pass
+    justification: "Computed FK re-validated on every write (Set backs update; Update/UpdateRecord also wired); input change to a missing parent fails without owner_key written; test passes."
+  - ac: computed-columns#ac:foreign-key-parent-delete-detected
+    verdict: pass
+    justification: "validateDeleteComputedForeignKeys (Delete) scans/recomputes child computed FKs and blocks naming things, record, owner_key, users; test passes."
+  - ac: computed-columns#ac:foreign-key-parent-rename-detected
+    verdict: pass
+    justification: "Rename manifests as old-key removal; the delete-side computed-FK scan blocks it with the reference-error shape; rename test passes."
+  - ac: computed-columns#ac:builtin-string-helper-available
+    verdict: pass
+    justification: "EvaluateFormula binds string fields exposing native Starlark methods; first_name.strip().upper() on ' ada ' yields 'ADA'; test passes."
+  - ac: computed-columns#ac:builtin-math-helper-available
+    verdict: pass
+    justification: "Bare round builtin (floatUnaryToInt + math.Round) yields int64(5) for round(4.6); test passes."
+```
+
+# Verify Report — computed-columns @ 48eb004
+
+All 16 acceptance criteria are mapped to `Verifies:`-trailed commits and verified **pass**. 0 failed, 0 unmapped, 0 errored.
+
+## AC: formula-declared-and-computed
+
+**Verdict:** pass
+
+**Justification:** `ApplyFormulasToRead` evaluates `first_name + " " + last_name` on read and coerces to string; the read-path test asserts `full_name == "Ada Lovelace"` for `first_name=Ada`, `last_name=Lovelace`.
+
+**Commits:**
+- bdaa495 — feat(dalgo2ingitdb): compute computed columns on read with coercion
+
+**Evidence:**
+- pkg/dalgo2ingitdb/formula.go (ApplyFormulasToRead + coerceFormulaResult)
+- pkg/dalgo2ingitdb/formula_read_test.go (asserts "Ada Lovelace")
+- pkg/ingitdb/column_formula_eval.go (EvaluateFormula)
+
+## AC: formula-syntax-error
+
+**Verdict:** pass
+
+**Justification:** `validateComputedColumn` parses the formula via Starlark `ParseExpr`; `first_name +` fails with an error naming collection `people` and column `full_name`. Wired into `CollectionDef.Validate()`.
+
+**Commits:**
+- bae1c4b — feat(ingitdb): add formula attribute and computed-column validation
+
+**Evidence:**
+- pkg/ingitdb/column_formula.go (ParseExpr error wraps collection + column)
+- pkg/ingitdb/column_formula_test.go (syntax-error case)
+
+## AC: reject-stored-computed-value
+
+**Verdict:** pass
+
+**Justification:** `validateNoStoredComputedValues` (Set/Insert) and the datavalidator path both reject a record that supplies a value for a computed column, naming collection, record key, and column.
+
+**Commits:**
+- cb7252c — feat(dalgo2ingitdb): reject stored values for computed columns
+
+**Evidence:**
+- pkg/dalgo2ingitdb/computed_columns.go, tx_readwrite.go
+- pkg/ingitdb/datavalidator/validator.go (ValidationError with collection/record/field)
+
+## AC: reject-chained-computed-reference
+
+**Verdict:** pass
+
+**Justification:** `validateComputedColumn` walks the parsed formula and rejects any identifier naming a computed sibling, with "a formula may reference only stored fields".
+
+**Commits:**
+- bae1c4b — feat(ingitdb): add formula attribute and computed-column validation
+
+**Evidence:**
+- pkg/ingitdb/column_formula.go (refErr message)
+- pkg/ingitdb/column_formula_test.go (greeting → full_name case)
+
+## AC: deterministic-evaluation
+
+**Verdict:** pass
+
+**Justification:** `EvaluateFormula` is a pure Starlark sandbox — no `load()` loader, no-op `print`, no `time`/`random`/`math`/`open` exposed. Determinism (evaluate-twice DeepEqual) and sandbox (time/random/open/load all error) tests pass.
+
+**Commits:**
+- a863490 — feat(ingitdb): add sandboxed deterministic formula evaluator
+
+**Evidence:**
+- pkg/ingitdb/column_formula_eval.go
+- pkg/ingitdb/column_formula_eval_test.go (TestEvaluateFormulaDeterministic, TestEvaluateFormulaSandbox)
+
+## AC: type-coercion-success
+
+**Verdict:** pass
+
+**Justification:** `coerceFormulaResult` coerces `qty * price` to `ColumnTypeInt` → `int64(12)`; `TestApplyFormulasToRead_IntTotal` matches the AC exactly.
+
+**Commits:**
+- bdaa495 — feat(dalgo2ingitdb): compute computed columns on read with coercion
+
+**Evidence:**
+- pkg/dalgo2ingitdb/formula.go (coerceFormulaResult → int64)
+- pkg/dalgo2ingitdb/formula_test.go (TestApplyFormulasToRead_IntTotal)
+
+## AC: unsupported-type-rejected
+
+**Verdict:** pass
+
+**Justification:** `validateComputedColumn` rejects a computed column declared `datetime` (not in `{string,int,float,bool,any}`).
+
+**Commits:**
+- bae1c4b — feat(ingitdb): add formula attribute and computed-column validation
+
+**Evidence:**
+- pkg/ingitdb/column_formula.go (computedColumnTypes + slices.Contains)
+- pkg/ingitdb/column_formula_test.go (unsupported_type_datetime case)
+
+## AC: runtime-error-fails-read
+
+**Verdict:** pass
+
+**Justification:** On a divide-by-zero eval error, `ApplyFormulasToRead` returns a nil map and an error naming collection, record key, and column — no partial row.
+
+**Commits:**
+- bdaa495 — feat(dalgo2ingitdb): compute computed columns on read with coercion
+
+**Evidence:**
+- pkg/dalgo2ingitdb/formula.go (wrapped error, nil map)
+- pkg/dalgo2ingitdb/formula_read_test.go, formula_test.go (runtime-error cases)
+
+## AC: filter-on-computed-column
+
+**Verdict:** pass
+
+**Justification:** `tx_query.go` (`dalgo2fsingitdb`) evaluates computed columns before WHERE; the select test returns only records whose computed `full_name == "Ada Lovelace"`.
+
+**Commits:**
+- 28860cf — fix(dalgo2fsingitdb): evaluate computed columns in the CLI read path
+
+**Evidence:**
+- pkg/dalgo2fsingitdb/tx_query.go (ApplyFormulasToRead in both read funcs)
+- cmd/ingitdb/commands/select_computed_test.go (TestSelect_SetMode_WhereOnComputedColumn)
+
+## AC: order-by-computed-column
+
+**Verdict:** pass
+
+**Justification:** Computed columns are evaluated before ORDER BY; the order-by test seeds record keys out of `full_name` order and asserts the result is sorted by the computed value.
+
+**Commits:**
+- 28860cf — fix(dalgo2fsingitdb): evaluate computed columns in the CLI read path
+
+**Evidence:**
+- pkg/dalgo2fsingitdb/tx_query.go
+- cmd/ingitdb/commands/select_computed_test.go (TestSelect_SetMode_OrderByComputedColumn)
+
+## AC: foreign-key-on-insert-violation
+
+**Verdict:** pass
+
+**Justification:** `validateComputedWriteForeignKeys` (Insert) evaluates the computed FK and blocks an absent derived key with a reference-error-shape error naming `things`, record key, `owner_key`, `users`.
+
+**Commits:**
+- 7d8c89e — feat(dalgo2ingitdb): enforce foreign keys for computed columns on write
+
+**Evidence:**
+- pkg/dalgo2ingitdb/foreign_keys.go (validateComputedWriteForeignKeys)
+- pkg/dalgo2ingitdb/tx_readwrite.go (Insert wiring)
+- pkg/dalgo2ingitdb/computed_foreign_keys_test.go
+
+## AC: foreign-key-revalidates-on-input-change
+
+**Verdict:** pass
+
+**Justification:** The computed FK is re-validated on every write (Set backs update; Update/UpdateRecord also wired). An update to an input field that makes the derived key resolve to a missing parent fails, even though `owner_key` is never written.
+
+**Commits:**
+- 7d8c89e — feat(dalgo2ingitdb): enforce foreign keys for computed columns on write
+
+**Evidence:**
+- pkg/dalgo2ingitdb/foreign_keys.go, tx_readwrite.go (Set/Update/UpdateRecord)
+- pkg/dalgo2ingitdb/computed_foreign_keys_test.go (Update input-change case)
+
+## AC: foreign-key-parent-delete-detected
+
+**Verdict:** pass
+
+**Justification:** `validateDeleteComputedForeignKeys` (Delete) scans child collections with a computed FK, recomputes each formula, and blocks the delete naming `things`, record key, `owner_key`, `users`.
+
+**Commits:**
+- e43cdff — feat(dalgo2ingitdb): enforce parent-side FKs for computed columns
+
+**Evidence:**
+- pkg/dalgo2ingitdb/foreign_keys.go (validateDeleteComputedForeignKeys)
+- pkg/dalgo2ingitdb/tx_readwrite.go (Delete wiring)
+- pkg/dalgo2ingitdb/computed_foreign_keys_test.go
+
+## AC: foreign-key-parent-rename-detected
+
+**Verdict:** pass
+
+**Justification:** A key rename manifests as removal of the old key; the same delete-side computed-FK scan blocks it with the reference-error shape. The rename test asserts the block.
+
+**Commits:**
+- e43cdff — feat(dalgo2ingitdb): enforce parent-side FKs for computed columns
+
+**Evidence:**
+- pkg/dalgo2ingitdb/foreign_keys.go (validateDeleteComputedForeignKeys)
+- pkg/dalgo2ingitdb/computed_foreign_keys_test.go (TestReadwriteTx_RenameReferencedByComputedForeignKeyFails)
+
+## AC: builtin-string-helper-available
+
+**Verdict:** pass
+
+**Justification:** `EvaluateFormula` binds string fields exposing native Starlark string methods; `first_name.strip().upper()` on `" ada "` yields `"ADA"`.
+
+**Commits:**
+- a863490 — feat(ingitdb): add sandboxed deterministic formula evaluator
+
+**Evidence:**
+- pkg/ingitdb/column_formula_eval.go
+- pkg/ingitdb/column_formula_eval_test.go (string-helper AC case)
+
+## AC: builtin-math-helper-available
+
+**Verdict:** pass
+
+**Justification:** The bare `round` builtin (`floatUnaryToInt` + `math.Round` → Starlark Int → Go `int64`) yields `int64(5)` for `round(4.6)`.
+
+**Commits:**
+- a863490 — feat(ingitdb): add sandboxed deterministic formula evaluator
+
+**Evidence:**
+- pkg/ingitdb/column_formula_eval.go (formulaRound/floatUnaryToInt)
+- pkg/ingitdb/column_formula_eval_test.go (round(score) case)

--- a/spec/features/computed-columns/_verify/README.md
+++ b/spec/features/computed-columns/_verify/README.md
@@ -1,0 +1,16 @@
+# Verify Reports — computed-columns
+
+Per-run verify reports produced by `specstudio:verify`. Each report is named `<sha>.md` where `<sha>` is the abbreviated git SHA of `HEAD` at run time.
+
+## Contents
+
+| Report | Run revision | Verdict summary |
+|---|---|---|
+| [48eb004.md](48eb004.md) | 48eb004 | 16 passed, 0 failed, 0 unmapped, 0 errored |
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/index-specification*

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -18,6 +18,7 @@ Use `specscore idea new <slug>` to scaffold a new idea.
 | [derived-record-keys](derived-record-keys.md) | Approved | 2026-05-30 | alexander.trakhimenok@gmail.com | — |
 | [list-of-records-files](list-of-records-files.md) | Approved | 2026-05-29 | alexander.trakhimenok@gmail.com | — |
 | [markdown-insert-ux](markdown-insert-ux.md) | Draft | 2026-05-12 | alexander.trakhimenok@gmail.com | — |
+| [scripted-formulas-and-views](scripted-formulas-and-views.md) | Implementing | 2026-06-02 | alexander.trakhimenok@gmail.com | computed-columns |
 | [where-like-regex](where-like-regex.md) | Draft | 2026-05-12 | alexander.trakhimenok@gmail.com | — |
 
 ## Open Questions

--- a/spec/ideas/scripted-formulas-and-views.md
+++ b/spec/ideas/scripted-formulas-and-views.md
@@ -1,0 +1,70 @@
+# Idea: Scripted Computed Fields & Materialized Views (Starlark)
+
+**Status:** Implementing
+**Date:** 2026-06-02
+**Owner:** alexander.trakhimenok@gmail.com
+**Promotes To:** computed-columns
+**Supersedes:** —
+**Related Ideas:** —
+
+## Problem Statement
+
+How might we let schema authors compute field values (and later whole materialized views) from record data using one sandboxed, deterministic, Python-like scripting language, without breaking git reproducibility or inventing a bespoke expression grammar?
+
+## Context
+
+Triggered by a request to let users script materialized views and field formulas in an open-source, Go-embeddable, Python-like language. Today views are purely declarative (Columns, OrderBy, Top; Where is a stub) and ColumnDef has no computed-field concept; go.mod has no scripting engine. The Approved derived-record-keys Idea deliberately chose declarative transforms over arbitrary code, so introducing scripting is a real philosophical fork this Idea must justify: scripting is added only where declarative config runs out of room. Related: where-like-regex (the unimplemented Where predicate).
+
+## Recommended Direction
+
+Adopt Starlark (google/starlark-go) as the single embedded language, exposed in two modes, and ship formula mode first. Each mode lives in the file that already owns its concept: a formula is an optional attribute on a `ColumnDef` inside the collection's `.collection/definition.yaml`, holding one inline Starlark expression, evaluated per record with the record's sibling fields bound as variables, producing that column's value. Inline is the default and the only MVP shape; large or shared formulas getting their own reusable file is a deliberate future extension (see Not Doing). The sandbox is strict and deterministic by default: no network, filesystem, clock, or randomness, so the same record plus the same schema always yields the same output and git diffs stay truthful. Computed columns are derived output, not source-of-truth stored in record files. Phase 2 reuses the exact same language for view mode, honoring the existing one-file-per-view convention: a scripted view's definition file under the schema's `views/` directory (the view ID derives from its filename, as today) references a sibling `.star` Starlark script file that receives the collection's records and emits view rows — enabling grouping and aggregation the declarative view cannot express. Keeping the script in its own `.star` file gives proper syntax highlighting and clean, reviewable diffs rather than a YAML-embedded heredoc. One language, one sandbox, one security review, and a seamless formula-to-view upgrade path.
+
+## Alternatives Considered
+
+**Two engines — expr/CEL for formulas, Starlark for views.** Each tool is optimally shaped for its job (a pure terminating evaluator per record; an imperative language for view aggregation). Lost because it doubles the surface: two syntaxes across the schema (C-style ternary in a column's `definition.yaml` formula, Python-style in the per-view script file), two sandboxes to audit, two dependencies, two docs sets — and it breaks the original "one Python-like language" promise, since CEL and expr are C-flavored, not Python-like. A formula that outgrows expressions then faces a cross-language migration cliff.
+
+**Expression-only (CEL or expr), never adopt full scripting.** Safest and fastest for per-record formulas. Lost because it cannot express the imperative grouping/aggregation that view scripting needs; the original request explicitly wants *scripts* for views, so this caps the vision short.
+
+**Extend declarative transforms (the derived-record-keys DSL) to formulas.** Stays inside the project's existing declarative philosophy. Lost because formulas need conditionals, string ops, and arithmetic; a config-only DSL runs out of room immediately and ends up reinventing an expression language badly.
+
+**Go plugins / hooks (arbitrary compiled Go).** Maximum power. Lost on every axis that matters here: not sandboxable, not deterministic, not portable across machines, and a security non-starter for a git-shared schema.
+
+## MVP Scope
+
+A two-to-three-week spike: a `formula` attribute on a `ColumnDef` (in the collection's `.collection/definition.yaml`) accepts a single inline Starlark expression, evaluated per record in a strict no-IO sandbox with sibling fields bound as variables, output coerced to the column's declared type (loud failure on mismatch), and the computed value surfaced in select/view output. No view scripting, no cross-collection reads, no aggregation. Verify determinism by evaluating the same input twice and asserting byte-identical output.
+
+## Not Doing (and Why)
+
+- View-scripting mode now — deferred to Phase 2; field formulas are the wedge that proves the engine and sandbox
+- Cross-collection reads or joins in formulas — keeps the sandbox tight and per-record evaluation cheap; revisit for view mode
+- Storing computed values as source-of-truth in record files — computed columns are derived output only, to avoid git drift
+- Two-engine approach (expr/CEL for formulas + Starlark for views) — rejected for one Python-like syntax, one sandbox, and no migration cliff
+- Non-deterministic builtins (clock, random, network, filesystem) — banned by the determinism guarantee that keeps materialization reproducible
+- External/shared reusable formula files now — MVP formulas are inline. A future extension can let large or complex formulas live in a separate, reusable file shared across columns, via either a `script: <path>` reference or mutually exclusive `formula` | `script` fields on the `ColumnDef`
+
+## Key Assumptions to Validate
+
+| Tier | Assumption | How to validate |
+|------|------------|-----------------|
+| Must-be-true | `google/starlark-go` can evaluate a single expression with the record's fields bound as globals, in a sandbox with no network/filesystem/clock/random, deterministically | Spike: evaluate a fixed expression over a fixed record twice; assert byte-identical output and confirm no I/O builtins are reachable |
+| Must-be-true | Computed values can be coerced into inGitDB's declared column types reliably, failing loud on mismatch instead of silently corrupting output | Build a coercion test matrix (string/int/float/bool) including mismatch cases; assert clear errors |
+| Should-be-true | Schema authors find a single Starlark expression natural enough to prefer over more declarative config | Show 3–5 real formulas (full_name, conditional price, formatted label) to target authors and observe friction |
+| Should-be-true | Per-record evaluation is fast enough on realistic collection sizes that materialization stays acceptable | Benchmark formula evaluation across N records (e.g. 1k/10k/100k) and compare to current materialization cost |
+| Might-be-true | The same engine and sandbox extend cleanly to Phase-2 view-scripting mode without a redesign | Prototype a minimal view script reusing the formula-mode runtime; confirm the API generalizes |
+
+
+## SpecScore Integration
+
+- **New Features this would create:** a computed-fields (formula mode) Feature for the MVP; a later scripted-views Feature for Phase 2
+- **Existing Features affected:** record-format and output-formats (select must surface computed columns); shared-cli-flags (whether computed columns are usable in `--where`/`order_by`); view materialization (Phase 2)
+- **Dependencies:** new module dependency `google/starlark-go`; relates to the where-like-regex Idea (the unimplemented `Where` predicate) and the Approved derived-record-keys Idea (the declarative-vs-code precedent this Idea consciously diverges from)
+
+## Open Questions
+
+- Compute-on-read vs materialize-and-store: are computed values produced fresh on every select/materialize (leaning yes, to avoid git drift), or cached anywhere?
+- Are computed columns allowed to participate in `--where`, `order_by`, or as foreign keys — or are they output-only?
+- How are evaluation errors surfaced — fail the whole read/materialization, or null the offending cell with a warning?
+- Does formula mode bind only sibling fields, or also a small curated stdlib (string/number helpers) — and which builtins are explicitly disabled to preserve determinism?
+
+---
+*This document follows the https://specscore.md/idea-specification*

--- a/spec/ideas/seeds/specify-computed-columns-and-materialized-view-scripts-in.md
+++ b/spec/ideas/seeds/specify-computed-columns-and-materialized-view-scripts-in.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: specify-computed-columns-and-materialized-view-scripts-in
+captured_at: 2026-06-02T07:42:06Z
+captured_by: specstudio:implement
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Specify computed columns and materialized-view scripts in the inGitDB standard repo as a language-agnostic Idea so Go and TypeScript implementations share one standard
+
+Create after the Go computed-columns implementation in ingitdb-cli completes — it becomes the reference implementation. The standard repo (../ingitdb) is not yet specscore-initialized, so bootstrap specscore.yaml + spec/ideas/ first. Scope mirrors the ingitdb-cli Feature: computed columns (inline formulas) now, materialized-view scripts as Phase 2.

--- a/spec/ideas/seeds/wire-write-time-validations-foreign-keys-and-reject-stored.md
+++ b/spec/ideas/seeds/wire-write-time-validations-foreign-keys-and-reject-stored.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: wire-write-time-validations-foreign-keys-and-reject-stored
+captured_at: 2026-06-02T08:46:12Z
+captured_by: specstudio:implement
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Wire write-time validations (foreign keys and reject-stored-computed-values) into the CLI dalgo2fsingitdb read-write path so inserts and updates enforce them, not just the dalgo2ingitdb DALgo layer
+
+The CLI builds its DB via dalgo2fsingitdb.NewLocalDBWithDef (cmd/ingitdb/main.go), whose readwriteTx.Set/Insert/Update/Delete perform no validation. So write-time foreign-key enforcement and computed-value rejection currently run only at the dalgo2ingitdb layer (and the validate command via datavalidator), not on CLI inserts/updates. This is a pre-existing limitation that also affects the shipped dalgo2ingitdb-referential-integrity feature. Consider extracting the write validations into shared functions callable from both dalgo2ingitdb and dalgo2fsingitdb (and dalgo2ghingitdb), or have the fs/gh write txns delegate.

--- a/spec/plans/computed-columns.md
+++ b/spec/plans/computed-columns.md
@@ -101,7 +101,7 @@ computed foreign-key column is never written directly.
 
 ### Task 7: Parent-side foreign-key enforcement (delete and rename)
 
-**Status:** pending
+**Status:** done
 **Verifies:** computed-columns#ac:foreign-key-parent-delete-detected, computed-columns#ac:foreign-key-parent-rename-detected
 
 When a referenced record is deleted or its key renamed, scan the referencing

--- a/spec/plans/computed-columns.md
+++ b/spec/plans/computed-columns.md
@@ -49,7 +49,7 @@ rejected as a stored-fields-only violation.
 
 ### Task 2: Sandboxed deterministic evaluator and builtin helpers
 
-**Status:** pending
+**Status:** done
 **Verifies:** computed-columns#ac:deterministic-evaluation, computed-columns#ac:builtin-string-helper-available, computed-columns#ac:builtin-math-helper-available
 
 Build the formula evaluation function: evaluate a parsed Starlark expression with the

--- a/spec/plans/computed-columns.md
+++ b/spec/plans/computed-columns.md
@@ -61,7 +61,7 @@ non-deterministic or I/O-capable builtin or module is reachable.
 
 ### Task 3: Compute-on-read integration, type coercion, and fail-loud errors
 
-**Status:** pending
+**Status:** done
 **Verifies:** computed-columns#ac:formula-declared-and-computed, computed-columns#ac:type-coercion-success, computed-columns#ac:runtime-error-fails-read
 
 Invoke the evaluator in the read path alongside `ApplyLocaleToRead` so every read

--- a/spec/plans/computed-columns.md
+++ b/spec/plans/computed-columns.md
@@ -89,7 +89,7 @@ do; close any gap where filtering/sorting reads pre-evaluation record state.
 
 ### Task 6: Write-time foreign-key enforcement for computed columns (child side)
 
-**Status:** pending
+**Status:** done
 **Verifies:** computed-columns#ac:foreign-key-on-insert-violation, computed-columns#ac:foreign-key-revalidates-on-input-change
 
 Extend the existing write-time referential-integrity path: on `insert`/`update`,

--- a/spec/plans/computed-columns.md
+++ b/spec/plans/computed-columns.md
@@ -1,6 +1,6 @@
 # Plan: Computed Columns (Inline Starlark Formulas)
 
-**Status:** Approved
+**Status:** Implementing
 **Source Feature:** computed-columns
 **Date:** 2026-06-02
 **Owner:** alexander.trakhimenok@gmail.com
@@ -37,6 +37,7 @@ bar applies to all seven tasks.
 
 ### Task 1: Add `formula` attribute and load-time validation
 
+**Status:** done
 **Verifies:** computed-columns#ac:formula-syntax-error, computed-columns#ac:unsupported-type-rejected, computed-columns#ac:reject-chained-computed-reference
 
 Add a `formula` string field to `ColumnDef` and extend schema validation: the formula
@@ -48,6 +49,7 @@ rejected as a stored-fields-only violation.
 
 ### Task 2: Sandboxed deterministic evaluator and builtin helpers
 
+**Status:** pending
 **Verifies:** computed-columns#ac:deterministic-evaluation, computed-columns#ac:builtin-string-helper-available, computed-columns#ac:builtin-math-helper-available
 
 Build the formula evaluation function: evaluate a parsed Starlark expression with the
@@ -59,6 +61,7 @@ non-deterministic or I/O-capable builtin or module is reachable.
 
 ### Task 3: Compute-on-read integration, type coercion, and fail-loud errors
 
+**Status:** pending
 **Verifies:** computed-columns#ac:formula-declared-and-computed, computed-columns#ac:type-coercion-success, computed-columns#ac:runtime-error-fails-read
 
 Invoke the evaluator in the read path alongside `ApplyLocaleToRead` so every read
@@ -68,6 +71,7 @@ collection, record key, column, and cause — no partial row, no silent null.
 
 ### Task 4: Reject stored values for computed columns
 
+**Status:** pending
 **Verifies:** computed-columns#ac:reject-stored-computed-value
 
 On `insert`/`update` and during file validation, reject any record that supplies a
@@ -76,6 +80,7 @@ column. The computed value remains the sole source of truth.
 
 ### Task 5: Computed columns usable in `--where` and `order_by`
 
+**Status:** pending
 **Verifies:** computed-columns#ac:filter-on-computed-column, computed-columns#ac:order-by-computed-column
 
 Confirm and test that, because evaluation precedes query operations, computed columns
@@ -84,6 +89,7 @@ do; close any gap where filtering/sorting reads pre-evaluation record state.
 
 ### Task 6: Write-time foreign-key enforcement for computed columns (child side)
 
+**Status:** pending
 **Verifies:** computed-columns#ac:foreign-key-on-insert-violation, computed-columns#ac:foreign-key-revalidates-on-input-change
 
 Extend the existing write-time referential-integrity path: on `insert`/`update`,
@@ -95,6 +101,7 @@ computed foreign-key column is never written directly.
 
 ### Task 7: Parent-side foreign-key enforcement (delete and rename)
 
+**Status:** pending
 **Verifies:** computed-columns#ac:foreign-key-parent-delete-detected, computed-columns#ac:foreign-key-parent-rename-detected
 
 When a referenced record is deleted or its key renamed, scan the referencing

--- a/spec/plans/computed-columns.md
+++ b/spec/plans/computed-columns.md
@@ -1,0 +1,110 @@
+# Plan: Computed Columns (Inline Starlark Formulas)
+
+**Status:** Approved
+**Source Feature:** computed-columns
+**Date:** 2026-06-02
+**Owner:** alexander.trakhimenok@gmail.com
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `computed-columns` Feature into seven linear tasks that build the
+inline-Starlark formula capability bottom-up: schema and validation first, then the
+sandboxed evaluator, then read-time integration, and finally query and foreign-key
+integration. All 16 acceptance criteria are covered; none are deferred.
+
+## Approach
+
+Tasks follow the natural dependency chain in the codebase. Task 1 introduces the
+`formula` attribute and all static (load-time) validation. Task 2 builds the
+evaluation engine and its deterministic helper set in isolation so it can be unit
+tested without the read path. Task 3 wires evaluation into the existing
+`ApplyLocaleToRead` read stage, adding coercion and fail-loud behavior. Task 4 guards
+the write/validate path against stored values. Task 5 confirms computed columns flow
+through `--where`/`order_by` (which work for free once evaluation precedes query ops,
+but need their own tests). Tasks 6 and 7 extend the existing write-time
+referential-integrity engine to computed foreign keys — child side first, then the
+parent-side delete/rename scan. ACs are grouped by the unit of implementation work,
+never split into AC-wrapper tasks.
+
+**Testing standard (every task).** No task is complete until the code it introduces
+has 100% test coverage, verified with `go test -coverprofile`. Tests must exercise the
+task's acceptance criteria plus every error path and branch in the new code; any line
+that is genuinely unreachable must be refactored away rather than left uncovered. This
+bar applies to all seven tasks.
+
+## Tasks
+
+### Task 1: Add `formula` attribute and load-time validation
+
+**Verifies:** computed-columns#ac:formula-syntax-error, computed-columns#ac:unsupported-type-rejected, computed-columns#ac:reject-chained-computed-reference
+
+Add a `formula` string field to `ColumnDef` and extend schema validation: the formula
+must parse as a single Starlark expression (introduces the `google/starlark-go`
+dependency), a statement body or parse error is a validation error naming collection
+and column, a computed column declared with a type outside `{string, int, float,
+bool, any}` is rejected, and a formula that references another computed column is
+rejected as a stored-fields-only violation.
+
+### Task 2: Sandboxed deterministic evaluator and builtin helpers
+
+**Verifies:** computed-columns#ac:deterministic-evaluation, computed-columns#ac:builtin-string-helper-available, computed-columns#ac:builtin-math-helper-available
+
+Build the formula evaluation function: evaluate a parsed Starlark expression with the
+record's stored fields bound as variables, in a sandbox exposing no network,
+filesystem, clock, or randomness, guaranteeing identical output for identical input.
+Expose the curated deterministic helper set — native Starlark string methods,
+`len`/`min`/`max`, and numeric `abs`/`round`/`floor`/`ceil` — and confirm no
+non-deterministic or I/O-capable builtin or module is reachable.
+
+### Task 3: Compute-on-read integration, type coercion, and fail-loud errors
+
+**Verifies:** computed-columns#ac:formula-declared-and-computed, computed-columns#ac:type-coercion-success, computed-columns#ac:runtime-error-fails-read
+
+Invoke the evaluator in the read path alongside `ApplyLocaleToRead` so every read
+record gains its computed column values, coerced to the declared `ColumnType`. A
+runtime error or a result that cannot coerce aborts the read with an error naming
+collection, record key, column, and cause — no partial row, no silent null.
+
+### Task 4: Reject stored values for computed columns
+
+**Verifies:** computed-columns#ac:reject-stored-computed-value
+
+On `insert`/`update` and during file validation, reject any record that supplies a
+value for a computed column, with an error naming the collection, record key, and
+column. The computed value remains the sole source of truth.
+
+### Task 5: Computed columns usable in `--where` and `order_by`
+
+**Verifies:** computed-columns#ac:filter-on-computed-column, computed-columns#ac:order-by-computed-column
+
+Confirm and test that, because evaluation precedes query operations, computed columns
+filter under `--where` predicates and sort under `order_by` exactly as stored columns
+do; close any gap where filtering/sorting reads pre-evaluation record state.
+
+### Task 6: Write-time foreign-key enforcement for computed columns (child side)
+
+**Verifies:** computed-columns#ac:foreign-key-on-insert-violation, computed-columns#ac:foreign-key-revalidates-on-input-change
+
+Extend the existing write-time referential-integrity path: on `insert`/`update`,
+evaluate a computed `foreign_key` column from the payload and validate the derived
+value against the referenced collection, raising a referential-integrity error in the
+reference-error shape (referencing collection, record key, computed column, referenced
+collection). Re-run the check for every computed foreign key on every update, since a
+computed foreign-key column is never written directly.
+
+### Task 7: Parent-side foreign-key enforcement (delete and rename)
+
+**Verifies:** computed-columns#ac:foreign-key-parent-delete-detected, computed-columns#ac:foreign-key-parent-rename-detected
+
+When a referenced record is deleted or its key renamed, scan the referencing
+collection and recompute each computed foreign key (full scan, no index) to find
+records that resolve to the affected key, blocking the operation with a
+referential-integrity error in the reference-error shape.
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/computed-columns.md
+++ b/spec/plans/computed-columns.md
@@ -80,7 +80,7 @@ column. The computed value remains the sole source of truth.
 
 ### Task 5: Computed columns usable in `--where` and `order_by`
 
-**Status:** pending
+**Status:** done
 **Verifies:** computed-columns#ac:filter-on-computed-column, computed-columns#ac:order-by-computed-column
 
 Confirm and test that, because evaluation precedes query operations, computed columns

--- a/spec/plans/computed-columns.md
+++ b/spec/plans/computed-columns.md
@@ -1,6 +1,6 @@
 # Plan: Computed Columns (Inline Starlark Formulas)
 
-**Status:** Implementing
+**Status:** Completed
 **Source Feature:** computed-columns
 **Date:** 2026-06-02
 **Owner:** alexander.trakhimenok@gmail.com

--- a/spec/plans/computed-columns.md
+++ b/spec/plans/computed-columns.md
@@ -71,7 +71,7 @@ collection, record key, column, and cause — no partial row, no silent null.
 
 ### Task 4: Reject stored values for computed columns
 
-**Status:** pending
+**Status:** done
 **Verifies:** computed-columns#ac:reject-stored-computed-value
 
 On `insert`/`update` and during file validation, reject any record that supplies a

--- a/spec/plans/dalgo2ingitdb-referential-integrity.md
+++ b/spec/plans/dalgo2ingitdb-referential-integrity.md
@@ -49,7 +49,7 @@ Define the empty-value boundary for FK validation so missing, nil, and empty-str
 
 Before deleting a parent record, scan collections with FK columns that reference the parent collection. Fail deletes that have at least one matching child reference with an error that identifies the parent and blocking child record, and preserve existing delete behavior when no child reference matches.
 
-## Outstanding Questions
+## Open Questions
 
 - Should the implementation introduce exported sentinel errors for FK failures now, or keep them as deterministic wrapped errors until callers need type assertions?
 


### PR DESCRIPTION
## Summary

Adds **computed columns** to inGitDB: a `ColumnDef` may declare an inline
[Starlark](https://github.com/google/starlark-go) `formula` whose value is
derived from the record's other stored fields. Built end-to-end through the
SpecScore pipeline (idea → specify → plan → implement → verify → recap → review).

- **Schema:** `formula` on `ColumnDef`; validated at load (single Starlark
  expression, supported types `string`/`int`/`float`/`bool`/`any`, may reference
  only stored sibling fields).
- **Evaluation:** sandboxed, deterministic (no network/filesystem/clock/random,
  no `load()`), curated helpers (native string methods, `len`/`min`/`max`,
  `abs`/`round`/`floor`/`ceil`). Execution-step-bounded and compiled-program-cached.
- **Read:** computed on read (`ApplyFormulasToRead`) in both DALgo read paths;
  coerced to the declared type; fail-loud on errors. Usable in `--where`/`order_by`.
- **Write:** computed columns are never stored — supplying a value is rejected on
  insert/update and during file validation.
- **Foreign keys:** a computed column may declare `foreign_key`; enforced on the
  write-time referential-integrity path (insert/update/delete/rename), child- and
  parent-side, with a consistent reference-error shape.

## Verification

- **16/16 acceptance criteria** verified `pass` and `no-drift` — see
  `spec/features/computed-columns/_verify/` and `_recap/`.
- `go build ./...`, `go test ./...`, `golangci-lint run ./...`, `specscore spec lint` all clean.
- 100% test coverage on all new code.
- Every implementation commit carries a `Verifies:` trailer mapping to its AC(s).

## Follow-ups (captured as sidekick seeds, not in this PR)

- Wire write-time validations into the CLI `dalgo2fsingitdb` write path (the
  `dalgo2ingitdb` enforcement here matches the existing referential-integrity
  feature's layer; CLI-write enforcement is a separate cross-cutting change).
- Specify computed columns + materialized-view scripts in the `ingitdb` standard
  repo as a language-agnostic Idea (Go + TypeScript implementations share one spec).

## Not included

Phase-2 scripted materialized views (separate future Feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)