### PR TITLE
test(dalgo2ingitdb): drive stored-value conformance via ValidateWrite

### DIFF
--- a/pkg/dalgo2ingitdb/validation_conformance_test.go
+++ b/pkg/dalgo2ingitdb/validation_conformance_test.go
@@ -80,8 +80,8 @@ func TestValidationConformanceVectors(t *testing.T) {
 			case "schema":
 				err = def.Validate()
 			case "stored-value":
-				r := readwriteTx{}
-				err = r.validateNoStoredComputedValues(collectionID, def, "ada", v.Record)
+				wdef := &ingitdb.Definition{Collections: map[string]*ingitdb.CollectionDef{collectionID: def}}
+				err = ValidateWrite(wdef, "Insert", collectionID, def, "ada", v.Record)
 			default:
 				t.Fatalf("unknown vector kind %q", v.Kind)
 			}


### PR DESCRIPTION
Now that `ValidateWrite` is on `main` (#70), repoint the `reject-stored-computed-value` conformance vector at that exported, driver-facing entry point instead of the unexported `validateNoStoredComputedValues`.

`ValidateWrite` is the same entry the CLI write path (`dalgo2fsingitdb`) uses, so the conformance check now exercises the real boundary an implementation must enforce. `validateNoStoredComputedValues` runs first inside `ValidateWrite` and returns early, so the vector still fails on the stored-computed-value rule before any foreign-key logic runs.

Behavior-preserving test refactor — all four validation conformance vectors stay green.

## Verification
- `go build ./...` ✓
- `go test ./...` ✓
- `golangci-lint run` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)