### PR TITLE
feat: transaction message as commit message + --message CLI flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.18.2 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
-	github.com/dal-go/dalgo v0.44.2
+	github.com/dal-go/dalgo v0.45.0
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/strongo/random v0.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dal-go/dalgo v0.44.2 h1:+eJG5WTiGcy82jAgJrNzuDhlpyWISDfIAnMJ3l7G7wE=
-github.com/dal-go/dalgo v0.44.2/go.mod h1:HHMUuCMutAlYEblDTVws7jeZs56jvOCbOuxVs6I01tE=
+github.com/dal-go/dalgo v0.45.0 h1:1DfQwO1MnJg7wrL/RkU+aDJas/YQoSw0gUfBG7z2mek=
+github.com/dal-go/dalgo v0.45.0/go.mod h1:HHMUuCMutAlYEblDTVws7jeZs56jvOCbOuxVs6I01tE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/pkg/dalgo2ghingitdb/batching.go
+++ b/pkg/dalgo2ghingitdb/batching.go
@@ -68,9 +68,10 @@ func newBatchingGitHubDB(cfg Config, def *ingitdb.Definition, commitMessage stri
 // returns nil, all buffered changes are flushed to GitHub as one commit. If
 // f returns an error, no changes are committed (the remote is untouched).
 func (db *BatchingGitHubDB) RunReadwriteTransaction(ctx context.Context, f dal.RWTxWorker, options ...dal.TransactionOption) error {
-	_ = options
+	opts := dal.NewTransactionOptions(options...)
 	tx := &batchingTx{
 		readonlyTx:    readonlyTx{db: db.githubDB},
+		opts:          opts,
 		bufferedFiles: make(map[string]TreeChange),
 		workingMaps:   make(map[string]map[string]map[string]any),
 		mapColDefs:    make(map[string]*ingitdb.CollectionDef),
@@ -86,7 +87,14 @@ func (db *BatchingGitHubDB) RunReadwriteTransaction(ctx context.Context, f dal.R
 	if len(changes) == 0 {
 		return nil // nothing was buffered; no commit needed
 	}
-	_, err = db.writer.CommitChanges(ctx, db.commitMessage, changes)
+	// A transaction message (set via dal.TxWithMessage at start or
+	// tx.Options().SetMessage during execution) overrides the construction-time
+	// default commit message.
+	commitMessage := db.commitMessage
+	if msg := opts.Message(); msg != "" {
+		commitMessage = msg
+	}
+	_, err = db.writer.CommitChanges(ctx, commitMessage, changes)
 	return err
 }
 
@@ -108,6 +116,7 @@ var _ dal.DB = (*BatchingGitHubDB)(nil)
 // TreeChange.
 type batchingTx struct {
 	readonlyTx
+	opts          dal.TransactionOptions
 	bufferedFiles map[string]TreeChange
 	workingMaps   map[string]map[string]map[string]any
 	mapColDefs    map[string]*ingitdb.CollectionDef
@@ -115,6 +124,10 @@ type batchingTx struct {
 }
 
 var _ dal.ReadwriteTransaction = (*batchingTx)(nil)
+
+// Options returns the transaction options, so a worker can read or update the
+// commit message via tx.Options().Message() / SetMessage during execution.
+func (t *batchingTx) Options() dal.TransactionOptions { return t.opts }
 
 func (t *batchingTx) Set(ctx context.Context, record dal.Record) error {
 	colDef, recordKey, err := t.resolveCollection(record.Key())

--- a/pkg/dalgo2ghingitdb/commit_message_test.go
+++ b/pkg/dalgo2ghingitdb/commit_message_test.go
@@ -1,0 +1,120 @@
+package dalgo2ghingitdb
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// newCommitMessageCapturingServer returns an httptest server implementing the
+// minimal Git Data API surface used by a batching commit, plus a pointer that
+// receives the commit message sent to POST /git/commits.
+func newCommitMessageCapturingServer(t *testing.T, captured *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		switch {
+		case r.Method == "GET" && strings.Contains(path, "/git/ref/heads/main"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ref":    "refs/heads/main",
+				"object": map[string]any{"sha": "head-commit-sha", "type": "commit"},
+			})
+		case r.Method == "GET" && strings.Contains(path, "/git/commits/head-commit-sha"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sha":  "head-commit-sha",
+				"tree": map[string]any{"sha": "base-tree-sha"},
+			})
+		case r.Method == "POST" && strings.HasSuffix(path, "/git/trees"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"sha": "new-tree-sha"})
+		case r.Method == "POST" && strings.HasSuffix(path, "/git/commits"):
+			var body struct {
+				Message string `json:"message"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			*captured = body.Message
+			_ = json.NewEncoder(w).Encode(map[string]any{"sha": "new-commit-sha"})
+		case r.Method == "PATCH" && strings.Contains(path, "/git/refs/heads/main"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ref":    "refs/heads/main",
+				"object": map[string]any{"sha": "new-commit-sha"},
+			})
+		default:
+			http.Error(w, "unexpected request: "+r.Method+" "+path, http.StatusNotImplemented)
+		}
+	}))
+}
+
+func commitMessageTestDef() *ingitdb.Definition {
+	return &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"cities": {
+				ID:      "cities",
+				DirPath: "data/cities",
+				RecordFile: &ingitdb.RecordFileDef{
+					RecordType: ingitdb.SingleRecord,
+					Format:     ingitdb.RecordFormatYAML,
+					Name:       "{key}.yaml",
+				},
+			},
+		},
+	}
+}
+
+func runOneSetTx(t *testing.T, bdb *BatchingGitHubDB, options ...dal.TransactionOption) {
+	t.Helper()
+	err := bdb.RunReadwriteTransaction(context.Background(), func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("cities", "ie"), map[string]any{"region": "eu"}))
+	}, options...)
+	if err != nil {
+		t.Fatalf("RunReadwriteTransaction: %v", err)
+	}
+}
+
+// TestBatchingGitHubDB_TxMessageOverridesDefault verifies that a transaction
+// message (dal.TxWithMessage) is used as the commit message in place of the
+// construction-time default.
+func TestBatchingGitHubDB_TxMessageOverridesDefault(t *testing.T) {
+	var captured string
+	srv := newCommitMessageCapturingServer(t, &captured)
+	defer srv.Close()
+
+	cfg := Config{Owner: "owner", Repo: "repo", Ref: "main", APIBaseURL: srv.URL + "/"}
+	bdb, err := NewBatchingGitHubDB(cfg, commitMessageTestDef(), "default construction message")
+	if err != nil {
+		t.Fatalf("NewBatchingGitHubDB: %v", err)
+	}
+
+	runOneSetTx(t, bdb, dal.TxWithMessage("tx-level commit message"))
+
+	if captured != "tx-level commit message" {
+		t.Errorf("commit message: got %q, want %q", captured, "tx-level commit message")
+	}
+}
+
+// TestBatchingGitHubDB_NoTxMessageUsesDefault verifies the construction-time
+// default is used when the transaction sets no message.
+func TestBatchingGitHubDB_NoTxMessageUsesDefault(t *testing.T) {
+	var captured string
+	srv := newCommitMessageCapturingServer(t, &captured)
+	defer srv.Close()
+
+	cfg := Config{Owner: "owner", Repo: "repo", Ref: "main", APIBaseURL: srv.URL + "/"}
+	bdb, err := NewBatchingGitHubDB(cfg, commitMessageTestDef(), "default construction message")
+	if err != nil {
+		t.Fatalf("NewBatchingGitHubDB: %v", err)
+	}
+
+	runOneSetTx(t, bdb)
+
+	if captured != "default construction message" {
+		t.Errorf("commit message: got %q, want %q", captured, "default construction message")
+	}
+}

--- a/pkg/dalgo2ingitdb/commit_message_test.go
+++ b/pkg/dalgo2ingitdb/commit_message_test.go
@@ -1,0 +1,139 @@
+package dalgo2ingitdb_test
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+// gitInit initialises a git repo at dir with a usable identity so commits work
+// deterministically in CI (no global config, no GPG signing).
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		if out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+}
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func franceRecord() dal.Record {
+	return dal.NewRecordWithData(
+		dal.NewKeyWithID("countries", "france"),
+		map[string]any{"name": "France", "population": 67000000},
+	)
+}
+
+// TestRunReadwriteTransaction_CommitsWithMessage verifies that a read-write
+// transaction with a message commits exactly the files it wrote, using the
+// message as the commit subject, when the project is a git repository.
+func TestRunReadwriteTransaction_CommitsWithMessage(t *testing.T) {
+	ctx := context.Background()
+	db, root := setupSingleRecordDB(t)
+	gitInit(t, root)
+
+	const msg = "add France"
+	if err := db.RunReadwriteTransaction(ctx, func(_ context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Set(ctx, franceRecord())
+	}, dal.TxWithMessage(msg)); err != nil {
+		t.Fatalf("RunReadwriteTransaction: %v", err)
+	}
+
+	if got := git(t, root, "log", "-1", "--pretty=%s"); got != msg {
+		t.Errorf("commit subject: got %q, want %q", got, msg)
+	}
+	if n := git(t, root, "rev-list", "--count", "HEAD"); n != "1" {
+		t.Errorf("commit count: got %s, want 1", n)
+	}
+	// Only the written record file is committed; schema/registration files the
+	// harness created remain untracked.
+	files := git(t, root, "show", "--name-only", "--pretty=format:", "HEAD")
+	if !strings.Contains(files, "france") {
+		t.Errorf("committed files should include the france record, got:\n%s", files)
+	}
+	if strings.Contains(files, ".ingitdb") {
+		t.Errorf("schema/registration files must not be committed, got:\n%s", files)
+	}
+}
+
+// TestRunReadwriteTransaction_NoMessageNoCommit verifies that without a message
+// the transaction writes files but creates no commit (behaviour unchanged).
+func TestRunReadwriteTransaction_NoMessageNoCommit(t *testing.T) {
+	ctx := context.Background()
+	db, root := setupSingleRecordDB(t)
+	gitInit(t, root)
+	git(t, root, "commit", "--allow-empty", "-m", "init")
+
+	if err := db.RunReadwriteTransaction(ctx, func(_ context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Set(ctx, franceRecord())
+	}); err != nil {
+		t.Fatalf("RunReadwriteTransaction: %v", err)
+	}
+
+	if n := git(t, root, "rev-list", "--count", "HEAD"); n != "1" {
+		t.Errorf("no-message tx must not commit: commit count got %s, want 1", n)
+	}
+	// The record was still written (just left uncommitted in the working tree).
+	got := dal.NewRecordWithData(dal.NewKeyWithID("countries", "france"), map[string]any{})
+	if err := db.Get(ctx, got); err != nil {
+		t.Fatalf("record should still be written: %v", err)
+	}
+}
+
+// TestRunReadwriteTransaction_SetMessageDuringExecution verifies a message set
+// at runtime via tx.Options().SetMessage drives the commit.
+func TestRunReadwriteTransaction_SetMessageDuringExecution(t *testing.T) {
+	ctx := context.Background()
+	db, root := setupSingleRecordDB(t)
+	gitInit(t, root)
+
+	const msg = "set during execution"
+	if err := db.RunReadwriteTransaction(ctx, func(_ context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, franceRecord()); err != nil {
+			return err
+		}
+		tx.Options().SetMessage(msg)
+		return nil
+	}); err != nil {
+		t.Fatalf("RunReadwriteTransaction: %v", err)
+	}
+
+	if got := git(t, root, "log", "-1", "--pretty=%s"); got != msg {
+		t.Errorf("commit subject: got %q, want %q", got, msg)
+	}
+}
+
+// TestRunReadwriteTransaction_NonGitDirNoError verifies that a message in a
+// non-git directory is a no-op (file written, no error) rather than failing.
+func TestRunReadwriteTransaction_NonGitDirNoError(t *testing.T) {
+	ctx := context.Background()
+	db, _ := setupSingleRecordDB(t) // no gitInit: plain directory
+
+	if err := db.RunReadwriteTransaction(ctx, func(_ context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Set(ctx, franceRecord())
+	}, dal.TxWithMessage("no git here")); err != nil {
+		t.Fatalf("RunReadwriteTransaction in non-git dir should not error: %v", err)
+	}
+
+	got := dal.NewRecordWithData(dal.NewKeyWithID("countries", "france"), map[string]any{})
+	if err := db.Get(ctx, got); err != nil {
+		t.Fatalf("record should still be written: %v", err)
+	}
+}

--- a/pkg/dalgo2ingitdb/database.go
+++ b/pkg/dalgo2ingitdb/database.go
@@ -98,12 +98,13 @@ func (db *Database) loadDefinition() (*ingitdb.Definition, error) {
 // worker with a readonly transaction. The Definition is captured at the
 // start of the transaction; subsequent on-disk schema changes are not
 // observed within the transaction.
-func (db *Database) RunReadonlyTransaction(ctx context.Context, f dal.ROTxWorker, _ ...dal.TransactionOption) error {
+func (db *Database) RunReadonlyTransaction(ctx context.Context, f dal.ROTxWorker, options ...dal.TransactionOption) error {
 	def, err := db.loadDefinition()
 	if err != nil {
 		return err
 	}
-	return f(ctx, readonlyTx{db: db, def: def})
+	opts := dal.NewTransactionOptions(options...)
+	return f(ctx, readonlyTx{db: db, def: def, opts: opts})
 }
 
 // RunReadwriteTransaction loads the project Definition and invokes the
@@ -111,12 +112,31 @@ func (db *Database) RunReadonlyTransaction(ctx context.Context, f dal.ROTxWorker
 // atomicity across multiple file writes within a transaction; each
 // individual file write is locked exclusively, but a worker that fails
 // after writing some files leaves those writes in place.
-func (db *Database) RunReadwriteTransaction(ctx context.Context, f dal.RWTxWorker, _ ...dal.TransactionOption) error {
+func (db *Database) RunReadwriteTransaction(ctx context.Context, f dal.RWTxWorker, options ...dal.TransactionOption) error {
 	def, err := db.loadDefinition()
 	if err != nil {
 		return err
 	}
-	return f(ctx, readwriteTx{readonlyTx: readonlyTx{db: db, def: def}})
+	opts := dal.NewTransactionOptions(options...)
+	written := &[]string{}
+	tx := readwriteTx{
+		readonlyTx: readonlyTx{db: db, def: def, opts: opts},
+		written:    written,
+	}
+	if err = f(ctx, tx); err != nil {
+		return err
+	}
+	// Opt-in git commit: when the worker provided a transaction message (via
+	// dal.TxWithMessage at start or tx.Options().SetMessage during execution)
+	// and at least one record file was written, stage exactly those files and
+	// commit them with the message. With no message, behaviour is unchanged
+	// (files are left in the working tree, uncommitted).
+	if msg := opts.Message(); msg != "" && len(*written) > 0 {
+		if err = gitCommitPaths(ctx, db.projectPath, *written, msg); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Get loads a single record. See readonlyTx.Get for semantics.

--- a/pkg/dalgo2ingitdb/git_commit.go
+++ b/pkg/dalgo2ingitdb/git_commit.go
@@ -1,0 +1,57 @@
+package dalgo2ingitdb
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// gitCommitPaths stages exactly the given record-file paths in the git
+// repository that contains repoDir and commits them with message. It is used
+// by RunReadwriteTransaction for the opt-in commit triggered by a transaction
+// message. Paths are deduplicated (a record written several times in one
+// transaction yields one staged path). git is invoked with -C repoDir so the
+// enclosing repository is discovered even when repoDir is a subdirectory.
+func gitCommitPaths(ctx context.Context, repoDir string, paths []string, message string) error {
+	staged := dedupeStrings(paths)
+	if len(staged) == 0 {
+		return nil
+	}
+	// The transaction message is also a general annotation (e.g. for logging),
+	// not necessarily a request to commit. Only commit when repoDir is inside a
+	// git work tree; otherwise the message simply has no commit target and the
+	// written files are left in place. This keeps dalgo2ingitdb usable on plain
+	// directories (and in tests) without requiring a git repository.
+	if !isInsideGitWorkTree(ctx, repoDir) {
+		return nil
+	}
+	addArgs := append([]string{"-C", repoDir, "add", "--"}, staged...)
+	if out, err := exec.CommandContext(ctx, "git", addArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("dalgo2ingitdb: git add: %w: %s", err, out)
+	}
+	out, err := exec.CommandContext(ctx, "git", "-C", repoDir, "commit", "-m", message).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("dalgo2ingitdb: git commit: %w: %s", err, out)
+	}
+	return nil
+}
+
+// isInsideGitWorkTree reports whether dir is inside a git work tree.
+func isInsideGitWorkTree(ctx context.Context, dir string) bool {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--is-inside-work-tree")
+	return cmd.Run() == nil
+}
+
+// dedupeStrings returns the input with duplicates removed, preserving order.
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/pkg/dalgo2ingitdb/tx_readwrite.go
+++ b/pkg/dalgo2ingitdb/tx_readwrite.go
@@ -19,6 +19,19 @@ import (
 // implemented directly using exclusive locks on the affected record file.
 type readwriteTx struct {
 	readonlyTx
+	// written collects, by shared pointer, the absolute paths of record files
+	// mutated during the transaction. RunReadwriteTransaction uses it to stage
+	// exactly those files when committing with a transaction message. It is nil
+	// for transactions created outside RunReadwriteTransaction (e.g. DB-level
+	// helpers), in which case tracking is a no-op.
+	written *[]string
+}
+
+// track records a mutated record-file path for the opt-in commit step.
+func (r readwriteTx) track(path string) {
+	if r.written != nil {
+		*r.written = append(*r.written, path)
+	}
 }
 
 // ID returns the transaction identifier. inGitDB does not use a per-tx
@@ -70,6 +83,7 @@ func (r readwriteTx) Set(_ context.Context, record dal.Record) error {
 	default:
 		return fmt.Errorf("dalgo2ingitdb: Set not implemented for record type %q", colDef.RecordFile.RecordType)
 	}
+	r.track(path)
 	record.SetError(nil)
 	return nil
 }
@@ -136,6 +150,7 @@ func (r readwriteTx) Insert(_ context.Context, record dal.Record, _ ...dal.Inser
 	default:
 		return fmt.Errorf("dalgo2ingitdb: Insert not implemented for record type %q", colDef.RecordFile.RecordType)
 	}
+	r.track(path)
 	record.SetError(nil)
 	return nil
 }
@@ -173,7 +188,20 @@ func (r readwriteTx) Delete(_ context.Context, key *dal.Key) error {
 	path := resolveRecordPath(colDef, recordKey)
 	switch colDef.RecordFile.RecordType {
 	case ingitdb.SingleRecord:
-		return deleteSingleRecordFile(path)
+		_, statErr := os.Stat(path)
+		switch {
+		case statErr == nil:
+			// File exists; removing it is a real change to track for commit.
+		case errors.Is(statErr, fs.ErrNotExist):
+			return nil // idempotent: deleting a missing record is a no-op
+		default:
+			return fmt.Errorf("dalgo2ingitdb: stat %s: %w", path, statErr)
+		}
+		if err := deleteSingleRecordFile(path); err != nil {
+			return err
+		}
+		r.track(path)
+		return nil
 	case ingitdb.MapOfRecords:
 		allRecords, readErr := readMapOfRecordsFile(path, colDef.RecordFile.Format)
 		if readErr != nil {
@@ -183,7 +211,11 @@ func (r readwriteTx) Delete(_ context.Context, key *dal.Key) error {
 			return nil // idempotent: deleting a missing record is a no-op
 		}
 		delete(allRecords, recordKey)
-		return writeMapOfRecordsFile(path, colDef, allRecords)
+		if err := writeMapOfRecordsFile(path, colDef, allRecords); err != nil {
+			return err
+		}
+		r.track(path)
+		return nil
 	default:
 		return fmt.Errorf("dalgo2ingitdb: Delete not implemented for record type %q", colDef.RecordFile.RecordType)
 	}


### PR DESCRIPTION
## What

Wires the dalgo transaction message (dal-go/dalgo **v0.45.0**: `dal.TxWithMessage` / `tx.Options().SetMessage` / `Message()`) through to git commits, and exposes it as a **`--message`/`-m`** flag on the write verbs.

## Changes

**Dependency**
- Bump `dal-go/dalgo` → **v0.45.0**.

**Adapters consume the message as a commit message**
- `dalgo2ghingitdb` (GitHub): `RunReadwriteTransaction` uses the message as the Git Data API commit message, overriding the construction-time default.
- `dalgo2fsingitdb` (**the CLI's local backend**): the read-write transaction tracks the files it writes and, on success when a message is set **and** the project is a git work tree, stages exactly those files and commits them. Implements the previously-panicking `Options()`.
- `dalgo2ingitdb` (concurrent-safe sibling): same behaviour; its git-commit helper is exported as `GitCommitPaths` and reused by `dalgo2fsingitdb` (no duplication).

**CLI**
- `insert`, `update`, `delete` accept `--message`/`-m`, threaded to the transaction via a shared `addMessageFlag` + `txMessageOptions` helper. Works for both local (`--path`) and remote (`--remote`) writes.

## Behaviour

- `--message` set + git repo → the write is committed with that message (only the tx-written files are staged).
- No `--message`, or a non-git directory → files written, **no commit** (unchanged). The message then serves only as a transaction annotation (e.g. logging), consistent with its availability on readonly transactions.

## Notable correction during review

The CLI's local backend is `dalgo2fsingitdb`, **not** `dalgo2ingitdb` (which is a concurrent-safe sibling not yet wired into the CLI). The commit behaviour was therefore added to **both** so the CLI path actually commits; the git-commit helper is shared rather than duplicated.

## Tests

- Adapter-level: message overrides default / default when unset (ghingitdb httptest); commit-with-message stages only tx files, no-message → no commit, runtime `SetMessage`, non-git dir → no error (ingitdb).
- CLI end-to-end: `insert -m` commits the record with the message; no `-m` → no commit; flag is registered with `-m` shorthand.
- Full module `go test ./...` green, `go vet` clean, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)