### PR TITLE
fix: enforce write-time integrity on the CLI write path (dalgo2fsingitdb)

### DIFF
--- a/pkg/dalgo2fsingitdb/tx_readwrite.go
+++ b/pkg/dalgo2fsingitdb/tx_readwrite.go
@@ -30,8 +30,11 @@ func (r readwriteTx) Set(ctx context.Context, record dal.Record) error {
 		return err
 	}
 	record.SetError(nil)
-	path := resolveRecordPath(colDef, recordKey)
 	data := record.Data().(map[string]any)
+	if err := dalgo2ingitdb.ValidateWrite(r.db.def, "Set", colDef.ID, colDef, recordKey, data); err != nil {
+		return err
+	}
+	path := resolveRecordPath(colDef, recordKey)
 	switch colDef.RecordFile.RecordType {
 	case ingitdb.MapOfRecords:
 		allRecords, _, err := readMapOfRecordsFile(path, colDef.RecordFile.Format)
@@ -60,6 +63,9 @@ func (r readwriteTx) Delete(ctx context.Context, key *dal.Key) error {
 	_ = ctx
 	colDef, recordKey, err := r.resolveCollection(key)
 	if err != nil {
+		return err
+	}
+	if err := dalgo2ingitdb.ValidateDelete(r.db.def, colDef.ID, recordKey); err != nil {
 		return err
 	}
 	path := resolveRecordPath(colDef, recordKey)
@@ -108,6 +114,11 @@ func (r readwriteTx) Insert(ctx context.Context, record dal.Record, opts ...dal.
 	if err != nil {
 		return err
 	}
+	record.SetError(nil)
+	data := record.Data().(map[string]any)
+	if err := dalgo2ingitdb.ValidateWrite(r.db.def, "Insert", colDef.ID, colDef, recordKey, data); err != nil {
+		return err
+	}
 	path := resolveRecordPath(colDef, recordKey)
 	switch colDef.RecordFile.RecordType {
 	case ingitdb.MapOfRecords:
@@ -121,8 +132,6 @@ func (r readwriteTx) Insert(ctx context.Context, record dal.Record, opts ...dal.
 		if _, exists := allRecords[recordKey]; exists {
 			return fmt.Errorf("record already exists: %s in %s", recordKey, path)
 		}
-		record.SetError(nil)
-		data := record.Data().(map[string]any)
 		allRecords[recordKey] = dalgo2ingitdb.ApplyLocaleToWrite(data, colDef.Columns)
 		return writeMapOfRecordsFile(path, colDef, allRecords)
 	default:
@@ -133,8 +142,6 @@ func (r readwriteTx) Insert(ctx context.Context, record dal.Record, opts ...dal.
 		if !errors.Is(statErr, os.ErrNotExist) {
 			return fmt.Errorf("failed to check file %s: %w", path, statErr)
 		}
-		record.SetError(nil)
-		data := record.Data().(map[string]any)
 		if colDef.RecordFile.Format == ingitdb.RecordFormatMarkdown {
 			return writeMarkdownRecord(path, colDef, data)
 		}

--- a/pkg/dalgo2fsingitdb/write_enforcement_test.go
+++ b/pkg/dalgo2fsingitdb/write_enforcement_test.go
@@ -1,0 +1,183 @@
+package dalgo2fsingitdb
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// makeFKTestDB builds a filesystem DB with a parent "users" collection and a
+// child "things" collection whose columns are supplied by the caller, so each
+// test can exercise stored foreign keys, computed foreign keys, or computed
+// columns in isolation.
+func makeFKTestDB(t *testing.T, childColumns map[string]*ingitdb.ColumnDef) dal.DB {
+	t.Helper()
+	dir := t.TempDir()
+	singleYAML := func() *ingitdb.RecordFileDef {
+		return &ingitdb.RecordFileDef{Name: "{key}.yaml", Format: "yaml", RecordType: ingitdb.SingleRecord}
+	}
+	def := &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"users": {
+				ID:         "users",
+				DirPath:    filepath.Join(dir, "users"),
+				RecordFile: singleYAML(),
+				Columns:    map[string]*ingitdb.ColumnDef{"name": {Type: ingitdb.ColumnTypeString}},
+			},
+			"things": {
+				ID:         "things",
+				DirPath:    filepath.Join(dir, "things"),
+				RecordFile: singleYAML(),
+				Columns:    childColumns,
+			},
+		},
+	}
+	db, err := NewLocalDBWithDef(dir, def)
+	if err != nil {
+		t.Fatalf("NewLocalDBWithDef: %v", err)
+	}
+	return db
+}
+
+func insertRecord(t *testing.T, db dal.DB, collection, key string, data map[string]any) error {
+	t.Helper()
+	return db.RunReadwriteTransaction(context.Background(), func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, dal.NewRecordWithData(dal.NewKeyWithID(collection, key), data))
+	})
+}
+
+func deleteRecord(t *testing.T, db dal.DB, collection, key string) error {
+	t.Helper()
+	return db.RunReadwriteTransaction(context.Background(), func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Delete(ctx, dal.NewKeyWithID(collection, key))
+	})
+}
+
+func requireErrContains(t *testing.T, err error, subs ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error containing %v, got nil", subs)
+	}
+	for _, sub := range subs {
+		if !strings.Contains(err.Error(), sub) {
+			t.Fatalf("error %q does not contain %q", err.Error(), sub)
+		}
+	}
+}
+
+var storedFKColumns = map[string]*ingitdb.ColumnDef{
+	"name":  {Type: ingitdb.ColumnTypeString},
+	"owner": {Type: ingitdb.ColumnTypeString, ForeignKey: "users"},
+}
+
+var computedFKColumns = map[string]*ingitdb.ColumnDef{
+	"owner_input": {Type: ingitdb.ColumnTypeString},
+	"owner_key":   {Type: ingitdb.ColumnTypeString, Formula: `"user-" + owner_input`, ForeignKey: "users"},
+}
+
+// --- Insert: stored foreign key -------------------------------------------------
+
+func TestFSInsert_StoredForeignKeyMissingParentFails(t *testing.T) {
+	t.Parallel()
+	db := makeFKTestDB(t, storedFKColumns)
+	err := insertRecord(t, db, "things", "thing-1", map[string]any{"name": "T", "owner": "user-absent"})
+	requireErrContains(t, err, "things", "owner", "users")
+}
+
+func TestFSInsert_StoredForeignKeyExistingParentSucceeds(t *testing.T) {
+	t.Parallel()
+	db := makeFKTestDB(t, storedFKColumns)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"name": "T", "owner": "user-1"}); err != nil {
+		t.Fatalf("insert thing with valid FK should succeed: %v", err)
+	}
+}
+
+// --- Insert: computed foreign key ----------------------------------------------
+
+func TestFSInsert_ComputedForeignKeyMissingParentFails(t *testing.T) {
+	t.Parallel()
+	db := makeFKTestDB(t, computedFKColumns)
+	err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "absent"})
+	requireErrContains(t, err, "things", "owner_key", "users")
+}
+
+func TestFSInsert_ComputedForeignKeyExistingParentSucceeds(t *testing.T) {
+	t.Parallel()
+	db := makeFKTestDB(t, computedFKColumns)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing whose computed owner_key resolves should succeed: %v", err)
+	}
+}
+
+// --- Insert: reject a supplied computed value -----------------------------------
+
+func TestFSInsert_RejectsStoredComputedValue(t *testing.T) {
+	t.Parallel()
+	db := makeFKTestDB(t, map[string]*ingitdb.ColumnDef{
+		"owner_input": {Type: ingitdb.ColumnTypeString},
+		"display":     {Type: ingitdb.ColumnTypeString, Formula: "owner_input"},
+	})
+	err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "x", "display": "hand-written"})
+	requireErrContains(t, err, "things", "display", "computed")
+}
+
+// --- Set: enforcement also applies ---------------------------------------------
+
+func TestFSSet_StoredForeignKeyMissingParentFails(t *testing.T) {
+	t.Parallel()
+	db := makeFKTestDB(t, storedFKColumns)
+	err := db.RunReadwriteTransaction(context.Background(), func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("things", "thing-1"), map[string]any{"name": "T", "owner": "user-absent"}))
+	})
+	requireErrContains(t, err, "things", "owner", "users")
+}
+
+// --- Delete: parent-side enforcement -------------------------------------------
+
+func TestFSDelete_StoredForeignKeyReferencedParentFails(t *testing.T) {
+	t.Parallel()
+	db := makeFKTestDB(t, storedFKColumns)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"name": "T", "owner": "user-1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+	err := deleteRecord(t, db, "users", "user-1")
+	requireErrContains(t, err, "things", "thing-1", "user-1")
+}
+
+func TestFSDelete_ComputedForeignKeyReferencedParentFails(t *testing.T) {
+	t.Parallel()
+	db := makeFKTestDB(t, computedFKColumns)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := insertRecord(t, db, "things", "thing-1", map[string]any{"owner_input": "1"}); err != nil {
+		t.Fatalf("insert thing: %v", err)
+	}
+	err := deleteRecord(t, db, "users", "user-1")
+	requireErrContains(t, err, "things", "thing-1", "owner_key", "user-1")
+}
+
+func TestFSDelete_UnreferencedParentSucceeds(t *testing.T) {
+	t.Parallel()
+	db := makeFKTestDB(t, storedFKColumns)
+	if err := insertRecord(t, db, "users", "user-1", map[string]any{"name": "Owner"}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := deleteRecord(t, db, "users", "user-1"); err != nil {
+		t.Fatalf("deleting an unreferenced parent should succeed: %v", err)
+	}
+}

--- a/pkg/dalgo2ingitdb/write_validation.go
+++ b/pkg/dalgo2ingitdb/write_validation.go
@@ -1,0 +1,43 @@
+package dalgo2ingitdb
+
+import "github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+
+// ValidateWrite enforces every write-time rule before a record is inserted or
+// set, against the on-disk state described by def:
+//
+//   - a computed column's value must not be supplied (it is derived, not stored),
+//   - every stored foreign key must resolve to an existing parent record, and
+//   - every computed foreign key, evaluated from the record's stored fields, must
+//     resolve to an existing parent record.
+//
+// operation labels the caller ("Insert" or "Set") for error messages.
+// collectionID and colDef identify the collection being written; recordKey and
+// data are the record's key and field values.
+//
+// This is the shared entry point for any DALgo driver's read-write transaction,
+// so enforcement is identical whether a record is written through the
+// concurrent-safe driver or the filesystem driver.
+func ValidateWrite(def *ingitdb.Definition, operation, collectionID string, colDef *ingitdb.CollectionDef, recordKey string, data map[string]any) error {
+	r := readwriteTx{readonlyTx: readonlyTx{def: def}}
+	if err := r.validateNoStoredComputedValues(collectionID, colDef, recordKey, data); err != nil {
+		return err
+	}
+	if err := r.validateWriteForeignKeys(operation, collectionID, colDef, data); err != nil {
+		return err
+	}
+	return r.validateComputedWriteForeignKeys(operation, collectionID, colDef, recordKey, data)
+}
+
+// ValidateDelete enforces parent-side referential integrity before a record is
+// removed (or its key renamed, which manifests as removal of the old key): no
+// stored or computed foreign key in any collection may still reference it.
+//
+// This is the shared entry point for any DALgo driver's delete path, so
+// enforcement is identical across drivers.
+func ValidateDelete(def *ingitdb.Definition, parentCollection, parentKey string) error {
+	r := readwriteTx{readonlyTx: readonlyTx{def: def}}
+	if err := r.validateDeleteForeignKeys(parentCollection, parentKey); err != nil {
+		return err
+	}
+	return r.validateDeleteComputedForeignKeys(parentCollection, parentKey)
+}


### PR DESCRIPTION
## Summary

The CLI writes through the `dalgo2fsingitdb` filesystem driver, whose
`Set`/`Insert`/`Delete` persisted records **without running any write-time
validation**. So CLI inserts/sets/deletes bypassed the integrity rules that the
`dalgo2ingitdb` driver enforces — for **both** the existing referential-integrity
feature and computed columns.

This was tracked as a sidekick during the computed-columns work; this PR closes it.

## Approach

Both drivers' `resolveRecordPath` are byte-identical (`filepath.Join(colDef.DirPath, …)`),
so `dalgo2ingitdb`'s validators read the same on-disk state `dalgo2fsingitdb` writes.

- Add two **shared, exported validators** to `dalgo2ingitdb`:
  - `ValidateWrite` — reject stored computed values; enforce stored foreign keys;
    enforce computed foreign keys.
  - `ValidateDelete` — parent-side stored and computed foreign-key scan.

  Both construct a `def`-only read-write tx and delegate to the **existing,
  unchanged** validators, so there is no change to the shipped FK logic.
- Call them from `dalgo2fsingitdb` `Set`, `Insert`, and `Delete`.

`Update`/`*Multi` in the fs driver remain `panic("implement me")` TODOs and are out
of scope (the CLI does not use them).

## Tests

Nine new enforcement tests against a real filesystem DB (parent `users` + child
`things`), covering stored-FK, computed-FK, and computed-value rejection on
insert/set/delete, plus the passing cases:

- insert/set with a stored or computed FK to a missing parent → rejected
- insert supplying a value for a computed column → rejected
- delete of a parent still referenced by a stored or computed FK → rejected
- valid insert and unreferenced delete → succeed

New code is 100% covered. Full module suite passes; `golangci-lint run ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)