### PR TITLE
feat: computed columns via dalgo (lazy recordset delegation)

### DIFF
--- a/cmd/ingitdb/commands/delete.go
+++ b/cmd/ingitdb/commands/delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ingitdb/ingitdb-cli/cmd/ingitdb/commands/sqlflags"
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
 
@@ -116,19 +117,26 @@ func runDeleteFromSet(
 	q := newQueryForCollection(from)
 	var matchedKeys []string
 	err = ictx.db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
-		reader, qerr := tx.ExecuteQueryToRecordsReader(ctx, q)
+		reader, qerr := tx.ExecuteQueryToRecordsetReader(ctx, q)
 		if qerr != nil {
 			return qerr
 		}
 		defer func() { _ = reader.Close() }()
+		var whereNames []string
 		for {
-			rec, nextErr := reader.Next()
+			row, rs, nextErr := reader.Next()
 			if nextErr != nil {
 				break
 			}
-			recKey := fmt.Sprintf("%v", rec.Key().ID)
+			recKey := dalgo2ingitdb.RowKey(row, rs)
 			if !allFlag {
-				data := rec.Data().(map[string]any)
+				if whereNames == nil {
+					whereNames = whereColumnNames(rs, conds)
+				}
+				data, derr := dalgo2ingitdb.RowData(row, rs, from, recKey, ictx.colDef, whereNames)
+				if derr != nil {
+					return derr
+				}
 				if match, _ := evalAllWhere(data, recKey, conds); !match {
 					continue
 				}

--- a/cmd/ingitdb/commands/delete_computed_test.go
+++ b/cmd/ingitdb/commands/delete_computed_test.go
@@ -1,0 +1,71 @@
+package commands
+
+// specscore: feature/computed-columns-via-dalgo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// AC: delete-where-on-computed — delete in set mode filters on a computed
+// column's value, deleting exactly the matching records.
+func TestDelete_SetMode_WhereOnComputedColumn(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := peopleSelectDeps(t, dir)
+	seedPerson(t, dir, "ada", "Ada", "Lovelace")
+	seedPerson(t, dir, "alan", "Alan", "Turing")
+
+	_, err := runDeleteCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people", `--where=full_name == "Ada Lovelace"`)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "$records", "ada.yaml")); !os.IsNotExist(statErr) {
+		t.Errorf("ada.yaml should have been deleted (matched computed full_name)")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "$records", "alan.yaml")); statErr != nil {
+		t.Errorf("alan.yaml should remain (did not match): %v", statErr)
+	}
+}
+
+// delete --where referencing an erroring computed column fails loud.
+func TestDelete_SetMode_WhereOnErroringComputedColumn(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := ratioSelectDeps(t, dir)
+	seedPersonFields(t, dir, "a", map[string]any{"qty": 3})
+
+	_, err := runDeleteCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people", "--where=ratio == 1")
+	if err == nil {
+		t.Fatal("delete --where on an erroring computed column must fail loud")
+	}
+	if !strings.Contains(err.Error(), "ratio") {
+		t.Errorf("error should name the ratio column, got: %v", err)
+	}
+}
+
+// delete --where on the $id pseudo-field exercises the whereColumnNames $id skip
+// (the key is resolved from the row, not read as a recordset column).
+func TestDelete_SetMode_WhereOnID(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := peopleSelectDeps(t, dir)
+	seedPerson(t, dir, "ada", "Ada", "Lovelace")
+	seedPerson(t, dir, "alan", "Alan", "Turing")
+
+	_, err := runDeleteCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people", `--where=$id == "ada"`)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "$records", "ada.yaml")); !os.IsNotExist(statErr) {
+		t.Errorf("ada.yaml should have been deleted by $id match")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "$records", "alan.yaml")); statErr != nil {
+		t.Errorf("alan.yaml should remain: %v", statErr)
+	}
+}

--- a/cmd/ingitdb/commands/recordset_read.go
+++ b/cmd/ingitdb/commands/recordset_read.go
@@ -5,41 +5,23 @@ package commands
 import (
 	"github.com/dal-go/dalgo/recordset"
 
-	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
-	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"github.com/ingitdb/ingitdb-cli/cmd/ingitdb/commands/sqlflags"
 )
 
-// rowData reads the named columns of a recordset row through the shared
-// coerce-on-access accessor, returning a map equivalent to the eager
-// ApplyFormulasToRead result for those columns: stored values plus computed
-// values resolved lazily on access. Only the requested columns are read, so an
-// unreferenced computed column is never evaluated. Nil values are omitted so the
-// map matches the ragged record map the eager pipeline produced (absent fields
-// were never keys). A referenced computed column that errors surfaces fail-loud.
-func rowData(row recordset.Row, rs recordset.Recordset, collectionID, recKey string, colDef *ingitdb.CollectionDef, names []string) (map[string]any, error) {
-	data := make(map[string]any, len(names))
-	for _, name := range names {
-		v, err := dalgo2ingitdb.AccessValue(row, rs, collectionID, recKey, name, colDef.Columns[name])
-		if err != nil {
-			return nil, err
-		}
-		if v == nil {
+// whereColumnNames returns the recordset columns referenced by --where
+// conditions, excluding the "$id" pseudo-field and any name that is not an
+// actual recordset column (an unknown field simply never matches, as before).
+func whereColumnNames(rs recordset.Recordset, conds []sqlflags.Condition) []string {
+	var names []string
+	seen := make(map[string]bool)
+	for _, c := range conds {
+		if c.Field == "$id" || seen[c.Field] {
 			continue
 		}
-		data[name] = v
-	}
-	return data, nil
-}
-
-// allColumnNames returns every column name of rs except the reserved $id column.
-func allColumnNames(rs recordset.Recordset) []string {
-	cols := rs.Columns()
-	names := make([]string, 0, len(cols))
-	for _, col := range cols {
-		if col.Name() == dalgo2ingitdb.IDColumn {
-			continue
+		seen[c.Field] = true
+		if rs.GetColumnByName(c.Field) != nil {
+			names = append(names, c.Field)
 		}
-		names = append(names, col.Name())
 	}
 	return names
 }

--- a/cmd/ingitdb/commands/recordset_read.go
+++ b/cmd/ingitdb/commands/recordset_read.go
@@ -1,0 +1,45 @@
+package commands
+
+// specscore: feature/computed-columns-via-dalgo
+
+import (
+	"github.com/dal-go/dalgo/recordset"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// rowData reads the named columns of a recordset row through the shared
+// coerce-on-access accessor, returning a map equivalent to the eager
+// ApplyFormulasToRead result for those columns: stored values plus computed
+// values resolved lazily on access. Only the requested columns are read, so an
+// unreferenced computed column is never evaluated. Nil values are omitted so the
+// map matches the ragged record map the eager pipeline produced (absent fields
+// were never keys). A referenced computed column that errors surfaces fail-loud.
+func rowData(row recordset.Row, rs recordset.Recordset, collectionID, recKey string, colDef *ingitdb.CollectionDef, names []string) (map[string]any, error) {
+	data := make(map[string]any, len(names))
+	for _, name := range names {
+		v, err := dalgo2ingitdb.AccessValue(row, rs, collectionID, recKey, name, colDef.Columns[name])
+		if err != nil {
+			return nil, err
+		}
+		if v == nil {
+			continue
+		}
+		data[name] = v
+	}
+	return data, nil
+}
+
+// allColumnNames returns every column name of rs except the reserved $id column.
+func allColumnNames(rs recordset.Recordset) []string {
+	cols := rs.Columns()
+	names := make([]string, 0, len(cols))
+	for _, col := range cols {
+		if col.Name() == dalgo2ingitdb.IDColumn {
+			continue
+		}
+		names = append(names, col.Name())
+	}
+	return names
+}

--- a/cmd/ingitdb/commands/select.go
+++ b/cmd/ingitdb/commands/select.go
@@ -10,9 +10,11 @@ import (
 	"strings"
 
 	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/recordset"
 	"github.com/spf13/cobra"
 
 	"github.com/ingitdb/ingitdb-cli/cmd/ingitdb/commands/sqlflags"
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
 
@@ -166,7 +168,7 @@ func runSelectFromSet(
 		if dbErr != nil {
 			return fmt.Errorf("failed to open remote database: %w", dbErr)
 		}
-		return runSelectFromSetWithDB(ctx, cmd, from, fields, format, db)
+		return runSelectFromSetWithDB(ctx, cmd, from, fields, format, db, def.Collections[from])
 	}
 
 	dirPath, err := resolveDBPath(cmd, homeDir, getWd)
@@ -184,7 +186,7 @@ func runSelectFromSet(
 	if err != nil {
 		return fmt.Errorf("failed to open database: %w", err)
 	}
-	return runSelectFromSetWithDB(ctx, cmd, from, fields, format, db)
+	return runSelectFromSetWithDB(ctx, cmd, from, fields, format, db, def.Collections[from])
 }
 
 // runSelectFromSetWithDB executes the set-mode query against a pre-opened DB.
@@ -196,6 +198,7 @@ func runSelectFromSetWithDB(
 	fields []string,
 	format string,
 	db dal.DB,
+	colDef *ingitdb.CollectionDef,
 ) error {
 	whereExprs, _ := cmd.Flags().GetStringArray("where")
 	conds := make([]sqlflags.Condition, 0, len(whereExprs))
@@ -211,18 +214,25 @@ func runSelectFromSetWithDB(
 
 	var rows []map[string]any
 	err := db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
-		reader, qerr := tx.ExecuteQueryToRecordsReader(ctx, q)
+		reader, qerr := tx.ExecuteQueryToRecordsetReader(ctx, q)
 		if qerr != nil {
 			return qerr
 		}
 		defer func() { _ = reader.Close() }()
+		var names []string
 		for {
-			rec, nextErr := reader.Next()
+			row, rs, nextErr := reader.Next()
 			if nextErr != nil {
 				break
 			}
-			data := rec.Data().(map[string]any)
-			recKey := fmt.Sprintf("%v", rec.Key().ID)
+			if names == nil {
+				names = selectColumnsToRead(rs, fields, conds)
+			}
+			recKey := dalgo2ingitdb.RowKey(row, rs)
+			data, derr := rowData(row, rs, from, recKey, colDef, names)
+			if derr != nil {
+				return derr
+			}
 			if match, _ := evalAllWhere(data, recKey, conds); !match {
 				continue
 			}
@@ -276,6 +286,39 @@ func runSelectFromSetWithDB(
 		format = "csv"
 	}
 	return writeSetMode(cmd.OutOrStdout(), rows, format, fields)
+}
+
+// selectColumnsToRead returns the recordset columns select must read per row:
+// the projected columns (every column when --fields is empty) plus any column a
+// --where condition references. Only columns that exist in the recordset are
+// returned, so an unreferenced computed column is never evaluated and an unknown
+// field name is silently ignored (matching the pre-migration behavior, where an
+// absent field simply did not appear in the record map).
+func selectColumnsToRead(rs recordset.Recordset, fields []string, conds []sqlflags.Condition) []string {
+	want := make(map[string]bool)
+	for _, c := range conds {
+		if c.Field != "$id" {
+			want[c.Field] = true
+		}
+	}
+	if len(fields) == 0 {
+		for _, name := range allColumnNames(rs) {
+			want[name] = true
+		}
+	} else {
+		for _, f := range fields {
+			if f != "$id" {
+				want[f] = true
+			}
+		}
+	}
+	names := make([]string, 0, len(want))
+	for name := range want {
+		if rs.GetColumnByName(name) != nil {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 // writeSetMode is the set-mode output dispatcher. Empty rows still

--- a/cmd/ingitdb/commands/select.go
+++ b/cmd/ingitdb/commands/select.go
@@ -229,7 +229,7 @@ func runSelectFromSetWithDB(
 				names = selectColumnsToRead(rs, fields, conds)
 			}
 			recKey := dalgo2ingitdb.RowKey(row, rs)
-			data, derr := rowData(row, rs, from, recKey, colDef, names)
+			data, derr := dalgo2ingitdb.RowData(row, rs, from, recKey, colDef, names)
 			if derr != nil {
 				return derr
 			}
@@ -296,27 +296,23 @@ func runSelectFromSetWithDB(
 // absent field simply did not appear in the record map).
 func selectColumnsToRead(rs recordset.Recordset, fields []string, conds []sqlflags.Condition) []string {
 	want := make(map[string]bool)
-	for _, c := range conds {
-		if c.Field != "$id" {
-			want[c.Field] = true
-		}
+	for _, name := range whereColumnNames(rs, conds) {
+		want[name] = true
 	}
 	if len(fields) == 0 {
-		for _, name := range allColumnNames(rs) {
+		for _, name := range dalgo2ingitdb.AllColumnNames(rs) {
 			want[name] = true
 		}
 	} else {
 		for _, f := range fields {
-			if f != "$id" {
+			if f != "$id" && rs.GetColumnByName(f) != nil {
 				want[f] = true
 			}
 		}
 	}
 	names := make([]string, 0, len(want))
 	for name := range want {
-		if rs.GetColumnByName(name) != nil {
-			names = append(names, name)
-		}
+		names = append(names, name)
 	}
 	return names
 }

--- a/cmd/ingitdb/commands/select_computed_test.go
+++ b/cmd/ingitdb/commands/select_computed_test.go
@@ -137,6 +137,199 @@ func TestSelect_SetMode_OrderByComputedColumn(t *testing.T) {
 	}
 }
 
+// peopleHelpersDef returns a people definition exercising the Starlark string
+// and numeric helpers through computed columns: full_name (concat), display
+// (strip+upper) and rounded (round of a float score, declared int).
+func peopleHelpersDef(dirPath string) *ingitdb.Definition {
+	return &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"people": {
+				ID:      "people",
+				DirPath: dirPath,
+				RecordFile: &ingitdb.RecordFileDef{
+					Name:       "{key}.yaml",
+					Format:     "yaml",
+					RecordType: ingitdb.SingleRecord,
+				},
+				Columns: map[string]*ingitdb.ColumnDef{
+					"first_name": {Type: ingitdb.ColumnTypeString},
+					"last_name":  {Type: ingitdb.ColumnTypeString},
+					"score":      {Type: ingitdb.ColumnTypeFloat},
+					"full_name":  {Type: ingitdb.ColumnTypeString, Formula: `first_name + " " + last_name`},
+					"display":    {Type: ingitdb.ColumnTypeString, Formula: `first_name.strip().upper()`},
+					"rounded":    {Type: ingitdb.ColumnTypeInt, Formula: `round(score)`},
+				},
+				ColumnsOrder: []string{"first_name", "last_name", "score", "full_name", "display", "rounded"},
+			},
+		},
+	}
+}
+
+func helpersSelectDeps(t *testing.T, dir string) (
+	func() (string, error),
+	func() (string, error),
+	func(string, ...ingitdb.ReadOption) (*ingitdb.Definition, error),
+	func(string, *ingitdb.Definition) (dal.DB, error),
+	func(...any),
+) {
+	t.Helper()
+	def := peopleHelpersDef(dir)
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return dir, nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) { return def, nil }
+	newDB := func(root string, d *ingitdb.Definition) (dal.DB, error) {
+		return dalgo2fsingitdb.NewLocalDBWithDef(root, d)
+	}
+	return homeDir, getWd, readDef, newDB, func(...any) {}
+}
+
+func seedPersonFields(t *testing.T, dir, key string, fields map[string]any) {
+	t.Helper()
+	colDir := filepath.Join(dir, "$records")
+	if err := os.MkdirAll(colDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	out, err := yaml.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(colDir, key+".yaml"), out, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// AC: select-renders-computed — select renders a computed string column.
+func TestSelect_RendersComputedColumn(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := helpersSelectDeps(t, dir)
+	seedPersonFields(t, dir, "ada", map[string]any{"first_name": "Ada", "last_name": "Lovelace"})
+
+	stdout, err := runSelectCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people", "--fields=$id,full_name", "--format=csv")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(stdout, "Ada Lovelace") {
+		t.Errorf("expected computed full_name in output:\n%s", stdout)
+	}
+}
+
+// AC: string-helper-preserved — Starlark string helpers (strip/upper) work.
+func TestSelect_StringHelperPreserved(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := helpersSelectDeps(t, dir)
+	seedPersonFields(t, dir, "ada", map[string]any{"first_name": " ada "})
+
+	stdout, err := runSelectCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people", "--fields=$id,display", "--format=csv")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(stdout, "ADA") {
+		t.Errorf("expected display 'ADA' (strip+upper) in output:\n%s", stdout)
+	}
+}
+
+// AC: math-helper-preserved — round() yields an int, rendered as 5 not 4.6/5.0.
+func TestSelect_MathHelperPreserved(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := helpersSelectDeps(t, dir)
+	seedPersonFields(t, dir, "ada", map[string]any{"score": 4.6})
+
+	stdout, err := runSelectCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people", "--fields=$id,rounded", "--format=csv")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want header + 1 row, got:\n%s", stdout)
+	}
+	if !strings.Contains(lines[1], "5") || strings.Contains(lines[1], "4.6") || strings.Contains(lines[1], "5.0") {
+		t.Errorf("expected rounded integer 5, got row: %q", lines[1])
+	}
+}
+
+// peopleRatioDef returns a people definition with a stored qty and a computed
+// int ratio = qty / 0 that raises at runtime when evaluated.
+func peopleRatioDef(dirPath string) *ingitdb.Definition {
+	return &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"people": {
+				ID:      "people",
+				DirPath: dirPath,
+				RecordFile: &ingitdb.RecordFileDef{
+					Name:       "{key}.yaml",
+					Format:     "yaml",
+					RecordType: ingitdb.SingleRecord,
+				},
+				Columns: map[string]*ingitdb.ColumnDef{
+					"qty":   {Type: ingitdb.ColumnTypeInt},
+					"ratio": {Type: ingitdb.ColumnTypeInt, Formula: "qty / 0"},
+				},
+				ColumnsOrder: []string{"qty", "ratio"},
+			},
+		},
+	}
+}
+
+func ratioSelectDeps(t *testing.T, dir string) (
+	func() (string, error),
+	func() (string, error),
+	func(string, ...ingitdb.ReadOption) (*ingitdb.Definition, error),
+	func(string, *ingitdb.Definition) (dal.DB, error),
+	func(...any),
+) {
+	t.Helper()
+	def := peopleRatioDef(dir)
+	return func() (string, error) { return "/tmp/home", nil },
+		func() (string, error) { return dir, nil },
+		func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) { return def, nil },
+		func(root string, d *ingitdb.Definition) (dal.DB, error) {
+			return dalgo2fsingitdb.NewLocalDBWithDef(root, d)
+		},
+		func(...any) {}
+}
+
+// AC: unreferenced-erroring-column-not-evaluated — projecting only the stored
+// column succeeds even though the computed ratio would raise, because ratio is
+// never referenced and therefore never evaluated (lazy).
+func TestSelect_UnreferencedErroringColumnNotEvaluated(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := ratioSelectDeps(t, dir)
+	seedPersonFields(t, dir, "a", map[string]any{"qty": 3})
+
+	stdout, err := runSelectCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people", "--fields=$id,qty", "--format=csv")
+	if err != nil {
+		t.Fatalf("projecting only qty must not evaluate ratio: %v", err)
+	}
+	if !strings.Contains(stdout, "3") {
+		t.Errorf("expected qty 3 in output:\n%s", stdout)
+	}
+}
+
+// Referencing the erroring computed column (projection) aborts the read.
+func TestSelect_ReferencedErroringColumnFailsLoud(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := ratioSelectDeps(t, dir)
+	seedPersonFields(t, dir, "a", map[string]any{"qty": 3})
+
+	_, err := runSelectCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people", "--fields=$id,ratio", "--format=csv")
+	if err == nil {
+		t.Fatal("projecting the erroring ratio column must fail loud")
+	}
+	if !strings.Contains(err.Error(), "ratio") {
+		t.Errorf("error should name the ratio column, got: %v", err)
+	}
+}
+
 // peopleBadFormulaDef returns a people definition whose computed column's
 // formula references a missing field, so formula evaluation fails on read.
 func peopleBadFormulaDef(dirPath string, recordType ingitdb.RecordType, name string) *ingitdb.Definition {

--- a/cmd/ingitdb/commands/update_computed_test.go
+++ b/cmd/ingitdb/commands/update_computed_test.go
@@ -1,0 +1,69 @@
+package commands
+
+// specscore: feature/computed-columns-via-dalgo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// update set-mode filters on a computed column and patches the matching record;
+// the computed column is never written back (the write path rejects stored
+// computed values), so the migration must persist stored fields only.
+func TestUpdate_SetMode_WhereOnComputedColumn(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := peopleSelectDeps(t, dir)
+	seedPerson(t, dir, "ada", "Ada", "Lovelace")
+	seedPerson(t, dir, "alan", "Alan", "Turing")
+
+	_, err := runUpdateCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people", `--where=full_name == "Ada Lovelace"`,
+		"--set=last_name=Byron")
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "$records", "ada.yaml"))
+	if err != nil {
+		t.Fatalf("read ada.yaml: %v", err)
+	}
+	var got map[string]any
+	if err := yaml.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["last_name"] != "Byron" {
+		t.Errorf("last_name = %v, want Byron", got["last_name"])
+	}
+	if _, hasComputed := got["full_name"]; hasComputed {
+		t.Errorf("computed full_name must NOT be persisted, got: %v", got["full_name"])
+	}
+
+	// alan untouched.
+	rawAlan, _ := os.ReadFile(filepath.Join(dir, "$records", "alan.yaml"))
+	if !strings.Contains(string(rawAlan), "Turing") {
+		t.Errorf("alan.yaml should be unchanged, got: %s", rawAlan)
+	}
+}
+
+// update --where referencing an erroring computed column fails loud (covers the
+// RowData error branch in the update read loop).
+func TestUpdate_SetMode_WhereOnErroringComputedColumn(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir, getWd, readDef, newDB, logf := ratioSelectDeps(t, dir)
+	seedPersonFields(t, dir, "a", map[string]any{"qty": 3})
+
+	_, err := runUpdateCmd(t, homeDir, getWd, readDef, newDB, logf,
+		"--path="+dir, "--from=people", "--where=ratio == 1", "--set=qty=5")
+	if err == nil {
+		t.Fatal("update --where on an erroring computed column must fail loud")
+	}
+	if !strings.Contains(err.Error(), "ratio") {
+		t.Errorf("error should name the ratio column, got: %v", err)
+	}
+}

--- a/cmd/ingitdb/commands/update_new.go
+++ b/cmd/ingitdb/commands/update_new.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ingitdb/ingitdb-cli/cmd/ingitdb/commands/sqlflags"
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
 
@@ -244,24 +245,54 @@ func runUpdateFromSet(
 	q := newQueryForCollection(from)
 	var matches []patchTarget
 	err = ictx.db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
-		reader, qerr := tx.ExecuteQueryToRecordsReader(ctx, q)
+		reader, qerr := tx.ExecuteQueryToRecordsetReader(ctx, q)
 		if qerr != nil {
 			return qerr
 		}
 		defer func() { _ = reader.Close() }()
+		var (
+			readNames []string
+			storedSet map[string]bool
+		)
 		for {
-			rec, nextErr := reader.Next()
+			row, rs, nextErr := reader.Next()
 			if nextErr != nil {
 				break
 			}
-			data := rec.Data().(map[string]any)
-			recKey := fmt.Sprintf("%v", rec.Key().ID)
+			if storedSet == nil {
+				storedNames := dalgo2ingitdb.StoredColumnNames(rs)
+				storedSet = make(map[string]bool, len(storedNames))
+				readNames = append(readNames, storedNames...)
+				for _, n := range storedNames {
+					storedSet[n] = true
+				}
+				// Computed columns referenced by --where are read for matching
+				// (and dropped before write-back).
+				for _, n := range whereColumnNames(rs, conds) {
+					if !storedSet[n] {
+						readNames = append(readNames, n)
+					}
+				}
+			}
+			recKey := dalgo2ingitdb.RowKey(row, rs)
+			data, derr := dalgo2ingitdb.RowData(row, rs, from, recKey, ictx.colDef, readNames)
+			if derr != nil {
+				return derr
+			}
 			if !allFlag {
 				if matched, _ := evalAllWhere(data, recKey, conds); !matched {
 					continue
 				}
 			}
-			matches = append(matches, patchTarget{key: recKey, data: data})
+			// Write-back persists stored fields only — computed columns are never
+			// stored (the write path rejects them).
+			storedData := make(map[string]any, len(data))
+			for k, v := range data {
+				if storedSet[k] {
+					storedData[k] = v
+				}
+			}
+			matches = append(matches, patchTarget{key: recKey, data: storedData})
 		}
 		return nil
 	})

--- a/cmd/ingitdb/tui/collection_screen.go
+++ b/cmd/ingitdb/tui/collection_screen.go
@@ -2,12 +2,12 @@ package tui
 
 import (
 	"context"
-	"fmt"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/dal-go/dalgo/dal"
 
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
 
@@ -218,18 +218,26 @@ func loadRecordsCmd(db dal.DB, colDef *ingitdb.CollectionDef) tea.Cmd {
 			keys    []string
 		)
 		err := db.RunReadonlyTransaction(context.Background(), func(ctx context.Context, tx dal.ReadTransaction) error {
-			reader, txErr := tx.ExecuteQueryToRecordsReader(ctx, q)
+			reader, txErr := tx.ExecuteQueryToRecordsetReader(ctx, q)
 			if txErr != nil {
 				return txErr
 			}
 			defer func() { _ = reader.Close() }()
+			var names []string
 			for {
-				rec, nextErr := reader.Next()
+				row, rs, nextErr := reader.Next()
 				if nextErr != nil {
 					break
 				}
-				data := rec.Data().(map[string]any)
-				keys = append(keys, fmt.Sprintf("%v", rec.Key().ID))
+				if names == nil {
+					names = dalgo2ingitdb.AllColumnNames(rs)
+				}
+				recKey := dalgo2ingitdb.RowKey(row, rs)
+				data, derr := dalgo2ingitdb.RowData(row, rs, colID, recKey, colDef, names)
+				if derr != nil {
+					return derr
+				}
+				keys = append(keys, recKey)
 				records = append(records, data)
 			}
 			return nil

--- a/cmd/ingitdb/tui/coverage_gaps_test.go
+++ b/cmd/ingitdb/tui/coverage_gaps_test.go
@@ -39,16 +39,16 @@ func (mockTx) Exists(_ context.Context, _ *dal.Key) (bool, error) { return false
 
 func (mockTx) GetMulti(_ context.Context, _ []dal.Record) error { return nil }
 
-func (mockTx) ExecuteQueryToRecordsetReader(_ context.Context, _ dal.Query, _ ...recordset.Option) (dal.RecordsetReader, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (mockTx) ExecuteQueryToRecordsReader(_ context.Context, q dal.Query) (dal.RecordsReader, error) {
+func (mockTx) ExecuteQueryToRecordsetReader(_ context.Context, q dal.Query, _ ...recordset.Option) (dal.RecordsetReader, error) {
 	sq, ok := q.(dal.StructuredQuery)
 	if ok {
 		// Call the factory — this is the line we need to cover.
 		_ = sq.IntoRecord()
 	}
+	return &emptyRecordsetReader{}, nil
+}
+
+func (mockTx) ExecuteQueryToRecordsReader(_ context.Context, _ dal.Query) (dal.RecordsReader, error) {
 	return &emptyRecordsReader{}, nil
 }
 
@@ -57,6 +57,15 @@ type emptyRecordsReader struct{}
 func (e *emptyRecordsReader) Next() (dal.Record, error) { return nil, dal.ErrNoMoreRecords }
 func (e *emptyRecordsReader) Cursor() (string, error)   { return "", nil }
 func (e *emptyRecordsReader) Close() error              { return nil }
+
+type emptyRecordsetReader struct{}
+
+func (e *emptyRecordsetReader) Next() (recordset.Row, recordset.Recordset, error) {
+	return nil, nil, dal.ErrNoMoreRecords
+}
+func (e *emptyRecordsetReader) Recordset() recordset.Recordset { return nil }
+func (e *emptyRecordsetReader) Cursor() (string, error)        { return "", nil }
+func (e *emptyRecordsetReader) Close() error                   { return nil }
 
 // mockDB wraps mockTx to satisfy the dal.DB interface.
 type mockDB struct{ dal.NoConcurrency }
@@ -166,6 +175,50 @@ func TestLoadRecordsCmd_Success(t *testing.T) {
 	}
 	if len(loaded.keys) != 2 {
 		t.Errorf("loaded %d keys, want 2", len(loaded.keys))
+	}
+}
+
+// TestLoadRecordsCmd_ComputedError exercises the per-row RowData error path: a
+// computed column whose formula raises at runtime aborts the load (the cells the
+// TUI would render are read through the shared coerce-on-access accessor).
+func TestLoadRecordsCmd_ComputedError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	recordsDir := filepath.Join(dir, "$records")
+	if err := os.MkdirAll(recordsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	makeYAMLFile(t, filepath.Join(recordsDir, "a.yaml"), map[string]any{"qty": 3})
+
+	colDef := &ingitdb.CollectionDef{
+		ID:      "people",
+		DirPath: dir,
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:       "{key}.yaml",
+			Format:     "yaml",
+			RecordType: ingitdb.SingleRecord,
+		},
+		Columns: map[string]*ingitdb.ColumnDef{
+			"qty":   {Type: ingitdb.ColumnTypeInt},
+			"ratio": {Type: ingitdb.ColumnTypeInt, Formula: "qty / 0"},
+		},
+		ColumnsOrder: []string{"qty", "ratio"},
+	}
+	def := &ingitdb.Definition{Collections: map[string]*ingitdb.CollectionDef{"people": colDef}}
+
+	db, err := dalgo2fsingitdb.NewLocalDBWithDef(dir, def)
+	if err != nil {
+		t.Fatalf("NewLocalDBWithDef: %v", err)
+	}
+
+	msg := loadRecordsCmd(db, colDef)()
+	loaded, ok := msg.(recordsLoadedMsg)
+	if !ok {
+		t.Fatalf("cmd() returned %T, want recordsLoadedMsg", msg)
+	}
+	if loaded.err == nil {
+		t.Fatal("expected error from erroring computed column")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.18.2 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
-	github.com/dal-go/dalgo v0.45.0
+	github.com/dal-go/dalgo v0.46.0
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/strongo/random v0.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dal-go/dalgo v0.45.0 h1:1DfQwO1MnJg7wrL/RkU+aDJas/YQoSw0gUfBG7z2mek=
-github.com/dal-go/dalgo v0.45.0/go.mod h1:HHMUuCMutAlYEblDTVws7jeZs56jvOCbOuxVs6I01tE=
+github.com/dal-go/dalgo v0.46.0 h1:j/FWUr6Gawm59pxi6cgFoGKeg+D7iy1FPww0LgbzliA=
+github.com/dal-go/dalgo v0.46.0/go.mod h1:HHMUuCMutAlYEblDTVws7jeZs56jvOCbOuxVs6I01tE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/pkg/dalgo2fsingitdb/recordset_test.go
+++ b/pkg/dalgo2fsingitdb/recordset_test.go
@@ -1,0 +1,224 @@
+package dalgo2fsingitdb
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// peopleComputedDef builds a SingleRecord YAML definition with a computed
+// full_name column derived from stored first_name/last_name.
+func peopleComputedDef(dirPath string) *ingitdb.Definition {
+	colDef := &ingitdb.CollectionDef{
+		ID:      "people",
+		DirPath: dirPath,
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:       "{key}.yaml",
+			Format:     ingitdb.RecordFormatYAML,
+			RecordType: ingitdb.SingleRecord,
+		},
+		Columns: map[string]*ingitdb.ColumnDef{
+			"first_name": {Type: ingitdb.ColumnTypeString},
+			"last_name":  {Type: ingitdb.ColumnTypeString},
+			"full_name":  {Type: ingitdb.ColumnTypeString, Formula: `first_name + " " + last_name`},
+		},
+		ColumnsOrder: []string{"first_name", "last_name", "full_name"},
+	}
+	return &ingitdb.Definition{Collections: map[string]*ingitdb.CollectionDef{"people": colDef}}
+}
+
+func peopleQuery() dal.Query {
+	return dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("people", ""))).
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithData(dal.NewKeyWithID("people", ""), map[string]any{})
+		})
+}
+
+func TestExecuteQueryToRecordsetReader_SingleRecords_Computed(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := peopleComputedDef(dir)
+	recordsDir := filepath.Join(dir, "$records")
+	if err := os.MkdirAll(recordsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeQueryFixture(t, filepath.Join(recordsDir, "ada.yaml"),
+		map[string]any{"first_name": "Ada", "last_name": "Lovelace"})
+
+	db := openTestDB(t, dir, def)
+	err := db.RunReadonlyTransaction(context.Background(), func(ctx context.Context, tx dal.ReadTransaction) error {
+		reader, qerr := tx.ExecuteQueryToRecordsetReader(ctx, peopleQuery())
+		if qerr != nil {
+			return qerr
+		}
+		defer func() { _ = reader.Close() }()
+		row, rs, nerr := reader.Next()
+		if nerr != nil {
+			return nerr
+		}
+		first, ferr := row.GetValueByName("first_name", rs)
+		if ferr != nil {
+			return ferr
+		}
+		if first != "Ada" {
+			t.Errorf("first_name = %v, want Ada", first)
+		}
+		full, cerr := row.GetValueByName("full_name", rs)
+		if cerr != nil {
+			return cerr
+		}
+		if full != "Ada Lovelace" {
+			t.Errorf("full_name = %v, want %q", full, "Ada Lovelace")
+		}
+		if _, _, eerr := reader.Next(); !errors.Is(eerr, dal.ErrNoMoreRecords) {
+			t.Errorf("second Next err = %v, want ErrNoMoreRecords", eerr)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunReadonlyTransaction: %v", err)
+	}
+}
+
+func TestExecuteQueryToRecordsetReader_MapOfRecords_Computed(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	colDef := &ingitdb.CollectionDef{
+		ID:      "scores",
+		DirPath: dir,
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:       "scores.yaml",
+			Format:     ingitdb.RecordFormatYAML,
+			RecordType: ingitdb.MapOfRecords,
+		},
+		Columns: map[string]*ingitdb.ColumnDef{
+			"score":   {Type: ingitdb.ColumnTypeInt},
+			"doubled": {Type: ingitdb.ColumnTypeInt, Formula: "score * 2"},
+		},
+		ColumnsOrder: []string{"score", "doubled"},
+	}
+	def := &ingitdb.Definition{Collections: map[string]*ingitdb.CollectionDef{"scores": colDef}}
+	// A fixed map-of-records file (Name has no {key}) lives at the collection
+	// root, not under $records.
+	if err := os.WriteFile(filepath.Join(dir, "scores.yaml"),
+		[]byte("alpha:\n  score: 5\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	db := openTestDB(t, dir, def)
+	query := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("scores", ""))).
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithData(dal.NewKeyWithID("scores", ""), map[string]any{})
+		})
+	err := db.RunReadonlyTransaction(context.Background(), func(ctx context.Context, tx dal.ReadTransaction) error {
+		reader, qerr := tx.ExecuteQueryToRecordsetReader(ctx, query)
+		if qerr != nil {
+			return qerr
+		}
+		defer func() { _ = reader.Close() }()
+		row, rs, nerr := reader.Next()
+		if nerr != nil {
+			return nerr
+		}
+		doubled, derr := row.GetValueByName("doubled", rs)
+		if derr != nil {
+			return derr
+		}
+		if doubled != int64(10) {
+			t.Errorf("doubled = %v, want 10", doubled)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunReadonlyTransaction: %v", err)
+	}
+}
+
+func TestExecuteQueryToRecordsetReader_UnknownCollection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	def := peopleComputedDef(dir)
+	db := openTestDB(t, dir, def)
+	query := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("nope", ""))).
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithData(dal.NewKeyWithID("nope", ""), map[string]any{})
+		})
+	err := db.RunReadonlyTransaction(context.Background(), func(ctx context.Context, tx dal.ReadTransaction) error {
+		_, qerr := tx.ExecuteQueryToRecordsetReader(ctx, query)
+		return qerr
+	})
+	if err == nil {
+		t.Fatal("want error for unknown collection")
+	}
+}
+
+func TestExecuteQueryToRecordsetReader_UnsupportedRecordType(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	colDef := &ingitdb.CollectionDef{
+		ID:      "people",
+		DirPath: dir,
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:       "{key}.yaml",
+			Format:     ingitdb.RecordFormatYAML,
+			RecordType: "bogus",
+		},
+		Columns: map[string]*ingitdb.ColumnDef{"first_name": {Type: ingitdb.ColumnTypeString}},
+	}
+	def := &ingitdb.Definition{Collections: map[string]*ingitdb.CollectionDef{"people": colDef}}
+	db := openTestDB(t, dir, def)
+	err := db.RunReadonlyTransaction(context.Background(), func(ctx context.Context, tx dal.ReadTransaction) error {
+		_, qerr := tx.ExecuteQueryToRecordsetReader(ctx, peopleQuery())
+		return qerr
+	})
+	if err == nil {
+		t.Fatal("want error for unsupported record type")
+	}
+}
+
+// TestExecuteQueryToRecordsReader_FormulaError covers the eager-bake error
+// branch (bakeStoredRecords): a computed column whose formula fails at runtime
+// aborts the records-reader read.
+func TestExecuteQueryToRecordsReader_FormulaError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	colDef := &ingitdb.CollectionDef{
+		ID:      "people",
+		DirPath: dir,
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:       "{key}.yaml",
+			Format:     ingitdb.RecordFormatYAML,
+			RecordType: ingitdb.SingleRecord,
+		},
+		Columns: map[string]*ingitdb.ColumnDef{
+			"qty":   {Type: ingitdb.ColumnTypeInt},
+			"ratio": {Type: ingitdb.ColumnTypeInt, Formula: "qty / 0"},
+		},
+		ColumnsOrder: []string{"qty", "ratio"},
+	}
+	def := &ingitdb.Definition{Collections: map[string]*ingitdb.CollectionDef{"people": colDef}}
+	recordsDir := filepath.Join(dir, "$records")
+	if err := os.MkdirAll(recordsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeQueryFixture(t, filepath.Join(recordsDir, "a.yaml"), map[string]any{"qty": 3})
+
+	db := openTestDB(t, dir, def)
+	err := db.RunReadonlyTransaction(context.Background(), func(ctx context.Context, tx dal.ReadTransaction) error {
+		_, qerr := tx.ExecuteQueryToRecordsReader(ctx, peopleQuery())
+		return qerr
+	})
+	if err == nil {
+		t.Fatal("want formula runtime error")
+	}
+	if !strings.Contains(err.Error(), "ratio") {
+		t.Errorf("error should name the ratio column, got: %v", err)
+	}
+}

--- a/pkg/dalgo2fsingitdb/tx_query.go
+++ b/pkg/dalgo2fsingitdb/tx_query.go
@@ -18,34 +18,12 @@ import (
 // slice-backed RecordsReader.
 func executeQueryToRecordsReader(ctx context.Context, r readonlyTx, query dal.Query) (dal.RecordsReader, error) {
 	_ = ctx
-	if r.db.def == nil {
-		return nil, fmt.Errorf("definition is required: use NewLocalDBWithDef")
+	colDef, err := collectionFromQuery(r.db.def, query)
+	if err != nil {
+		return nil, err
 	}
-
-	sq, ok := query.(dal.StructuredQuery)
-	if !ok {
-		return nil, fmt.Errorf("only StructuredQuery is supported")
-	}
-
-	// Extract collection ID from the From clause.
-	fromSrc := sq.From()
-	if fromSrc == nil {
-		return nil, fmt.Errorf("query has no FROM clause")
-	}
-	base := fromSrc.Base()
-	colRef, ok := base.(dal.CollectionRef)
-	if !ok {
-		return nil, fmt.Errorf("FROM source must be a CollectionRef, got %T", base)
-	}
-	collectionID := colRef.Name()
-
-	colDef, exists := r.db.def.Collections[collectionID]
-	if !exists {
-		return nil, fmt.Errorf("collection %q not found in definition", collectionID)
-	}
-	if colDef.RecordFile == nil {
-		return nil, fmt.Errorf("collection %q has no record_file definition", collectionID)
-	}
+	// collectionFromQuery already validated that query is a StructuredQuery.
+	sq, _ := query.(dal.StructuredQuery)
 
 	// Read all records from disk.
 	allRecords, err := readAllRecordsFromDisk(colDef)
@@ -114,7 +92,39 @@ func executeQueryToRecordsReader(ctx context.Context, r readonlyTx, query dal.Qu
 	return newSliceRecordsReader(allRecords), nil
 }
 
-// readAllRecordsFromDisk loads every record in colDef from the filesystem.
+// collectionFromQuery resolves the single collection a structured query reads
+// from, validating the FROM clause and that the collection exists with a record
+// file. Shared by the records-reader and recordset-reader query paths.
+func collectionFromQuery(def *ingitdb.Definition, query dal.Query) (*ingitdb.CollectionDef, error) {
+	if def == nil {
+		return nil, fmt.Errorf("definition is required: use NewLocalDBWithDef")
+	}
+	sq, ok := query.(dal.StructuredQuery)
+	if !ok {
+		return nil, fmt.Errorf("only StructuredQuery is supported")
+	}
+	fromSrc := sq.From()
+	if fromSrc == nil {
+		return nil, fmt.Errorf("query has no FROM clause")
+	}
+	base := fromSrc.Base()
+	colRef, ok := base.(dal.CollectionRef)
+	if !ok {
+		return nil, fmt.Errorf("FROM source must be a CollectionRef, got %T", base)
+	}
+	collectionID := colRef.Name()
+	colDef, exists := def.Collections[collectionID]
+	if !exists {
+		return nil, fmt.Errorf("collection %q not found in definition", collectionID)
+	}
+	if colDef.RecordFile == nil {
+		return nil, fmt.Errorf("collection %q has no record_file definition", collectionID)
+	}
+	return colDef, nil
+}
+
+// readAllRecordsFromDisk loads every record in colDef from the filesystem and
+// eagerly bakes computed columns into each returned dal.Record.
 func readAllRecordsFromDisk(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	switch colDef.RecordFile.RecordType {
 	case ingitdb.SingleRecord:
@@ -126,8 +136,62 @@ func readAllRecordsFromDisk(colDef *ingitdb.CollectionDef) ([]dal.Record, error)
 	}
 }
 
-// readAllSingleRecords globs for all record files and reads each one.
+// readAllSingleRecords reads every single-record file and eagerly bakes computed
+// columns into each returned dal.Record.
 func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
+	stored, err := readAllSingleStored(colDef)
+	if err != nil {
+		return nil, err
+	}
+	return bakeStoredRecords(colDef, stored)
+}
+
+// readAllMapOfRecords reads a map-of-records file and eagerly bakes computed
+// columns into each returned dal.Record.
+func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
+	stored, err := readAllMapStored(colDef)
+	if err != nil {
+		return nil, err
+	}
+	return bakeStoredRecords(colDef, stored)
+}
+
+// bakeStoredRecords eagerly evaluates every computed column for each stored
+// record and returns dal.Records carrying the merged stored+computed map. This
+// is the legacy eager read path consumed by ExecuteQueryToRecordsReader; the
+// recordset path skips it and resolves computed columns lazily instead.
+func bakeStoredRecords(colDef *ingitdb.CollectionDef, stored []dalgo2ingitdb.KeyedStored) ([]dal.Record, error) {
+	records := make([]dal.Record, 0, len(stored))
+	for _, s := range stored {
+		computed, computeErr := dalgo2ingitdb.ApplyFormulasToRead(s.Stored, colDef.Columns, colDef.ID, s.Key)
+		if computeErr != nil {
+			return nil, computeErr
+		}
+		key := dal.NewKeyWithID(colDef.ID, s.Key)
+		rec := dal.NewRecordWithData(key, computed)
+		rec.SetError(nil)
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// readAllStoredRecords reads every record in the collection from disk and
+// returns each one's stored fields, WITHOUT evaluating any computed column.
+func readAllStoredRecords(colDef *ingitdb.CollectionDef) ([]dalgo2ingitdb.KeyedStored, error) {
+	switch colDef.RecordFile.RecordType {
+	case ingitdb.SingleRecord:
+		return readAllSingleStored(colDef)
+	case ingitdb.MapOfRecords:
+		return readAllMapStored(colDef)
+	default:
+		return nil, fmt.Errorf("unsupported record type %q for query", colDef.RecordFile.RecordType)
+	}
+}
+
+// readAllSingleStored globs for all record files and returns each one's stored
+// fields. Single-record files are not locale-normalized here, preserving the
+// existing read behavior.
+func readAllSingleStored(colDef *ingitdb.CollectionDef) ([]dalgo2ingitdb.KeyedStored, error) {
 	nameTemplate := colDef.RecordFile.Name
 	globPattern := strings.ReplaceAll(nameTemplate, "{key}", "*")
 	basePath := filepath.Join(colDef.DirPath, colDef.RecordFile.RecordsBasePath())
@@ -138,7 +202,7 @@ func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 
 	keyExtractor := buildKeyExtractor(nameTemplate)
 
-	records := make([]dal.Record, 0, len(matches))
+	stored := make([]dalgo2ingitdb.KeyedStored, 0, len(matches))
 	for _, match := range matches {
 		if colDef.RecordFile.IsExcluded(filepath.Base(match)) {
 			continue
@@ -166,22 +230,14 @@ func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 		if !found {
 			continue
 		}
-		// Evaluate computed columns before WHERE/ORDER BY so they can be
-		// filtered and sorted exactly like stored columns.
-		computed, computeErr := dalgo2ingitdb.ApplyFormulasToRead(data, colDef.Columns, colDef.ID, recordKey)
-		if computeErr != nil {
-			return nil, computeErr
-		}
-		key := dal.NewKeyWithID(colDef.ID, recordKey)
-		rec := dal.NewRecordWithData(key, computed)
-		rec.SetError(nil)
-		records = append(records, rec)
+		stored = append(stored, dalgo2ingitdb.KeyedStored{Key: recordKey, Stored: data})
 	}
-	return records, nil
+	return stored, nil
 }
 
-// readAllMapOfRecords reads a single map-of-records file and returns all entries.
-func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
+// readAllMapStored reads a single map-of-records file and returns each entry's
+// locale-normalized stored fields.
+func readAllMapStored(colDef *ingitdb.CollectionDef) ([]dalgo2ingitdb.KeyedStored, error) {
 	path := resolveRecordPath(colDef, "")
 	allData, found, err := readMapOfRecordsFile(path, colDef.RecordFile.Format)
 	if err != nil {
@@ -190,19 +246,12 @@ func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	if !found {
 		return nil, nil
 	}
-	records := make([]dal.Record, 0, len(allData))
+	stored := make([]dalgo2ingitdb.KeyedStored, 0, len(allData))
 	for id, fields := range allData {
 		normalized := dalgo2ingitdb.ApplyLocaleToRead(fields, colDef.Columns)
-		computed, computeErr := dalgo2ingitdb.ApplyFormulasToRead(normalized, colDef.Columns, colDef.ID, id)
-		if computeErr != nil {
-			return nil, computeErr
-		}
-		key := dal.NewKeyWithID(colDef.ID, id)
-		rec := dal.NewRecordWithData(key, computed)
-		rec.SetError(nil)
-		records = append(records, rec)
+		stored = append(stored, dalgo2ingitdb.KeyedStored{Key: id, Stored: normalized})
 	}
-	return records, nil
+	return stored, nil
 }
 
 // buildKeyExtractor creates a function that extracts the record key from a path

--- a/pkg/dalgo2fsingitdb/tx_query.go
+++ b/pkg/dalgo2fsingitdb/tx_query.go
@@ -136,7 +136,7 @@ func readAllRecordsFromDisk(colDef *ingitdb.CollectionDef) ([]dal.Record, error)
 	}
 }
 
-// readAllSingleRecords reads every single-record file and eagerly bakes computed
+// readAllSingleRecords reads every single-record file and bakes computed
 // columns into each returned dal.Record.
 func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	stored, err := readAllSingleStored(colDef)
@@ -146,8 +146,8 @@ func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	return bakeStoredRecords(colDef, stored)
 }
 
-// readAllMapOfRecords reads a map-of-records file and eagerly bakes computed
-// columns into each returned dal.Record.
+// readAllMapOfRecords reads a map-of-records file and bakes computed columns
+// into each returned dal.Record.
 func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	stored, err := readAllMapStored(colDef)
 	if err != nil {
@@ -156,10 +156,14 @@ func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	return bakeStoredRecords(colDef, stored)
 }
 
-// bakeStoredRecords eagerly evaluates every computed column for each stored
-// record and returns dal.Records carrying the merged stored+computed map. This
-// is the legacy eager read path consumed by ExecuteQueryToRecordsReader; the
-// recordset path skips it and resolves computed columns lazily instead.
+// bakeStoredRecords evaluates every computed column for each stored record and
+// returns dal.Records carrying the merged stored+computed map.
+//
+// This is NOT on the read path of the select/delete/update/TUI consumers — those
+// resolve computed values lazily via ExecuteQueryToRecordsetReader. It is
+// retained for the write-time computed-foreign-key validation (Set/Delete),
+// which is explicitly out of scope for the lazy migration and must keep
+// evaluating computed FK columns to enforce referential integrity.
 func bakeStoredRecords(colDef *ingitdb.CollectionDef, stored []dalgo2ingitdb.KeyedStored) ([]dal.Record, error) {
 	records := make([]dal.Record, 0, len(stored))
 	for _, s := range stored {

--- a/pkg/dalgo2fsingitdb/tx_readonly.go
+++ b/pkg/dalgo2fsingitdb/tx_readonly.go
@@ -94,7 +94,19 @@ func (r readonlyTx) ExecuteQueryToRecordsReader(ctx context.Context, query dal.Q
 	return executeQueryToRecordsReader(ctx, r, query)
 }
 
-func (r readonlyTx) ExecuteQueryToRecordsetReader(ctx context.Context, query dal.Query, options ...recordset.Option) (dal.RecordsetReader, error) {
-	//TODO implement me
-	panic("implement me")
+// ExecuteQueryToRecordsetReader executes a structured query against a single
+// collection and returns a recordset-shaped reader. Stored columns carry each
+// record's value; computed (formula) columns are registered via
+// recordset.NewComputedColumn bound to a Starlark-backed evaluator, so computed
+// values resolve lazily when a consumer reads them rather than being baked in.
+func (r readonlyTx) ExecuteQueryToRecordsetReader(_ context.Context, query dal.Query, _ ...recordset.Option) (dal.RecordsetReader, error) {
+	colDef, err := collectionFromQuery(r.db.def, query)
+	if err != nil {
+		return nil, err
+	}
+	stored, err := readAllStoredRecords(colDef)
+	if err != nil {
+		return nil, err
+	}
+	return dalgo2ingitdb.NewRecordsetReader(dalgo2ingitdb.BuildRecordset(colDef, stored)), nil
 }

--- a/pkg/dalgo2fsingitdb/tx_readonly_test.go
+++ b/pkg/dalgo2fsingitdb/tx_readonly_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/dal-go/dalgo/dal"
-	"github.com/dal-go/dalgo/recordset"
 )
 
 func TestReadonlyTx_Panics(t *testing.T) {
@@ -14,9 +13,7 @@ func TestReadonlyTx_Panics(t *testing.T) {
 	tx := readonlyTx{db: localDB{rootDirPath: "/tmp/root"}}
 	ctx := context.Background()
 	var key *dal.Key
-	var query dal.Query
 	var records []dal.Record
-	var options []recordset.Option
 
 	tests := []struct {
 		name string
@@ -39,13 +36,6 @@ func TestReadonlyTx_Panics(t *testing.T) {
 			name: "get_multi",
 			fn: func() {
 				err := tx.GetMulti(ctx, records)
-				_ = err
-			},
-		},
-		{
-			name: "execute_query_recordset_reader",
-			fn: func() {
-				_, err := tx.ExecuteQueryToRecordsetReader(ctx, query, options...)
 				_ = err
 			},
 		},

--- a/pkg/dalgo2ingitdb/accessor.go
+++ b/pkg/dalgo2ingitdb/accessor.go
@@ -35,3 +35,54 @@ func AccessValue(row recordset.Row, rs recordset.Recordset, collectionID, record
 	}
 	return coerced, nil
 }
+
+// RowData reads the named columns of a recordset row through AccessValue and
+// returns them as a map, omitting nil values so the result matches the ragged
+// record map the eager pipeline produced (absent fields were never keys). Only
+// the requested columns are read, so an unreferenced computed column is never
+// evaluated; a referenced computed column that errors surfaces fail-loud.
+func RowData(row recordset.Row, rs recordset.Recordset, collectionID, recordKey string, colDef *ingitdb.CollectionDef, names []string) (map[string]any, error) {
+	data := make(map[string]any, len(names))
+	for _, name := range names {
+		v, err := AccessValue(row, rs, collectionID, recordKey, name, colDef.Columns[name])
+		if err != nil {
+			return nil, err
+		}
+		if v == nil {
+			continue
+		}
+		data[name] = v
+	}
+	return data, nil
+}
+
+// AllColumnNames returns every column name of rs except the reserved IDColumn.
+func AllColumnNames(rs recordset.Recordset) []string {
+	cols := rs.Columns()
+	names := make([]string, 0, len(cols))
+	for _, col := range cols {
+		if col.Name() == IDColumn {
+			continue
+		}
+		names = append(names, col.Name())
+	}
+	return names
+}
+
+// StoredColumnNames returns the stored (non-computed) column names of rs except
+// the reserved IDColumn. Used by write consumers that must persist stored fields
+// only, never computed values.
+func StoredColumnNames(rs recordset.Recordset) []string {
+	cols := rs.Columns()
+	names := make([]string, 0, len(cols))
+	for _, col := range cols {
+		if col.Name() == IDColumn {
+			continue
+		}
+		if _, computed := col.(recordset.ComputedColumn); computed {
+			continue
+		}
+		names = append(names, col.Name())
+	}
+	return names
+}

--- a/pkg/dalgo2ingitdb/accessor.go
+++ b/pkg/dalgo2ingitdb/accessor.go
@@ -1,0 +1,37 @@
+package dalgo2ingitdb
+
+import (
+	"fmt"
+
+	"github.com/dal-go/dalgo/recordset"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// AccessValue reads colName from a recordset row — the single coerce-on-access
+// path every read consumer (select/delete/update/TUI) uses.
+//
+// For a computed (formula) column the raw evaluator result is coerced to the
+// column's declared ColumnType via coerceFormulaResult, so typed results stay
+// identical to the eager ApplyFormulasToRead pipeline. A stored column's value
+// (colDef nil or no Formula) is returned unchanged — the eager pipeline never
+// coerced stored values, so neither do we.
+//
+// Because computation is lazy, evaluation happens here, on access. Any evaluator
+// or coercion error is wrapped with the collection, record key, and column, so
+// the failure is fail-loud and names its source (matching the eager pipeline's
+// error format).
+func AccessValue(row recordset.Row, rs recordset.Recordset, collectionID, recordKey, colName string, colDef *ingitdb.ColumnDef) (any, error) {
+	raw, err := row.GetValueByName(colName, rs)
+	if err != nil {
+		return nil, fmt.Errorf("collection %q record %q column %q: %w", collectionID, recordKey, colName, err)
+	}
+	if colDef == nil || colDef.Formula == "" {
+		return raw, nil
+	}
+	coerced, err := coerceFormulaResult(raw, colDef.Type)
+	if err != nil {
+		return nil, fmt.Errorf("collection %q record %q column %q: %w", collectionID, recordKey, colName, err)
+	}
+	return coerced, nil
+}

--- a/pkg/dalgo2ingitdb/accessor_test.go
+++ b/pkg/dalgo2ingitdb/accessor_test.go
@@ -105,6 +105,68 @@ func TestAccessValue_NilColDefPassesThrough(t *testing.T) {
 	}
 }
 
+func TestRowData(t *testing.T) {
+	t.Parallel()
+	records := []KeyedStored{{Key: "o1", Stored: map[string]any{"qty": int64(3), "price": int64(4)}}}
+	rs := BuildRecordset(ordersColDef(), records)
+	row := rs.GetRow(0)
+	// Read a stored column and a computed column.
+	data, err := RowData(row, rs, "orders", "o1", ordersColDef(), []string{"qty", "total"})
+	if err != nil {
+		t.Fatalf("RowData: %v", err)
+	}
+	if data["qty"] != int64(3) || data["total"] != int64(12) {
+		t.Errorf("data = %#v, want qty=3 total=12", data)
+	}
+
+	// An absent stored column resolves to nil and is omitted from the map.
+	sparse := BuildRecordset(ordersColDef(), []KeyedStored{{Key: "o2", Stored: map[string]any{"qty": int64(3)}}})
+	sparseData, err := RowData(sparse.GetRow(0), sparse, "orders", "o2", ordersColDef(), []string{"qty", "price"})
+	if err != nil {
+		t.Fatalf("RowData sparse: %v", err)
+	}
+	if _, ok := sparseData["price"]; ok {
+		t.Errorf("absent price must be omitted, got %#v", sparseData)
+	}
+	if sparseData["qty"] != int64(3) {
+		t.Errorf("qty = %#v, want 3", sparseData["qty"])
+	}
+
+	// An erroring computed column propagates.
+	if _, err := RowData(row, rs, "orders", "o1", ordersColDef(), []string{"ratio"}); err == nil {
+		t.Error("RowData should propagate the erroring computed column")
+	}
+}
+
+func TestColumnNameHelpers(t *testing.T) {
+	t.Parallel()
+	rs := BuildRecordset(ordersColDef(), []KeyedStored{{Key: "o1", Stored: map[string]any{"qty": int64(3)}}})
+	all := AllColumnNames(rs)
+	stored := StoredColumnNames(rs)
+	for _, name := range append(all, stored...) {
+		if name == IDColumn {
+			t.Errorf("%s must be excluded", IDColumn)
+		}
+	}
+	has := func(names []string, want string) bool {
+		for _, n := range names {
+			if n == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !has(all, "total") {
+		t.Error("AllColumnNames should include the computed column total")
+	}
+	if has(stored, "total") {
+		t.Error("StoredColumnNames must exclude the computed column total")
+	}
+	if !has(stored, "qty") {
+		t.Error("StoredColumnNames should include the stored column qty")
+	}
+}
+
 // An unknown column name surfaces a wrapped, fail-loud error.
 func TestAccessValue_UnknownColumnFailsLoud(t *testing.T) {
 	t.Parallel()

--- a/pkg/dalgo2ingitdb/accessor_test.go
+++ b/pkg/dalgo2ingitdb/accessor_test.go
@@ -1,0 +1,121 @@
+package dalgo2ingitdb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// ordersColDef has stored qty/price (ints) plus computed columns: total
+// (qty*price, int), ratio (qty/0, int — raises at runtime) and bad (a string
+// literal declared as int — coercion mismatch).
+func ordersColDef() *ingitdb.CollectionDef {
+	return &ingitdb.CollectionDef{
+		ID: "orders",
+		Columns: map[string]*ingitdb.ColumnDef{
+			"qty":   {Type: ingitdb.ColumnTypeInt},
+			"price": {Type: ingitdb.ColumnTypeInt},
+			"total": {Type: ingitdb.ColumnTypeInt, Formula: "qty * price"},
+			"ratio": {Type: ingitdb.ColumnTypeInt, Formula: "qty / 0"},
+			"bad":   {Type: ingitdb.ColumnTypeInt, Formula: `"not an int"`},
+		},
+		ColumnsOrder: []string{"qty", "price", "total", "ratio", "bad"},
+	}
+}
+
+// AC: type-coercion-preserved — an int computed column reads back as int64, not
+// float, exactly like the eager pipeline.
+func TestAccessValue_TypeCoercionPreserved(t *testing.T) {
+	t.Parallel()
+	records := []KeyedStored{{Key: "o1", Stored: map[string]any{"qty": int64(3), "price": int64(4)}}}
+	rs := BuildRecordset(ordersColDef(), records)
+	row := rs.GetRow(0)
+	got, err := AccessValue(row, rs, "orders", "o1", "total", ordersColDef().Columns["total"])
+	if err != nil {
+		t.Fatalf("AccessValue(total): %v", err)
+	}
+	if got != int64(12) {
+		t.Errorf("total = %#v, want int64(12)", got)
+	}
+}
+
+// AC: referenced-erroring-column-fails-loud — reading a computed column whose
+// formula raises aborts with an error naming collection, record key, and column.
+func TestAccessValue_ReferencedErroringColumnFailsLoud(t *testing.T) {
+	t.Parallel()
+	records := []KeyedStored{{Key: "o1", Stored: map[string]any{"qty": int64(3), "price": int64(4)}}}
+	rs := BuildRecordset(ordersColDef(), records)
+	row := rs.GetRow(0)
+	_, err := AccessValue(row, rs, "orders", "o1", "ratio", ordersColDef().Columns["ratio"])
+	if err == nil {
+		t.Fatal("want fail-loud error for erroring computed column")
+	}
+	for _, want := range []string{`collection "orders"`, `record "o1"`, `column "ratio"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// A computed result that cannot be coerced to the declared type fails loud too.
+func TestAccessValue_CoercionMismatchFailsLoud(t *testing.T) {
+	t.Parallel()
+	records := []KeyedStored{{Key: "o1", Stored: map[string]any{"qty": int64(3), "price": int64(4)}}}
+	rs := BuildRecordset(ordersColDef(), records)
+	row := rs.GetRow(0)
+	_, err := AccessValue(row, rs, "orders", "o1", "bad", ordersColDef().Columns["bad"])
+	if err == nil {
+		t.Fatal("want coercion-mismatch error")
+	}
+	if !strings.Contains(err.Error(), `column "bad"`) {
+		t.Errorf("error %q should name the bad column", err.Error())
+	}
+}
+
+// A stored column's value is returned unchanged — never run through
+// coerceFormulaResult (which would reject a Go int for an int column).
+func TestAccessValue_StoredValuePassesThroughUncoerced(t *testing.T) {
+	t.Parallel()
+	records := []KeyedStored{{Key: "o1", Stored: map[string]any{"qty": int(3)}}}
+	rs := BuildRecordset(ordersColDef(), records)
+	row := rs.GetRow(0)
+	got, err := AccessValue(row, rs, "orders", "o1", "qty", ordersColDef().Columns["qty"])
+	if err != nil {
+		t.Fatalf("AccessValue(qty): %v", err)
+	}
+	if got != int(3) {
+		t.Errorf("qty = %#v, want int(3) unchanged", got)
+	}
+}
+
+// A nil colDef (e.g. the reserved $id column or an undeclared stored field) is
+// passed through without coercion.
+func TestAccessValue_NilColDefPassesThrough(t *testing.T) {
+	t.Parallel()
+	records := []KeyedStored{{Key: "o1", Stored: map[string]any{"qty": int64(3)}}}
+	rs := BuildRecordset(ordersColDef(), records)
+	row := rs.GetRow(0)
+	got, err := AccessValue(row, rs, "orders", "o1", idColumnName, nil)
+	if err != nil {
+		t.Fatalf("AccessValue($id): %v", err)
+	}
+	if got != "o1" {
+		t.Errorf("$id = %#v, want \"o1\"", got)
+	}
+}
+
+// An unknown column name surfaces a wrapped, fail-loud error.
+func TestAccessValue_UnknownColumnFailsLoud(t *testing.T) {
+	t.Parallel()
+	records := []KeyedStored{{Key: "o1", Stored: map[string]any{"qty": int64(3)}}}
+	rs := BuildRecordset(ordersColDef(), records)
+	row := rs.GetRow(0)
+	_, err := AccessValue(row, rs, "orders", "o1", "nope", nil)
+	if err == nil {
+		t.Fatal("want error for unknown column")
+	}
+	if !strings.Contains(err.Error(), `column "nope"`) {
+		t.Errorf("error %q should name the unknown column", err.Error())
+	}
+}

--- a/pkg/dalgo2ingitdb/accessor_test.go
+++ b/pkg/dalgo2ingitdb/accessor_test.go
@@ -96,7 +96,7 @@ func TestAccessValue_NilColDefPassesThrough(t *testing.T) {
 	records := []KeyedStored{{Key: "o1", Stored: map[string]any{"qty": int64(3)}}}
 	rs := BuildRecordset(ordersColDef(), records)
 	row := rs.GetRow(0)
-	got, err := AccessValue(row, rs, "orders", "o1", idColumnName, nil)
+	got, err := AccessValue(row, rs, "orders", "o1", IDColumn, nil)
 	if err != nil {
 		t.Fatalf("AccessValue($id): %v", err)
 	}

--- a/pkg/dalgo2ingitdb/coverage_gaps_test.go
+++ b/pkg/dalgo2ingitdb/coverage_gaps_test.go
@@ -168,12 +168,12 @@ func TestReadonlyTx_Options(t *testing.T) {
 	_ = tx.Options() // just confirm it doesn't panic
 }
 
-func TestReadonlyTx_ExecuteQueryToRecordsetReader_NotSupported(t *testing.T) {
+func TestReadonlyTx_ExecuteQueryToRecordsetReader_NoDefinition(t *testing.T) {
 	t.Parallel()
 	tx := readonlyTx{}
 	_, err := tx.ExecuteQueryToRecordsetReader(context.Background(), nil)
 	if err == nil {
-		t.Fatal("want error")
+		t.Fatal("want error when the transaction has no loaded definition")
 	}
 }
 

--- a/pkg/dalgo2ingitdb/query.go
+++ b/pkg/dalgo2ingitdb/query.go
@@ -18,30 +18,12 @@ import (
 // and returns a slice-backed RecordsReader. Mirrors the algorithm in
 // dalgo2fsingitdb but uses this package's locked record I/O helpers.
 func executeQueryToRecordsReader(_ context.Context, r readonlyTx, query dal.Query) (dal.RecordsReader, error) {
-	if r.def == nil {
-		return nil, fmt.Errorf("dalgo2ingitdb: transaction has no loaded definition")
+	colDef, err := collectionFromQuery(r.def, query)
+	if err != nil {
+		return nil, err
 	}
-	sq, ok := query.(dal.StructuredQuery)
-	if !ok {
-		return nil, fmt.Errorf("dalgo2ingitdb: only StructuredQuery is supported, got %T", query)
-	}
-	fromSrc := sq.From()
-	if fromSrc == nil {
-		return nil, fmt.Errorf("dalgo2ingitdb: query has no FROM clause")
-	}
-	base := fromSrc.Base()
-	colRef, ok := base.(dal.CollectionRef)
-	if !ok {
-		return nil, fmt.Errorf("dalgo2ingitdb: FROM source must be a CollectionRef, got %T", base)
-	}
-	collectionID := colRef.Name()
-	colDef, exists := r.def.Collections[collectionID]
-	if !exists {
-		return nil, fmt.Errorf("dalgo2ingitdb: collection %q not found in definition", collectionID)
-	}
-	if colDef.RecordFile == nil {
-		return nil, fmt.Errorf("dalgo2ingitdb: collection %q has no record_file definition", collectionID)
-	}
+	// collectionFromQuery already validated that query is a StructuredQuery.
+	sq, _ := query.(dal.StructuredQuery)
 
 	records, err := readAllRecordsFromDisk(colDef)
 	if err != nil {
@@ -63,6 +45,37 @@ func executeQueryToRecordsReader(_ context.Context, r readonlyTx, query dal.Quer
 	return newSliceRecordsReader(records), nil
 }
 
+// collectionFromQuery resolves the single collection a structured query reads
+// from, validating the FROM clause and that the collection exists with a record
+// file. Shared by the records-reader and recordset-reader query paths.
+func collectionFromQuery(def *ingitdb.Definition, query dal.Query) (*ingitdb.CollectionDef, error) {
+	if def == nil {
+		return nil, fmt.Errorf("dalgo2ingitdb: transaction has no loaded definition")
+	}
+	sq, ok := query.(dal.StructuredQuery)
+	if !ok {
+		return nil, fmt.Errorf("dalgo2ingitdb: only StructuredQuery is supported, got %T", query)
+	}
+	fromSrc := sq.From()
+	if fromSrc == nil {
+		return nil, fmt.Errorf("dalgo2ingitdb: query has no FROM clause")
+	}
+	base := fromSrc.Base()
+	colRef, ok := base.(dal.CollectionRef)
+	if !ok {
+		return nil, fmt.Errorf("dalgo2ingitdb: FROM source must be a CollectionRef, got %T", base)
+	}
+	collectionID := colRef.Name()
+	colDef, exists := def.Collections[collectionID]
+	if !exists {
+		return nil, fmt.Errorf("dalgo2ingitdb: collection %q not found in definition", collectionID)
+	}
+	if colDef.RecordFile == nil {
+		return nil, fmt.Errorf("dalgo2ingitdb: collection %q has no record_file definition", collectionID)
+	}
+	return colDef, nil
+}
+
 func readAllRecordsFromDisk(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	switch colDef.RecordFile.RecordType {
 	case ingitdb.SingleRecord:
@@ -74,7 +87,60 @@ func readAllRecordsFromDisk(colDef *ingitdb.CollectionDef) ([]dal.Record, error)
 	}
 }
 
+// readAllSingleRecords reads every single-record file and eagerly bakes computed
+// columns into each returned dal.Record.
 func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
+	stored, err := readAllSingleStored(colDef)
+	if err != nil {
+		return nil, err
+	}
+	return bakeStoredRecords(colDef, stored)
+}
+
+// readAllMapOfRecords reads a map-of-records file and eagerly bakes computed
+// columns into each returned dal.Record.
+func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
+	stored, err := readAllMapStored(colDef)
+	if err != nil {
+		return nil, err
+	}
+	return bakeStoredRecords(colDef, stored)
+}
+
+// bakeStoredRecords eagerly evaluates every computed column for each stored
+// record and returns dal.Records carrying the merged stored+computed map. This
+// is the legacy eager read path consumed by ExecuteQueryToRecordsReader; the
+// recordset path skips it and resolves computed columns lazily instead.
+func bakeStoredRecords(colDef *ingitdb.CollectionDef, stored []KeyedStored) ([]dal.Record, error) {
+	records := make([]dal.Record, 0, len(stored))
+	for _, s := range stored {
+		computed, computeErr := ApplyFormulasToRead(s.Stored, colDef.Columns, colDef.ID, s.Key)
+		if computeErr != nil {
+			return nil, computeErr
+		}
+		key := dal.NewKeyWithID(colDef.ID, s.Key)
+		rec := dal.NewRecordWithData(key, computed)
+		rec.SetError(nil)
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// readAllStoredRecords reads every record in the collection from disk and
+// returns each one's locale-normalized stored fields, WITHOUT evaluating any
+// computed column.
+func readAllStoredRecords(colDef *ingitdb.CollectionDef) ([]KeyedStored, error) {
+	switch colDef.RecordFile.RecordType {
+	case ingitdb.SingleRecord:
+		return readAllSingleStored(colDef)
+	case ingitdb.MapOfRecords:
+		return readAllMapStored(colDef)
+	default:
+		return nil, fmt.Errorf("dalgo2ingitdb: query unsupported for record type %q", colDef.RecordFile.RecordType)
+	}
+}
+
+func readAllSingleStored(colDef *ingitdb.CollectionDef) ([]KeyedStored, error) {
 	nameTemplate := colDef.RecordFile.Name
 	globPattern := strings.ReplaceAll(nameTemplate, "{key}", "*")
 	basePath := filepath.Join(colDef.DirPath, colDef.RecordFile.RecordsBasePath())
@@ -86,7 +152,7 @@ func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	records := make([]dal.Record, 0, len(matches))
+	stored := make([]KeyedStored, 0, len(matches))
 	for _, match := range matches {
 		if colDef.RecordFile.IsExcluded(filepath.Base(match)) {
 			continue
@@ -107,37 +173,23 @@ func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 			continue
 		}
 		normalized := ApplyLocaleToRead(data, colDef.Columns)
-		computed, computeErr := ApplyFormulasToRead(normalized, colDef.Columns, colDef.ID, recordKey)
-		if computeErr != nil {
-			return nil, computeErr
-		}
-		key := dal.NewKeyWithID(colDef.ID, recordKey)
-		rec := dal.NewRecordWithData(key, computed)
-		rec.SetError(nil)
-		records = append(records, rec)
+		stored = append(stored, KeyedStored{Key: recordKey, Stored: normalized})
 	}
-	return records, nil
+	return stored, nil
 }
 
-func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
+func readAllMapStored(colDef *ingitdb.CollectionDef) ([]KeyedStored, error) {
 	path := resolveRecordPath(colDef, "")
 	allData, err := readMapOfRecordsFile(path, colDef.RecordFile.Format)
 	if err != nil {
 		return nil, err
 	}
-	records := make([]dal.Record, 0, len(allData))
+	stored := make([]KeyedStored, 0, len(allData))
 	for id, fields := range allData {
 		normalized := ApplyLocaleToRead(fields, colDef.Columns)
-		computed, computeErr := ApplyFormulasToRead(normalized, colDef.Columns, colDef.ID, id)
-		if computeErr != nil {
-			return nil, computeErr
-		}
-		key := dal.NewKeyWithID(colDef.ID, id)
-		rec := dal.NewRecordWithData(key, computed)
-		rec.SetError(nil)
-		records = append(records, rec)
+		stored = append(stored, KeyedStored{Key: id, Stored: normalized})
 	}
-	return records, nil
+	return stored, nil
 }
 
 // buildKeyExtractor returns a function that recovers the record key from

--- a/pkg/dalgo2ingitdb/query.go
+++ b/pkg/dalgo2ingitdb/query.go
@@ -87,7 +87,7 @@ func readAllRecordsFromDisk(colDef *ingitdb.CollectionDef) ([]dal.Record, error)
 	}
 }
 
-// readAllSingleRecords reads every single-record file and eagerly bakes computed
+// readAllSingleRecords reads every single-record file and bakes computed
 // columns into each returned dal.Record.
 func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	stored, err := readAllSingleStored(colDef)
@@ -97,8 +97,8 @@ func readAllSingleRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	return bakeStoredRecords(colDef, stored)
 }
 
-// readAllMapOfRecords reads a map-of-records file and eagerly bakes computed
-// columns into each returned dal.Record.
+// readAllMapOfRecords reads a map-of-records file and bakes computed columns
+// into each returned dal.Record.
 func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	stored, err := readAllMapStored(colDef)
 	if err != nil {
@@ -107,10 +107,14 @@ func readAllMapOfRecords(colDef *ingitdb.CollectionDef) ([]dal.Record, error) {
 	return bakeStoredRecords(colDef, stored)
 }
 
-// bakeStoredRecords eagerly evaluates every computed column for each stored
-// record and returns dal.Records carrying the merged stored+computed map. This
-// is the legacy eager read path consumed by ExecuteQueryToRecordsReader; the
-// recordset path skips it and resolves computed columns lazily instead.
+// bakeStoredRecords evaluates every computed column for each stored record and
+// returns dal.Records carrying the merged stored+computed map.
+//
+// This is NOT on the read path of the select/delete/update/TUI consumers — those
+// resolve computed values lazily via ExecuteQueryToRecordsetReader. It is
+// retained for the write-time computed-foreign-key validation (Set/Delete),
+// which is explicitly out of scope for the lazy migration and must keep
+// evaluating computed FK columns to enforce referential integrity.
 func bakeStoredRecords(colDef *ingitdb.CollectionDef, stored []KeyedStored) ([]dal.Record, error) {
 	records := make([]dal.Record, 0, len(stored))
 	for _, s := range stored {

--- a/pkg/dalgo2ingitdb/recordset.go
+++ b/pkg/dalgo2ingitdb/recordset.go
@@ -1,0 +1,185 @@
+package dalgo2ingitdb
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/recordset"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// idColumnName is the reserved recordset column that carries each record's key.
+// It is not a declared schema column; the Starlark evaluator strips it from the
+// stored field map so formula inputs match the eager ApplyFormulasToRead
+// pipeline exactly. The "$id" spelling mirrors the dal pseudo-field convention
+// and cannot collide with a real column (Starlark identifiers cannot contain
+// "$", so no formula can reference it).
+const idColumnName = "$id"
+
+// formulaEvaluator is a recordset.Evaluator that computes a computed column's
+// value by delegating to ingitdb.EvaluateFormula. dalgo carries no scripting
+// dependency: the Starlark engine, its sandbox, and schema-load-time validation
+// remain entirely in ingitdb.
+type formulaEvaluator struct {
+	formula string
+}
+
+var _ recordset.Evaluator = formulaEvaluator{}
+
+// Eval evaluates the formula against the row's stored sibling values. The
+// reserved idColumnName entry is removed first so the field set handed to
+// Starlark is identical to the eager pipeline's (which never carried "$id").
+func (e formulaEvaluator) Eval(stored map[string]any) (any, error) {
+	fields := stored
+	if _, ok := stored[idColumnName]; ok {
+		fields = make(map[string]any, len(stored))
+		for k, v := range stored {
+			if k == idColumnName {
+				continue
+			}
+			fields[k] = v
+		}
+	}
+	return ingitdb.EvaluateFormula(e.formula, fields)
+}
+
+// anyColumn is a recordset.Column[any] that stores arbitrary per-row values,
+// including nil. dalgo's UntypedColWrapper[any] cannot back a stored column here
+// because its Add rejects a nil interface value (the assertion value.(any) is
+// false for an untyped nil), so a nil/absent stored field would fail to grow the
+// column on NewRow. anyColumn appends unconditionally.
+type anyColumn struct {
+	name   string
+	values []any
+}
+
+var _ recordset.Column[any] = (*anyColumn)(nil)
+
+func (c *anyColumn) Name() string      { return c.name }
+func (c *anyColumn) DefaultValue() any { return nil }
+func (c *anyColumn) DbType() string    { return "" }
+func (c *anyColumn) IsBitmap() bool    { return false }
+func (c *anyColumn) ValueType() reflect.Type {
+	return reflect.TypeFor[any]()
+}
+
+func (c *anyColumn) Add(value any) error {
+	c.values = append(c.values, value)
+	return nil
+}
+
+func (c *anyColumn) GetValue(row int) (any, error) {
+	if row < 0 || row >= len(c.values) {
+		return nil, fmt.Errorf("row %d out of range for %d rows", row, len(c.values))
+	}
+	return c.values[row], nil
+}
+
+func (c *anyColumn) SetValue(row int, value any) error {
+	if row < 0 || row >= len(c.values) {
+		return fmt.Errorf("row %d out of range for %d rows", row, len(c.values))
+	}
+	c.values[row] = value
+	return nil
+}
+
+func (c *anyColumn) Values() []any {
+	out := make([]any, len(c.values))
+	copy(out, c.values)
+	return out
+}
+
+// KeyedStored pairs a record key with its locale-normalized stored fields. The
+// stored map holds only stored (non-computed) values; computed columns are
+// resolved lazily through the recordset, never baked in here.
+type KeyedStored struct {
+	Key    string
+	Stored map[string]any
+}
+
+// BuildRecordset assembles a recordset.Recordset for a collection: a reserved
+// "$id" column carrying each record key, one ordinary column per stored
+// (non-formula) column carrying the per-record stored value, and one
+// recordset.NewComputedColumn per formula column bound to a Starlark-backed
+// evaluator. Computed values are never evaluated here — they resolve lazily,
+// at most once per row, when a consumer reads them.
+func BuildRecordset(colDef *ingitdb.CollectionDef, records []KeyedStored) recordset.Recordset {
+	return buildRecordset(colDef, records, func(formula string) recordset.Evaluator {
+		return formulaEvaluator{formula: formula}
+	})
+}
+
+// buildRecordset is BuildRecordset with an injectable evaluator factory so tests
+// can substitute a counting evaluator to prove lazy, once-per-row resolution.
+func buildRecordset(colDef *ingitdb.CollectionDef, records []KeyedStored, evalFor func(formula string) recordset.Evaluator) recordset.Recordset {
+	storedNames := orderedColumns(colDef, func(c *ingitdb.ColumnDef) bool { return c.Formula == "" })
+	computedNames := orderedComputedColumns(colDef)
+
+	cols := make([]recordset.Column[any], 0, len(storedNames)+len(computedNames)+1)
+	cols = append(cols, &anyColumn{name: idColumnName})
+	storedSet := make(map[string]bool, len(storedNames))
+	for _, name := range storedNames {
+		cols = append(cols, &anyColumn{name: name})
+		storedSet[name] = true
+	}
+	for _, name := range computedNames {
+		cols = append(cols, recordset.NewComputedColumn(name, evalFor(colDef.Columns[name].Formula)))
+	}
+
+	rs := recordset.NewColumnarRecordset(colDef.ID, cols...)
+	for _, rec := range records {
+		row := rs.NewRow()
+		// SetValueByName on a stored column cannot fail here: every column was
+		// added above and the column value type is any, so the type assertion
+		// inside the recordset always succeeds.
+		_ = row.SetValueByName(idColumnName, rec.Key, rs)
+		for name, value := range rec.Stored {
+			if !storedSet[name] {
+				continue
+			}
+			_ = row.SetValueByName(name, value, rs)
+		}
+	}
+	return rs
+}
+
+// recordsetReader is a slice-backed dal.RecordsetReader over a prebuilt
+// recordset. Rows are yielded in insertion order.
+type recordsetReader struct {
+	rs    recordset.Recordset
+	index int
+}
+
+var _ dal.RecordsetReader = (*recordsetReader)(nil)
+
+// NewRecordsetReader returns a dal.RecordsetReader that walks the rows of rs.
+func NewRecordsetReader(rs recordset.Recordset) dal.RecordsetReader {
+	return &recordsetReader{rs: rs}
+}
+
+// Recordset returns the underlying recordset.
+func (r *recordsetReader) Recordset() recordset.Recordset {
+	return r.rs
+}
+
+// Next yields the next row, or dal.ErrNoMoreRecords when the rows are exhausted.
+func (r *recordsetReader) Next() (recordset.Row, recordset.Recordset, error) {
+	if r.index >= r.rs.RowsCount() {
+		return nil, r.rs, dal.ErrNoMoreRecords
+	}
+	row := r.rs.GetRow(r.index)
+	r.index++
+	return row, r.rs, nil
+}
+
+// Cursor is not supported; the reader returns the full result set eagerly.
+func (r *recordsetReader) Cursor() (string, error) {
+	return "", nil
+}
+
+// Close is a no-op: the reader holds an in-memory recordset.
+func (r *recordsetReader) Close() error {
+	return nil
+}

--- a/pkg/dalgo2ingitdb/recordset.go
+++ b/pkg/dalgo2ingitdb/recordset.go
@@ -3,6 +3,7 @@ package dalgo2ingitdb
 import (
 	"fmt"
 	"reflect"
+	"sort"
 
 	"github.com/dal-go/dalgo/dal"
 	"github.com/dal-go/dalgo/recordset"
@@ -10,13 +11,13 @@ import (
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
 
-// idColumnName is the reserved recordset column that carries each record's key.
+// IDColumn is the reserved recordset column that carries each record's key.
 // It is not a declared schema column; the Starlark evaluator strips it from the
 // stored field map so formula inputs match the eager ApplyFormulasToRead
 // pipeline exactly. The "$id" spelling mirrors the dal pseudo-field convention
 // and cannot collide with a real column (Starlark identifiers cannot contain
 // "$", so no formula can reference it).
-const idColumnName = "$id"
+const IDColumn = "$id"
 
 // formulaEvaluator is a recordset.Evaluator that computes a computed column's
 // value by delegating to ingitdb.EvaluateFormula. dalgo carries no scripting
@@ -29,14 +30,14 @@ type formulaEvaluator struct {
 var _ recordset.Evaluator = formulaEvaluator{}
 
 // Eval evaluates the formula against the row's stored sibling values. The
-// reserved idColumnName entry is removed first so the field set handed to
+// reserved IDColumn entry is removed first so the field set handed to
 // Starlark is identical to the eager pipeline's (which never carried "$id").
 func (e formulaEvaluator) Eval(stored map[string]any) (any, error) {
 	fields := stored
-	if _, ok := stored[idColumnName]; ok {
+	if _, ok := stored[IDColumn]; ok {
 		fields = make(map[string]any, len(stored))
 		for k, v := range stored {
-			if k == idColumnName {
+			if k == IDColumn {
 				continue
 			}
 			fields[k] = v
@@ -117,10 +118,37 @@ func buildRecordset(colDef *ingitdb.CollectionDef, records []KeyedStored, evalFo
 	storedNames := orderedColumns(colDef, func(c *ingitdb.ColumnDef) bool { return c.Formula == "" })
 	computedNames := orderedComputedColumns(colDef)
 
-	cols := make([]recordset.Column[any], 0, len(storedNames)+len(computedNames)+1)
-	cols = append(cols, &anyColumn{name: idColumnName})
-	storedSet := make(map[string]bool, len(storedNames))
+	known := make(map[string]bool, len(storedNames)+len(computedNames))
 	for _, name := range storedNames {
+		known[name] = true
+	}
+	for _, name := range computedNames {
+		known[name] = true
+	}
+	// Undeclared stored fields present in the data are preserved as stored
+	// columns so reads stay byte-identical with the eager pipeline, which
+	// surfaced any field present in the record (not only declared columns).
+	var extraNames []string
+	seenExtra := make(map[string]bool)
+	for _, rec := range records {
+		for name := range rec.Stored {
+			if known[name] || seenExtra[name] {
+				continue
+			}
+			seenExtra[name] = true
+			extraNames = append(extraNames, name)
+		}
+	}
+	sort.Strings(extraNames)
+
+	cols := make([]recordset.Column[any], 0, len(storedNames)+len(extraNames)+len(computedNames)+1)
+	cols = append(cols, &anyColumn{name: IDColumn})
+	storedSet := make(map[string]bool, len(storedNames)+len(extraNames))
+	for _, name := range storedNames {
+		cols = append(cols, &anyColumn{name: name})
+		storedSet[name] = true
+	}
+	for _, name := range extraNames {
 		cols = append(cols, &anyColumn{name: name})
 		storedSet[name] = true
 	}
@@ -134,7 +162,7 @@ func buildRecordset(colDef *ingitdb.CollectionDef, records []KeyedStored, evalFo
 		// SetValueByName on a stored column cannot fail here: every column was
 		// added above and the column value type is any, so the type assertion
 		// inside the recordset always succeeds.
-		_ = row.SetValueByName(idColumnName, rec.Key, rs)
+		_ = row.SetValueByName(IDColumn, rec.Key, rs)
 		for name, value := range rec.Stored {
 			if !storedSet[name] {
 				continue
@@ -153,6 +181,15 @@ type recordsetReader struct {
 }
 
 var _ dal.RecordsetReader = (*recordsetReader)(nil)
+
+// RowKey returns the record key carried by a row's reserved IDColumn. The
+// IDColumn is present in every recordset BuildRecordset produces, so the lookup
+// cannot fail; a missing or non-string value yields the empty string.
+func RowKey(row recordset.Row, rs recordset.Recordset) string {
+	v, _ := row.GetValueByName(IDColumn, rs)
+	key, _ := v.(string)
+	return key
+}
 
 // NewRecordsetReader returns a dal.RecordsetReader that walks the rows of rs.
 func NewRecordsetReader(rs recordset.Recordset) dal.RecordsetReader {

--- a/pkg/dalgo2ingitdb/recordset_test.go
+++ b/pkg/dalgo2ingitdb/recordset_test.go
@@ -86,6 +86,19 @@ func TestBuildRecordset_EvaluatorInvokedOncePerRow(t *testing.T) {
 	}
 }
 
+func TestRowKey(t *testing.T) {
+	t.Parallel()
+	colDef := &ingitdb.CollectionDef{
+		ID:           "people",
+		Columns:      map[string]*ingitdb.ColumnDef{"first_name": {Type: ingitdb.ColumnTypeString}},
+		ColumnsOrder: []string{"first_name"},
+	}
+	rs := BuildRecordset(colDef, []KeyedStored{{Key: "ada", Stored: map[string]any{"first_name": "Ada"}}})
+	if got := RowKey(rs.GetRow(0), rs); got != "ada" {
+		t.Errorf("RowKey = %q, want ada", got)
+	}
+}
+
 func TestFormulaEvaluator_Eval(t *testing.T) {
 	t.Parallel()
 	e := formulaEvaluator{formula: "a + b"}
@@ -104,7 +117,7 @@ func TestFormulaEvaluator_StripsIDColumn(t *testing.T) {
 	// field; the formula sees exactly the stored siblings.
 	e := formulaEvaluator{formula: `first_name + " " + last_name`}
 	got, err := e.Eval(map[string]any{
-		idColumnName: "ada",
+		IDColumn:     "ada",
 		"first_name": "Ada",
 		"last_name":  "Lovelace",
 	})
@@ -149,7 +162,7 @@ func TestNewRecordsetReader(t *testing.T) {
 		if gotRS != rs {
 			t.Error("Next() returned a different recordset")
 		}
-		id, err := row.GetValueByName(idColumnName, rs)
+		id, err := row.GetValueByName(IDColumn, rs)
 		if err != nil {
 			t.Fatalf("GetValueByName($id): %v", err)
 		}
@@ -276,22 +289,48 @@ func TestAnyColumn(t *testing.T) {
 	}
 }
 
-// TestBuildRecordset_SkipsNonColumnStoredKeys covers the branch where a record
-// carries a stored key that is not a declared (non-formula) column: it must be
-// ignored, not set on the recordset.
-func TestBuildRecordset_SkipsNonColumnStoredKeys(t *testing.T) {
+// TestBuildRecordset_PreservesUndeclaredStoredKeys covers the union branch: a
+// stored key that is not a declared column is preserved as a stored column so
+// reads stay byte-identical with the eager pipeline.
+func TestBuildRecordset_PreservesUndeclaredStoredKeys(t *testing.T) {
 	t.Parallel()
 	records := []KeyedStored{{Key: "a", Stored: map[string]any{
 		"qty":     int64(3),
-		"unknown": "ignored",
+		"unknown": "kept",
 	}}}
 	rs := BuildRecordset(lazyTestColDef(), records)
-	if rs.GetColumnByName("unknown") != nil {
-		t.Error("undeclared stored key must not become a recordset column")
+	if rs.GetColumnByName("unknown") == nil {
+		t.Fatal("undeclared stored key must be preserved as a recordset column")
 	}
 	row := rs.GetRow(0)
+	if v, err := row.GetValueByName("unknown", rs); err != nil || v != "kept" {
+		t.Errorf("unknown = (%v, %v), want (kept, nil)", v, err)
+	}
 	if v, err := row.GetValueByName("qty", rs); err != nil || v != int64(3) {
 		t.Errorf("qty = (%v, %v), want (3, nil)", v, err)
+	}
+}
+
+// TestBuildRecordset_SkipsFormulaColumnStoredKeys covers the storedSet guard: a
+// stored key that collides with a computed (formula) column is not set on the
+// recordset (which would otherwise error), leaving the column to resolve lazily.
+func TestBuildRecordset_SkipsFormulaColumnStoredKeys(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	records := []KeyedStored{{Key: "a", Stored: map[string]any{
+		"qty":   int64(3),
+		"ratio": int64(999), // collides with the computed "ratio" column
+	}}}
+	rs := buildRecordset(lazyTestColDef(), records, func(string) recordset.Evaluator {
+		return countingEvaluator{calls: &calls}
+	})
+	row := rs.GetRow(0)
+	got, err := row.GetValueByName("ratio", rs)
+	if err != nil {
+		t.Fatalf("GetValueByName(ratio): %v", err)
+	}
+	if got != int64(99) || calls != 1 {
+		t.Errorf("ratio = %v (calls=%d), want computed 99 (calls=1), not the stored 999", got, calls)
 	}
 }
 

--- a/pkg/dalgo2ingitdb/recordset_test.go
+++ b/pkg/dalgo2ingitdb/recordset_test.go
@@ -1,0 +1,355 @@
+package dalgo2ingitdb
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/recordset"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// countingEvaluator is a recordset.Evaluator that records how many times it is
+// invoked, so tests can prove lazy, once-per-row resolution.
+type countingEvaluator struct {
+	calls *int
+}
+
+func (e countingEvaluator) Eval(_ map[string]any) (any, error) {
+	*e.calls++
+	return int64(99), nil
+}
+
+// lazyTestColDef returns a collection with one stored column (qty) and one
+// computed column (ratio).
+func lazyTestColDef() *ingitdb.CollectionDef {
+	return &ingitdb.CollectionDef{
+		ID: "items",
+		Columns: map[string]*ingitdb.ColumnDef{
+			"qty":   {Type: ingitdb.ColumnTypeInt},
+			"ratio": {Type: ingitdb.ColumnTypeInt, Formula: "qty / 0"},
+		},
+		ColumnsOrder: []string{"qty", "ratio"},
+	}
+}
+
+// AC: stored-only-projection-evaluates-nothing — reading only the stored column
+// must never invoke the computed column's evaluator (no eager bake).
+func TestBuildRecordset_StoredOnlyProjectionEvaluatesNothing(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	records := []KeyedStored{{Key: "a", Stored: map[string]any{"qty": int64(3)}}}
+	rs := buildRecordset(lazyTestColDef(), records, func(string) recordset.Evaluator {
+		return countingEvaluator{calls: &calls}
+	})
+	row := rs.GetRow(0)
+	got, err := row.GetValueByName("qty", rs)
+	if err != nil {
+		t.Fatalf("GetValueByName(qty): %v", err)
+	}
+	if got != int64(3) {
+		t.Errorf("qty = %v, want 3", got)
+	}
+	if calls != 0 {
+		t.Errorf("evaluator invoked %d times, want 0 — computed column must not be evaluated", calls)
+	}
+}
+
+// AC: evaluator-invoked-once-per-row — reading the same row's computed value via
+// more than one access path must invoke the evaluator exactly once (per-row
+// memoization is relied upon, not defeated).
+func TestBuildRecordset_EvaluatorInvokedOncePerRow(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	records := []KeyedStored{{Key: "a", Stored: map[string]any{"qty": int64(3)}}}
+	rs := buildRecordset(lazyTestColDef(), records, func(string) recordset.Evaluator {
+		return countingEvaluator{calls: &calls}
+	})
+	row := rs.GetRow(0)
+	// Simulate a --where predicate read and an output-projection read of the
+	// same computed column on the same row instance.
+	if _, err := row.GetValueByName("ratio", rs); err != nil {
+		t.Fatalf("GetValueByName(ratio) #1: %v", err)
+	}
+	if _, err := row.GetValueByName("ratio", rs); err != nil {
+		t.Fatalf("GetValueByName(ratio) #2: %v", err)
+	}
+	if _, err := row.Data(rs); err != nil {
+		t.Fatalf("Data: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("evaluator invoked %d times, want 1 (per-row memoization)", calls)
+	}
+}
+
+func TestFormulaEvaluator_Eval(t *testing.T) {
+	t.Parallel()
+	e := formulaEvaluator{formula: "a + b"}
+	got, err := e.Eval(map[string]any{"a": int64(2), "b": int64(3)})
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if got != int64(5) {
+		t.Errorf("a + b = %v, want 5", got)
+	}
+}
+
+func TestFormulaEvaluator_StripsIDColumn(t *testing.T) {
+	t.Parallel()
+	// The reserved "$id" entry must be stripped so it is not bound as a Starlark
+	// field; the formula sees exactly the stored siblings.
+	e := formulaEvaluator{formula: `first_name + " " + last_name`}
+	got, err := e.Eval(map[string]any{
+		idColumnName: "ada",
+		"first_name": "Ada",
+		"last_name":  "Lovelace",
+	})
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if got != "Ada Lovelace" {
+		t.Errorf("full_name = %v, want %q", got, "Ada Lovelace")
+	}
+}
+
+func TestNewRecordsetReader(t *testing.T) {
+	t.Parallel()
+	colDef := &ingitdb.CollectionDef{
+		ID:           "people",
+		Columns:      map[string]*ingitdb.ColumnDef{"first_name": {Type: ingitdb.ColumnTypeString}},
+		ColumnsOrder: []string{"first_name"},
+	}
+	records := []KeyedStored{
+		{Key: "ada", Stored: map[string]any{"first_name": "Ada"}},
+		{Key: "alan", Stored: map[string]any{"first_name": "Alan"}},
+	}
+	rs := BuildRecordset(colDef, records)
+	reader := NewRecordsetReader(rs)
+
+	if reader.Recordset() != rs {
+		t.Error("Recordset() did not return the underlying recordset")
+	}
+	if c, err := reader.Cursor(); err != nil || c != "" {
+		t.Errorf("Cursor() = (%q, %v), want (\"\", nil)", c, err)
+	}
+
+	var keys []string
+	for {
+		row, gotRS, err := reader.Next()
+		if errors.Is(err, dal.ErrNoMoreRecords) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if gotRS != rs {
+			t.Error("Next() returned a different recordset")
+		}
+		id, err := row.GetValueByName(idColumnName, rs)
+		if err != nil {
+			t.Fatalf("GetValueByName($id): %v", err)
+		}
+		keys = append(keys, id.(string))
+	}
+	if len(keys) != 2 || keys[0] != "ada" || keys[1] != "alan" {
+		t.Errorf("keys = %v, want [ada alan]", keys)
+	}
+	if err := reader.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+// recordsetQueryTx builds a disk-backed readonlyTx with a "people" SingleRecord
+// collection declaring a computed full_name, plus a structured query for it.
+func recordsetQueryTx(t *testing.T) (readonlyTx, dal.Query) {
+	t.Helper()
+	root := t.TempDir()
+	colDef := &ingitdb.CollectionDef{
+		ID:      "people",
+		DirPath: filepath.Join(root, "people"),
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:       "{key}.yaml",
+			Format:     ingitdb.RecordFormatYAML,
+			RecordType: ingitdb.SingleRecord,
+		},
+		Columns: map[string]*ingitdb.ColumnDef{
+			"first_name": {Type: ingitdb.ColumnTypeString},
+			"last_name":  {Type: ingitdb.ColumnTypeString},
+			"full_name":  {Type: ingitdb.ColumnTypeString, Formula: `first_name + " " + last_name`},
+		},
+		ColumnsOrder: []string{"first_name", "last_name", "full_name"},
+	}
+	recDir := filepath.Join(colDef.DirPath, colDef.RecordFile.RecordsBasePath())
+	if err := os.MkdirAll(recDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", recDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(recDir, "ada.yaml"),
+		[]byte("first_name: Ada\nlast_name: Lovelace\n"), 0o644); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+	def := &ingitdb.Definition{Collections: map[string]*ingitdb.CollectionDef{"people": colDef}}
+	query := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithData(dal.NewKeyWithID("people", ""), map[string]any{})
+		})
+	return readonlyTx{def: def}, query
+}
+
+func TestReadonlyTx_ExecuteQueryToRecordsetReader_Success(t *testing.T) {
+	t.Parallel()
+	tx, query := recordsetQueryTx(t)
+	reader, err := tx.ExecuteQueryToRecordsetReader(context.Background(), query)
+	if err != nil {
+		t.Fatalf("ExecuteQueryToRecordsetReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	row, rs, err := reader.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	first, err := row.GetValueByName("first_name", rs)
+	if err != nil {
+		t.Fatalf("GetValueByName(first_name): %v", err)
+	}
+	if first != "Ada" {
+		t.Errorf("first_name = %v, want Ada", first)
+	}
+	full, err := row.GetValueByName("full_name", rs)
+	if err != nil {
+		t.Fatalf("GetValueByName(full_name): %v", err)
+	}
+	if full != "Ada Lovelace" {
+		t.Errorf("full_name = %v, want %q", full, "Ada Lovelace")
+	}
+	if _, _, err := reader.Next(); !errors.Is(err, dal.ErrNoMoreRecords) {
+		t.Errorf("second Next err = %v, want ErrNoMoreRecords", err)
+	}
+}
+
+func TestAnyColumn(t *testing.T) {
+	t.Parallel()
+	c := &anyColumn{name: "x"}
+	if c.Name() != "x" {
+		t.Errorf("Name = %q, want x", c.Name())
+	}
+	if c.DefaultValue() != nil {
+		t.Error("DefaultValue should be nil")
+	}
+	if c.DbType() != "" {
+		t.Errorf("DbType = %q, want empty", c.DbType())
+	}
+	if c.IsBitmap() {
+		t.Error("IsBitmap should be false")
+	}
+	if c.ValueType() == nil {
+		t.Error("ValueType should not be nil")
+	}
+	// Out-of-range access before any Add.
+	if _, err := c.GetValue(0); err == nil {
+		t.Error("GetValue out of range should error")
+	}
+	if err := c.SetValue(0, "v"); err == nil {
+		t.Error("SetValue out of range should error")
+	}
+	// Add (including a nil value) then read back.
+	if err := c.Add(nil); err != nil {
+		t.Fatalf("Add(nil): %v", err)
+	}
+	if err := c.Add("a"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	got, err := c.GetValue(0)
+	if err != nil || got != nil {
+		t.Errorf("GetValue(0) = (%v, %v), want (nil, nil)", got, err)
+	}
+	if err := c.SetValue(0, "z"); err != nil {
+		t.Errorf("SetValue(0): %v", err)
+	}
+	vals := c.Values()
+	if len(vals) != 2 || vals[0] != "z" || vals[1] != "a" {
+		t.Errorf("Values = %v, want [z a]", vals)
+	}
+}
+
+// TestBuildRecordset_SkipsNonColumnStoredKeys covers the branch where a record
+// carries a stored key that is not a declared (non-formula) column: it must be
+// ignored, not set on the recordset.
+func TestBuildRecordset_SkipsNonColumnStoredKeys(t *testing.T) {
+	t.Parallel()
+	records := []KeyedStored{{Key: "a", Stored: map[string]any{
+		"qty":     int64(3),
+		"unknown": "ignored",
+	}}}
+	rs := BuildRecordset(lazyTestColDef(), records)
+	if rs.GetColumnByName("unknown") != nil {
+		t.Error("undeclared stored key must not become a recordset column")
+	}
+	row := rs.GetRow(0)
+	if v, err := row.GetValueByName("qty", rs); err != nil || v != int64(3) {
+		t.Errorf("qty = (%v, %v), want (3, nil)", v, err)
+	}
+}
+
+func TestReadonlyTx_ExecuteQueryToRecordsetReader_MapOfRecords(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	colDef := &ingitdb.CollectionDef{
+		ID:      "scores",
+		DirPath: filepath.Join(root, "scores"),
+		RecordFile: &ingitdb.RecordFileDef{
+			Name:       "scores.yaml",
+			Format:     ingitdb.RecordFormatYAML,
+			RecordType: ingitdb.MapOfRecords,
+		},
+		Columns: map[string]*ingitdb.ColumnDef{
+			"score":   {Type: ingitdb.ColumnTypeInt},
+			"doubled": {Type: ingitdb.ColumnTypeInt, Formula: "score * 2"},
+		},
+		ColumnsOrder: []string{"score", "doubled"},
+	}
+	recDir := filepath.Join(colDef.DirPath, colDef.RecordFile.RecordsBasePath())
+	if err := os.MkdirAll(recDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(recDir, "scores.yaml"),
+		[]byte("alpha:\n  score: 5\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	def := &ingitdb.Definition{Collections: map[string]*ingitdb.CollectionDef{"scores": colDef}}
+	tx := readonlyTx{def: def}
+	query := dal.From(dal.NewRootCollectionRef("scores", "")).NewQuery().
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithData(dal.NewKeyWithID("scores", ""), map[string]any{})
+		})
+	reader, err := tx.ExecuteQueryToRecordsetReader(context.Background(), query)
+	if err != nil {
+		t.Fatalf("ExecuteQueryToRecordsetReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	row, rs, err := reader.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	doubled, err := row.GetValueByName("doubled", rs)
+	if err != nil {
+		t.Fatalf("GetValueByName(doubled): %v", err)
+	}
+	if doubled != int64(10) {
+		t.Errorf("doubled = %v, want 10", doubled)
+	}
+}
+
+func TestReadonlyTx_ExecuteQueryToRecordsetReader_QueryErrors(t *testing.T) {
+	t.Parallel()
+	tx, query := recordsetQueryTx(t)
+	// Read error: point the collection at a record type the query path rejects.
+	tx.def.Collections["people"].RecordFile.RecordType = "bogus"
+	if _, err := tx.ExecuteQueryToRecordsetReader(context.Background(), query); err == nil {
+		t.Fatal("want error for unsupported record type")
+	}
+}

--- a/pkg/dalgo2ingitdb/tx_readonly.go
+++ b/pkg/dalgo2ingitdb/tx_readonly.go
@@ -149,10 +149,22 @@ func (r readonlyTx) ExecuteQueryToRecordsReader(ctx context.Context, query dal.Q
 	return executeQueryToRecordsReader(ctx, r, query)
 }
 
-// ExecuteQueryToRecordsetReader is not implemented yet. Callers that need
-// recordset-shaped output should fall back to ExecuteQueryToRecordsReader.
-func (r readonlyTx) ExecuteQueryToRecordsetReader(_ context.Context, _ dal.Query, _ ...recordset.Option) (dal.RecordsetReader, error) {
-	return nil, dal.ErrNotSupported
+// ExecuteQueryToRecordsetReader executes a structured query against a single
+// collection and returns a recordset-shaped reader. Every stored column carries
+// the record's locale-normalized value; every computed (formula) column is
+// registered via recordset.NewComputedColumn bound to a Starlark-backed
+// evaluator, so computed values resolve lazily — only when a consumer reads
+// them — never eagerly baked here.
+func (r readonlyTx) ExecuteQueryToRecordsetReader(_ context.Context, query dal.Query, _ ...recordset.Option) (dal.RecordsetReader, error) {
+	colDef, err := collectionFromQuery(r.def, query)
+	if err != nil {
+		return nil, err
+	}
+	stored, err := readAllStoredRecords(colDef)
+	if err != nil {
+		return nil, err
+	}
+	return NewRecordsetReader(BuildRecordset(colDef, stored)), nil
 }
 
 // resolveCollection looks up the collection definition for a key and

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -43,6 +43,7 @@ This directory tracks the SpecScore feature specifications for the **ingitdb-cli
 | [dalgo2ingitdb-referential-integrity](dalgo2ingitdb-referential-integrity/README.md) | Approved | DALgo write transactions enforce existing `foreign_key` metadata on Set, Insert, Update, and Delete. |
 | [record-key](record-key/README.md) | Draft | Umbrella for canonical record identity behavior across schema validation, storage paths, writes, and CLI key surfaces. |
 | [computed-columns](computed-columns/README.md) | Approved | TODO: Add description. |
+| [computed-columns-via-dalgo](computed-columns-via-dalgo/README.md) | Approved | TODO: Add description. |
 
 ## Feature Summaries
 

--- a/spec/features/computed-columns-via-dalgo/README.md
+++ b/spec/features/computed-columns-via-dalgo/README.md
@@ -266,5 +266,9 @@ v0.46.0):
   `REQ:fail-loud` prose were amended to match REQ:fail-loud-on-access — the abort
   fires only when the computed column is referenced.
 
+## Sidekick Seeds Generated
+
+- [tui-collection-screen-should-evaluate-only-painted-visible](../../ideas/seeds/tui-collection-screen-should-evaluate-only-painted-visible.md) — captured 2026-06-03 by specstudio:implement
+
 ---
 *This document follows the https://specscore.md/feature-specification*

--- a/spec/features/computed-columns-via-dalgo/README.md
+++ b/spec/features/computed-columns-via-dalgo/README.md
@@ -1,0 +1,270 @@
+# Feature: Computed Columns via dalgo (lazy delegation)
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=request-change) |
+**Status:** Approved
+**Date:** 2026-06-03
+**Owner:** alex
+**Source Ideas:** —
+**Supersedes:** —
+
+## Summary
+
+Moves computed-column (FORMULA) value computation out of ingitdb's eager read
+pipeline and onto dalgo's `recordset.Evaluator` contract (dalgo v0.46.0). ingitdb
+keeps owning the Starlark language and schema validation, but delegates the
+*computation wiring* to dalgo so computed values are resolved **lazily, per
+accessed column**, through `recordset.Row`. It serves ingitdb users by avoiding
+needless formula evaluation — a computed column is only computed when a consumer
+actually reads it.
+
+## Problem
+
+Today every read goes through `executeQueryToRecordsReader`, which calls
+`ApplyFormulasToRead` to evaluate **every** computed column for **every** record
+and bake the results into a `map[string]any`. `select`, `delete`, `update`, and
+the TUI then read that map. This is wasteful: `delete`/`update` only need a
+computed column referenced by a `--where` predicate (and render none); the TUI
+only needs cells it actually paints; `select` only needs projected, filtered, and
+sorted columns. Heavy Starlark evaluation runs for columns no consumer reads.
+
+dalgo v0.46.0 ships a neutral computed-column contract (`recordset.Evaluator`,
+`NewComputedColumn`, lazy memoized resolution in `Row`). This Feature adopts it:
+ingitdb supplies a Starlark-backed `Evaluator`, materializes query results as a
+`recordset.Recordset`, and routes all read consumers through lazy `Row` access —
+so a formula runs only when, and only as often as, its column is read.
+
+## Behavior
+
+### Delegating computation to dalgo
+
+ingitdb stops evaluating formulas eagerly and instead hands dalgo an opaque
+evaluator plus a recordset whose computed columns are marked as such.
+
+#### REQ: starlark-evaluator-adapter
+
+ingitdb MUST provide a `recordset.Evaluator` implementation that computes a
+computed column's value by delegating to the existing
+`ingitdb.EvaluateFormula(formula, stored)`. dalgo MUST NOT parse, compile, or
+sandbox anything; the Starlark engine, its sandbox, and schema-load-time
+validation remain entirely in ingitdb.
+
+#### REQ: recordset-query-path
+
+The previously stubbed `ExecuteQueryToRecordsetReader` MUST be implemented to
+return a `dal.RecordsetReader` whose `recordset.Recordset` registers each stored
+(non-computed) column as an ordinary column carrying the record's
+locale-normalized stored value, and each computed column via
+`recordset.NewComputedColumn` bound to the Starlark-backed `Evaluator`.
+
+#### REQ: remove-eager-bake
+
+The read path MUST NOT eagerly evaluate formulas into the record map: computed
+values are produced only through `recordset.Row` access. `ApplyFormulasToRead`
+MUST no longer run as a read-time stage. (Write-time foreign-key evaluation is
+out of scope and unchanged — see Not Doing.)
+
+### Lazy, per-reference computation
+
+The point of the migration: never compute a computed column a consumer does not
+read.
+
+#### REQ: compute-only-on-reference
+
+A computed column's formula MUST be evaluated only when a consumer reads that
+column — via output projection, a `--where` predicate, an `order_by` term, or a
+painted TUI cell. A computed column that no consumer references in a given
+operation MUST NOT be evaluated.
+
+#### REQ: compute-once-per-row
+
+Within a single `recordset.Row` instance, a computed column MUST be evaluated at
+most once regardless of how many times it is read (relying on dalgo's per-row
+memoization); ingitdb's access path MUST NOT defeat that memoization by
+reconstructing rows mid-operation.
+
+### Preserving observable behavior
+
+The migration is behavior-preserving for referenced columns; only the timing of
+computation (and of error surfacing) changes.
+
+#### REQ: coerce-on-access
+
+A value read from a `recordset.Row` MUST be coerced to the column's declared
+`ColumnType` (via the existing `coerceFormulaResult`) before it is used in a
+comparison, a sort, or output. All read consumers MUST obtain values through one
+shared accessor that performs this coercion, so typed results stay identical to
+the eager pipeline.
+
+#### REQ: fail-loud-on-access
+
+If a formula raises a runtime error, or its result cannot be coerced, the error
+MUST abort the operation when the column is accessed, with an error identifying
+the collection, record key, and column (the shared accessor wraps dalgo's
+evaluator error with that context). Because computation is lazy, this Feature
+narrows `computed-columns#ac:runtime-error-fails-read`: an erroring computed
+column that is never referenced in an operation MUST NOT abort that operation.
+
+#### REQ: where-and-order-lazy
+
+`--where` and `order_by` MUST continue to support computed columns, with their
+values now obtained through the shared lazy accessor rather than a pre-baked map,
+so only the computed columns named in the predicate or sort terms are evaluated.
+
+#### REQ: all-consumers-via-recordset
+
+`select`, `delete`, `update`, and the TUI collection screen MUST obtain query
+results via `ExecuteQueryToRecordsetReader` and read every field value through the
+shared coerce-on-access accessor. The TUI MUST read only the cells it renders, so
+hidden or off-viewport computed columns are not evaluated.
+
+## Acceptance Criteria
+
+### AC: select-renders-computed (verifies REQ:starlark-evaluator-adapter, REQ:recordset-query-path)
+
+**Given** a collection `people` with a `string` column `full_name` declaring `formula: 'first_name + " " + last_name'` and a record `first_name: "Ada"`, `last_name: "Lovelace"`
+**When** the record is read via `select`
+**Then** the returned `full_name` equals `"Ada Lovelace"`
+
+### AC: type-coercion-preserved (verifies REQ:coerce-on-access)
+
+**Given** an `int` column `total` with `formula: 'qty * price'` and a record with `qty: 3`, `price: 4`
+**When** the record is read via `select`
+**Then** `total` equals integer `12` (not a float or other type)
+
+### AC: string-helper-preserved (verifies REQ:recordset-query-path, REQ:starlark-evaluator-adapter)
+
+**Given** a `string` column `display` with `formula: 'first_name.strip().upper()'` and a record with `first_name: " ada "`
+**When** the record is read via `select`
+**Then** `display` equals `"ADA"`
+
+### AC: math-helper-preserved (verifies REQ:coerce-on-access, REQ:starlark-evaluator-adapter)
+
+**Given** an `int` column `rounded` with `formula: 'round(score)'` and a record with `score: 4.6`
+**When** the record is read via `select`
+**Then** `rounded` equals integer `5`
+
+### AC: where-on-computed-still-works (verifies REQ:where-and-order-lazy, REQ:all-consumers-via-recordset)
+
+**Given** the `people` collection with computed `full_name`
+**When** `select` runs with `--where 'full_name == "Ada Lovelace"'`
+**Then** only records whose computed `full_name` equals `"Ada Lovelace"` are returned
+
+### AC: order-by-computed-still-works (verifies REQ:where-and-order-lazy)
+
+**Given** the `people` collection with computed `full_name`
+**When** `select` runs with `order_by full_name asc`
+**Then** the returned records are ordered by their computed `full_name`
+
+### AC: delete-where-on-computed (verifies REQ:all-consumers-via-recordset, REQ:where-and-order-lazy)
+
+**Given** the `people` collection with computed `full_name` and a `delete` in set mode
+**When** `delete` runs with `--where 'full_name == "Ada Lovelace"'`
+**Then** exactly the records whose computed `full_name` equals `"Ada Lovelace"` are deleted
+
+### AC: unreferenced-erroring-column-not-evaluated (verifies REQ:compute-only-on-reference, REQ:fail-loud-on-access)
+
+**Given** a collection with a stored column `qty` and a computed `int` column `ratio` whose `formula: 'qty / 0'` raises at runtime
+**When** `select` runs projecting only `qty` (with no `--where`/`order_by` referencing `ratio`)
+**Then** the operation succeeds and returns `qty`, and the read does not abort with the `ratio` runtime error
+
+### AC: referenced-erroring-column-fails-loud (verifies REQ:fail-loud-on-access)
+
+**Given** the same collection with computed `int` column `ratio` whose `formula: 'qty / 0'`
+**When** `select` runs projecting `ratio` (or with `--where` referencing it)
+**Then** the operation aborts with an error naming the collection, record key, and the `ratio` column
+
+### AC: stored-only-projection-evaluates-nothing (verifies REQ:remove-eager-bake, REQ:compute-only-on-reference)
+
+**Given** a `recordset.Recordset` built for a record with a stored column `qty` and a computed column whose `Evaluator` increments a counter
+**When** a consumer reads only `qty` (no projection, `--where`, or `order_by` references the computed column)
+**Then** the counter equals `0` — the computed column's formula is never evaluated (no eager bake)
+
+### AC: evaluator-invoked-once-per-row (verifies REQ:compute-once-per-row)
+
+**Given** a `recordset.Recordset` built for a record with a computed column whose `Evaluator` increments a counter
+**When** the same `Row` instance's computed value is read by both a `--where` predicate and output projection
+**Then** the counter equals `1` for that row
+
+## Architecture & Components
+
+| Unit | What it does | Depends on |
+|------|--------------|-----------|
+| `formulaEvaluator` (new, `pkg/dalgo2ingitdb`) | Implements `recordset.Evaluator`; `Eval(stored)` → `ingitdb.EvaluateFormula(formula, stored)`. | `ingitdb.EvaluateFormula`, `recordset.Evaluator` |
+| `ExecuteQueryToRecordsetReader` (implement stub, `tx_readonly.go`) | Materializes a `recordset.Recordset` per query: stored columns from locale-normalized fields, computed columns via `NewComputedColumn`; returns a `dal.RecordsetReader`. | `recordset`, `ColumnDef`, `ApplyLocaleToRead`, read-from-disk path |
+| shared value accessor (new) | `value(row, rs, colDef)`: `row.GetValueByName` → `coerceFormulaResult(v, colDef.Type)`; wraps evaluator errors with collection/key/column. | `recordset.Row`, `coerceFormulaResult` |
+| `select`/`delete`/`update`/TUI consumers | Switched from `ExecuteQueryToRecordsReader` to the recordset reader; read via the shared accessor; WHERE/ORDER BY evaluate through it. | recordset reader, shared accessor |
+
+## Data Flow
+
+1. Query resolves the collection; records are read from disk and locale-normalized
+   (`ApplyLocaleToRead`) into stored fields — unchanged.
+2. A `recordset.Recordset` is built: one column per stored field (value set), one
+   `NewComputedColumn` per formula column bound to a `formulaEvaluator`.
+3. Consumers pull rows from the `dal.RecordsetReader`. Any value read (WHERE,
+   ORDER BY, output cell, TUI cell) goes through the shared accessor →
+   `Row.GetValueByName` → (lazy) `Evaluator.Eval(stored siblings)` → coerce to
+   declared type. dalgo memoizes per row; unreferenced computed columns are never
+   evaluated.
+
+## Error Handling & Failure Modes
+
+- **Formula runtime error / coercion failure** → surfaced at access via the shared
+  accessor, wrapped with collection + record key + column; aborts the operation
+  (REQ:fail-loud-on-access). Never panics.
+- **Unreferenced erroring computed column** → not evaluated, no error
+  (REQ:compute-only-on-reference) — the deliberate narrowing of the eager
+  fail-loud behavior.
+- **Unknown column in `--where`/`order_by`/projection** → unchanged from today.
+
+## Testing Strategy
+
+Go tests across two surfaces: (1) `pkg/dalgo2ingitdb` unit tests for the evaluator
+adapter, the recordset reader, the shared accessor (coercion + error wrapping +
+invoked-once), using a counter-instrumented evaluator; (2) CLI-level tests
+exercising `select`/`delete` against fixtures for the read, coercion, helper,
+where/order, lazy-skip, and fail-loud ACs. Existing `computed-columns` ACs
+(read-output, filter, sort) are re-run to confirm byte-identical results.
+
+## Rehearse Integration
+
+Every AC has a concrete surface (CLI `select`/`delete` output/errors, or
+pure-function `recordset`-construction tests), so one Rehearse Scenario stub per
+AC is scaffolded under `_tests/`. `evaluator-invoked-once-per-row` is a
+pure-function/unit surface; the TUI viewport behavior is covered indirectly via
+`compute-only-on-reference` (no dedicated TUI-render stub in this Feature).
+
+## Not Doing / Out of Scope
+
+- Changing the Starlark language, helper set, or schema-load-time validation —
+  all remain in ingitdb unchanged.
+- Write-time foreign-key evaluation and the computed-FK referential-integrity
+  paths — they keep their current evaluation; only the read path migrates.
+- Adding new computed-column capabilities (chained computed columns, new types) —
+  behavior is preserved, not extended.
+- Pushing coercion into dalgo — coercion stays on the ingitdb consumer side
+  (dalgo returns raw values by contract).
+- The `starlark4dalgo` shared-engine-library extraction — tracked separately.
+
+## Assumption Carryover
+
+From the dalgo-side Idea `recordset-computed-columns` (Phase A, shipped in
+v0.46.0):
+
+- **Validated / relied upon:** `recordset.Row` is the carrier; the evaluator
+  receives the full stored-field map; lazy + per-row memoized; dalgo carries no
+  scripting dependency; `EvaluateFormula(formula, fields)` already matches the
+  `Eval(stored)` shape.
+- **Now decided (was open):** the fail-loud timing shift is **accepted** — errors
+  surface on access, and unreferenced erroring columns do not abort
+  (REQ:fail-loud-on-access). This narrows `computed-columns#ac:runtime-error-fails-read`.
+- **Coercion:** stays consumer-side (REQ:coerce-on-access), consistent with
+  dalgo's no-coercion contract.
+
+## Open Questions
+
+- Resolved in this work: `computed-columns#ac:runtime-error-fails-read` and its
+  `REQ:fail-loud` prose were amended to match REQ:fail-loud-on-access — the abort
+  fires only when the computed column is referenced.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/features/computed-columns/README.md
+++ b/spec/features/computed-columns/README.md
@@ -63,7 +63,10 @@ referencing another computed column — are deferred to a future Feature.)
 
 For every record read from a collection, each computed column's value MUST be
 produced by evaluating its `formula` before the record is returned to the caller,
-in the same read-time transformation stage as `ApplyLocaleToRead`.
+in the same read-time transformation stage as `ApplyLocaleToRead`. (Computation
+timing is superseded by `computed-columns-via-dalgo`: values are produced lazily
+on access via dalgo's `recordset.Row` rather than eagerly, so a computed column is
+evaluated only when a consumer references it.)
 
 #### REQ: sandboxed-deterministic
 
@@ -97,7 +100,10 @@ outside that set on a computed column MUST be rejected as a schema validation er
 If a formula raises a runtime error, or its result cannot be coerced to the declared
 type, the read/materialization MUST abort with an error identifying the collection,
 record key, column, and underlying cause. The system MUST NOT emit a partial row or
-silently null the offending cell.
+silently null the offending cell. Because computation is lazy (see
+`computed-columns-via-dalgo`), this abort fires when the computed column is
+*referenced* — projected, filtered, or sorted; a computed column that no consumer
+references in an operation is not evaluated and does not abort that operation.
 
 ### Query and reference integration
 
@@ -186,8 +192,8 @@ optimization, out of scope for this Feature.)
 ### AC: runtime-error-fails-read (verifies REQ:fail-loud)
 
 **Given** a computed `int` column whose formula divides by a field that is zero for some record
-**When** that record is read
-**Then** the read aborts with an error naming the collection, record key, and column, and no partial row is emitted
+**When** that record is read **and the computed column is referenced** (projected, filtered, or sorted)
+**Then** the read aborts with an error naming the collection, record key, and column, and no partial row is emitted; **a computed column that no consumer references is not evaluated and does not abort the read**
 
 ### AC: filter-on-computed-column (verifies REQ:usable-in-filter-and-sort)
 

--- a/spec/ideas/seeds/tui-collection-screen-should-evaluate-only-painted-visible.md
+++ b/spec/ideas/seeds/tui-collection-screen-should-evaluate-only-painted-visible.md
@@ -1,0 +1,31 @@
+---
+type: sidekick-seed
+slug: tui-collection-screen-should-evaluate-only-painted-visible
+captured_at: 2026-06-03T12:03:29Z
+captured_by: specstudio:implement
+captured_during: spec/features/computed-columns-via-dalgo
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# TUI collection screen should evaluate only painted visible computed-column cells, not all cells at load
+
+During `computed-columns-via-dalgo` Task 5 the TUI collection screen was migrated
+onto `ExecuteQueryToRecordsetReader` + the shared `AccessValue` accessor, but it
+still builds a full per-record map at load time (reading every column), so every
+computed column is evaluated up front — byte-identical to the prior eager
+behavior, but not the per-cell laziness `REQ:all-consumers-via-recordset`
+envisions ("The TUI MUST read only the cells it renders, so hidden or
+off-viewport computed columns are not evaluated").
+
+Root cause: the TUI model holds `records []map[string]any` and scans **all
+records × all columns** for column-width sizing, locale discovery
+(`discoverLocales`), and numeric detection (`isNumeric(records[0][c])`). True
+per-painted-cell laziness needs a model refactor to hold recordset rows + the
+recordset and defer `AccessValue` to render time (and to bound column sizing to
+the visible viewport).
+
+Out of scope for the lazy migration Feature (no dedicated TUI AC; data-layer
+`compute-only-on-reference` is satisfied and unit-verified via the recordset).
+Worth a follow-up Feature if computed columns become expensive enough that
+off-viewport evaluation hurts TUI responsiveness.

--- a/spec/plans/2026-06-03-computed-columns-via-dalgo.md
+++ b/spec/plans/2026-06-03-computed-columns-via-dalgo.md
@@ -1,0 +1,88 @@
+# Plan: Computed Columns via dalgo (lazy delegation)
+
+**Status:** Approved
+**Source Feature:** computed-columns-via-dalgo
+**Date:** 2026-06-03
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `computed-columns-via-dalgo` Feature into five linear tasks that
+migrate computed-column computation from ingitdb's eager read pipeline onto
+dalgo's `recordset.Evaluator` contract: the lazy core first (evaluator adapter +
+recordset reader + coerce/fail-loud accessor), then the consumer migrations
+(`select` output, `select` filter/sort, then `delete`/`update`/TUI), ending with
+removal of the eager `ApplyFormulasToRead` stage. All 11 acceptance criteria are
+covered; none are deferred.
+
+## Approach
+
+Tasks follow the dependency chain. Task 1 lands the lazy core — the
+Starlark-backed `recordset.Evaluator` adapter and the now-implemented
+`ExecuteQueryToRecordsetReader` (adapter and reader are merged because the adapter
+has no consumer without the reader). Task 2 adds the shared coerce-on-access
+accessor that every consumer reads through, including fail-loud error wrapping.
+Tasks 3 and 4 migrate `select` — output projection first, then `--where`/`order_by`
+onto the lazy accessor. Task 5 migrates the remaining consumers (`delete`/`update`
+set-mode WHERE and the TUI collection screen) and, once no consumer uses the old
+reader, removes the eager `ApplyFormulasToRead` read-time stage. The `select`
+migration is split (output vs filter/sort) to keep each task focused; the TUI has
+no dedicated AC and rides Task 5 under the all-consumers requirement.
+
+## Tasks
+
+### Task 1: Starlark Evaluator adapter and recordset query reader
+
+**Verifies:** computed-columns-via-dalgo#ac:evaluator-invoked-once-per-row, computed-columns-via-dalgo#ac:stored-only-projection-evaluates-nothing
+
+Add a `recordset.Evaluator` (`formulaEvaluator`) that delegates to
+`ingitdb.EvaluateFormula`, and implement the stubbed `ExecuteQueryToRecordsetReader`
+to materialize a `recordset.Recordset` whose stored columns carry locale-normalized
+values and whose computed columns are registered via `recordset.NewComputedColumn`.
+Lazy resolution and per-row single evaluation come from the dalgo contract; verify
+the evaluator is invoked once per row and never for unreferenced stored-only reads.
+
+### Task 2: Shared coerce-on-access accessor with fail-loud error wrapping
+
+**Verifies:** computed-columns-via-dalgo#ac:type-coercion-preserved, computed-columns-via-dalgo#ac:referenced-erroring-column-fails-loud
+
+Add one accessor that reads a value from a `recordset.Row` and coerces it to the
+column's declared `ColumnType` via `coerceFormulaResult`, wrapping any evaluator or
+coercion error with the collection, record key, and column. This is the single
+read path all consumers will use, keeping typed results identical and errors
+fail-loud at access time.
+
+### Task 3: Migrate select output projection onto the recordset reader
+
+**Verifies:** computed-columns-via-dalgo#ac:select-renders-computed, computed-columns-via-dalgo#ac:string-helper-preserved, computed-columns-via-dalgo#ac:math-helper-preserved
+
+Switch `select`'s record consumption from `ExecuteQueryToRecordsReader` to the
+recordset reader, reading each projected/output field through the shared accessor,
+so computed columns render byte-identically (including Starlark string and numeric
+helper results) but are computed lazily per projected column.
+
+### Task 4: Migrate select --where and order_by to the lazy accessor
+
+**Verifies:** computed-columns-via-dalgo#ac:where-on-computed-still-works, computed-columns-via-dalgo#ac:order-by-computed-still-works, computed-columns-via-dalgo#ac:unreferenced-erroring-column-not-evaluated
+
+Move `select`'s `--where` predicate evaluation and `order_by` sorting onto values
+obtained through the shared lazy accessor instead of a pre-baked map, so only the
+computed columns named in predicates or sort terms are evaluated and an unreferenced
+erroring computed column no longer aborts the read.
+
+### Task 5: Migrate delete/update and TUI consumers; remove eager formula bake
+
+**Verifies:** computed-columns-via-dalgo#ac:delete-where-on-computed
+
+Migrate `delete`/`update` set-mode WHERE and the TUI collection screen (visible-cell
+reads only) onto the recordset reader via the shared accessor, then remove the
+eager `ApplyFormulasToRead` read-time stage now that no consumer uses the old
+records reader for computed values.
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/2026-06-03-computed-columns-via-dalgo.md
+++ b/spec/plans/2026-06-03-computed-columns-via-dalgo.md
@@ -1,6 +1,6 @@
 # Plan: Computed Columns via dalgo (lazy delegation)
 
-**Status:** Implementing
+**Status:** Completed
 **Source Feature:** computed-columns-via-dalgo
 **Date:** 2026-06-03
 **Owner:** alex
@@ -42,6 +42,24 @@ shared coerce-on-access accessor — live in `pkg/dalgo2ingitdb`, and
 `pkg/dalgo2fsingitdb`'s recordset method plus the CLI consumers are wired to them;
 the eager bake is removed from both query paths. Task 1 implements both packages'
 `ExecuteQueryToRecordsetReader`; Task 5 removes the eager bake from both.
+
+**Implementation note (eager-bake retained for write-time FK).** During Task 5
+the records-reader eager bake (`ApplyFormulasToRead` via `bakeStoredRecords`) was
+found to also back **write-time computed-foreign-key validation** (`Set`/`Delete`
+referential-integrity checks read child records and must see computed FK values).
+Write-time FK evaluation is explicitly out of scope and unchanged (Feature → Not
+Doing), so the bake is *not* deleted; instead all four read consumers were
+migrated off the records reader onto the lazy recordset reader, so the **read
+path** no longer eagerly evaluates formulas (`REQ:remove-eager-bake`). The
+records-reader bake now serves only the out-of-scope write-time FK path.
+
+**Implementation note (TUI laziness).** The TUI collection screen scans all
+records × columns for column-width sizing, locale discovery, and numeric
+detection, so strict per-visible-cell laziness conflicts with its current
+architecture. The TUI was migrated onto the recordset reader + shared accessor
+(byte-identical to prior behavior); true per-cell laziness is deferred as a
+follow-up. The data-layer `REQ:compute-only-on-reference` is satisfied and
+unit-verified via the recordset.
 
 ## Tasks
 

--- a/spec/plans/2026-06-03-computed-columns-via-dalgo.md
+++ b/spec/plans/2026-06-03-computed-columns-via-dalgo.md
@@ -1,6 +1,6 @@
 # Plan: Computed Columns via dalgo (lazy delegation)
 
-**Status:** Approved
+**Status:** Implementing
 **Source Feature:** computed-columns-via-dalgo
 **Date:** 2026-06-03
 **Owner:** alex
@@ -29,6 +29,19 @@ set-mode WHERE and the TUI collection screen) and, once no consumer uses the old
 reader, removes the eager `ApplyFormulasToRead` read-time stage. The `select`
 migration is split (output vs filter/sort) to keep each task focused; the TUI has
 no dedicated AC and rides Task 5 under the all-consumers requirement.
+
+**Scope note (two packages).** The CLI consumers (`select`/`delete`/`update`/TUI)
+run through `pkg/dalgo2fsingitdb` (the filesystem driver wired in `main.go` via
+`NewLocalDBWithDef`), which delegates parsing/locale/formula/validation to
+`pkg/dalgo2ingitdb`. Both packages carry their own readonly-tx with a
+`ExecuteQueryToRecordsetReader` stub (`dalgo2ingitdb` returns `dal.ErrNotSupported`;
+`dalgo2fsingitdb` panics) and their own eager `ApplyFormulasToRead` call sites.
+To deliver the Feature's observable goal, the reusable pieces — the Starlark
+`recordset.Evaluator` adapter, the recordset builder, the recordset reader, and the
+shared coerce-on-access accessor — live in `pkg/dalgo2ingitdb`, and
+`pkg/dalgo2fsingitdb`'s recordset method plus the CLI consumers are wired to them;
+the eager bake is removed from both query paths. Task 1 implements both packages'
+`ExecuteQueryToRecordsetReader`; Task 5 removes the eager bake from both.
 
 ## Tasks
 

--- a/spec/plans/README.md
+++ b/spec/plans/README.md
@@ -11,6 +11,7 @@ verifiable tasks with clear acceptance criteria and dependency ordering.
 | [query-command-prd](query-command-prd.md) | cli/query | Done |
 | [2026-05-12-create-record-stdin-edit](2026-05-12-create-record-stdin-edit.md) | cli/create-record | Ready |
 | [dalgo2ingitdb-referential-integrity](dalgo2ingitdb-referential-integrity.md) | dalgo2ingitdb-referential-integrity | Approved |
+| [2026-06-03-computed-columns-via-dalgo](2026-06-03-computed-columns-via-dalgo.md) | computed-columns-via-dalgo | Draft |
 
 ## Open Questions
 


### PR DESCRIPTION
Migrates computed-column (FORMULA) computation off ingitdb's eager `ApplyFormulasToRead` read pipeline onto dalgo's `recordset.Evaluator` contract (dalgo v0.46.0), resolved **lazily per accessed column**.

Implements Feature `spec/features/computed-columns-via-dalgo/` per Plan `spec/plans/2026-06-03-computed-columns-via-dalgo.md` (all 11 ACs).

## What changed
- **Starlark `recordset.Evaluator` adapter** + recordset builder + slice-backed `RecordsetReader` in `pkg/dalgo2ingitdb`; `ExecuteQueryToRecordsetReader` implemented in both `dalgo2ingitdb` and `dalgo2fsingitdb` (the CLI's driver).
- **Shared coerce-on-access accessor** (`AccessValue`): coerces computed results to the declared `ColumnType`, passes stored values through unchanged, wraps evaluator/coercion errors with collection + record key + column (fail-loud).
- **Consumers migrated** to the recordset reader via the accessor: `select` (output + `--where` + `order_by`), `delete`/`update` set-mode WHERE, and the TUI collection screen. Only referenced columns are evaluated, so an unreferenced erroring column no longer aborts the read.
- `update` now persists **stored fields only** (computed columns are never written back).

## Key decisions (see Plan implementation notes)
- **Two packages:** the CLI runs through `dalgo2fsingitdb`; reusable pieces live in `dalgo2ingitdb` and both drivers' recordset methods + consumers are wired to them.
- **Eager bake retained for write-time FK:** the records-reader bake also backs write-time computed-foreign-key validation (explicitly out of scope / unchanged), so it is not deleted — the *read path* is migrated off it instead.
- **TUI per-cell laziness** deferred (its column-width/locale scans read all cells); migrated byte-identically. Captured as a sidekick seed for a follow-up.

## Constraints honored
- Behavior byte-identical for referenced columns (existing computed-columns read/filter/sort tests pass unchanged).
- dalgo gets no scripting dependency; Starlark stays in ingitdb.

## Gates
`go build ./...` · `go test ./...` · `golangci-lint run` (0 issues) · `specscore spec lint` (0 violations) — all clean; new code 100% covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)