### PR TITLE
test: stop flaky git temp-dir cleanup race in commands tests

### DIFF
--- a/cmd/ingitdb/commands/main_test.go
+++ b/cmd/ingitdb/commands/main_test.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMain installs a hermetic global git config for every test in this package
+// so test repos never spawn a detached auto-gc / background-maintenance process.
+// Such a process can keep writing to a temp repo's .git/objects after a test
+// returns, racing with t.TempDir()'s RemoveAll and failing cleanup with
+// "directory not empty" (observed flaking the rebase tests on CI).
+//
+// The temp config INCLUDES the pre-existing global config (so init.defaultBranch,
+// identity, safe.directory, etc. are preserved) and only adds the gc/maintenance
+// overrides, which — appearing after the include — take precedence. It is
+// process-local via GIT_CONFIG_GLOBAL and removed on exit. The rebase tests also
+// set these knobs per-repo, so the hotspot stays covered even if a test
+// overrides GIT_CONFIG_GLOBAL or HOME for its own purposes.
+func TestMain(m *testing.M) {
+	restore, err := installHermeticGitConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: hermetic git config setup failed: %v\n", err)
+		os.Exit(m.Run())
+	}
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
+
+// installHermeticGitConfig writes a temp global git config disabling auto-gc and
+// background maintenance, points GIT_CONFIG_GLOBAL at it, and returns a function
+// that restores the previous environment and removes the temp file.
+func installHermeticGitConfig() (restore func(), err error) {
+	dir, err := os.MkdirTemp("", "ingitdb-gitconfig-")
+	if err != nil {
+		return nil, err
+	}
+
+	// Preserve the pre-existing global config via include so we only ADD the gc
+	// overrides rather than replacing the user's/CI's global settings.
+	var prior string
+	if v := os.Getenv("GIT_CONFIG_GLOBAL"); v != "" {
+		prior = v
+	} else if home, herr := os.UserHomeDir(); herr == nil {
+		prior = filepath.Join(home, ".gitconfig")
+	}
+
+	var b strings.Builder
+	if prior != "" {
+		// A missing include path is silently ignored by git, so this is safe even
+		// when no global config exists.
+		fmt.Fprintf(&b, "[include]\n\tpath = %s\n", prior)
+	}
+	b.WriteString("[gc]\n\tauto = 0\n[maintenance]\n\tauto = false\n")
+
+	cfgPath := filepath.Join(dir, "gitconfig")
+	if writeErr := os.WriteFile(cfgPath, []byte(b.String()), 0o644); writeErr != nil {
+		_ = os.RemoveAll(dir)
+		return nil, writeErr
+	}
+
+	prev, had := os.LookupEnv("GIT_CONFIG_GLOBAL")
+	_ = os.Setenv("GIT_CONFIG_GLOBAL", cfgPath)
+	return func() {
+		if had {
+			_ = os.Setenv("GIT_CONFIG_GLOBAL", prev)
+		} else {
+			_ = os.Unsetenv("GIT_CONFIG_GLOBAL")
+		}
+		_ = os.RemoveAll(dir)
+	}, nil
+}

--- a/cmd/ingitdb/commands/rebase_test.go
+++ b/cmd/ingitdb/commands/rebase_test.go
@@ -17,6 +17,7 @@ func TestRebaseCommand(t *testing.T) {
 
 	// Initialize a git repo
 	runGit(t, tempDir, "init")
+	disableGitBackgroundMaintenance(t, tempDir)
 	runGit(t, tempDir, "config", "user.email", "test@example.com")
 	runGit(t, tempDir, "config", "user.name", "Test User")
 
@@ -120,6 +121,17 @@ func runGit(t *testing.T, dir string, args ...string) []byte {
 	return out
 }
 
+// disableGitBackgroundMaintenance turns off auto-gc and background maintenance
+// for a freshly-initialized test repo. Without this, `git commit` can spawn a
+// detached `git gc --auto` / `git maintenance` process that keeps writing to
+// .git/objects after the test returns, racing with t.TempDir()'s RemoveAll and
+// failing cleanup with "directory not empty".
+func disableGitBackgroundMaintenance(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "config", "gc.auto", "0")
+	runGit(t, dir, "config", "maintenance.auto", "false")
+}
+
 // setupRebaseCollectionReadmeConflict creates a git repo where rebasing main
 // onto base conflicts on a collection README.md. With secondConflict, main has
 // two README-changing commits so `git rebase --continue` hits a second
@@ -127,6 +139,7 @@ func runGit(t *testing.T, dir string, args ...string) []byte {
 func setupRebaseCollectionReadmeConflict(t *testing.T, dir string, secondConflict bool) string {
 	t.Helper()
 	runGit(t, dir, "init")
+	disableGitBackgroundMaintenance(t, dir)
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	runGit(t, dir, "config", "user.name", "Test User")
 


### PR DESCRIPTION
Fixes the intermittent CI failure `TestRebase_ContinueFails: TempDir RemoveAll cleanup: unlinkat .../.git/objects: directory not empty` (observed on PR #75's first run).

## Root cause
`git commit` can spawn a **detached** `git gc --auto` / `git maintenance` process. In a `t.TempDir()` git repo that process keeps writing to `.git/objects` after the test returns, racing with `RemoveAll` and failing cleanup with *directory not empty*. It's load-independent and rare, hence flaky.

## Fix (two complementary layers)
1. **Package-level `TestMain`** (`main_test.go`) installs a hermetic `GIT_CONFIG_GLOBAL` for every test in `cmd/ingitdb/commands` that **includes** the pre-existing global config (preserving `init.defaultBranch`, `safe.directory`, identity) and adds `gc.auto=0` + `maintenance.auto=false`. Covers every git-init test — current and future — automatically. Restored and removed on exit; process-local.
2. **Per-repo hardening** in the rebase tests (`disableGitBackgroundMaintenance`) sets the same knobs on each throwaway repo — belt-and-suspenders that still protects if a test overrides `HOME`/`GIT_CONFIG_GLOBAL`.

No production code changes — test-only. Per-repo config lives in the ephemeral temp repo and needs no restore.

## Verification
- `TestRebase*` run repeatedly with no cleanup error.
- `go build ./...`, `go test ./...`, `golangci-lint run` (0 issues) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)