### PR TITLE
feat(tui): evaluate computed columns lazily, only for painted cells

### DIFF
--- a/cmd/ingitdb/tui/collection_data_panel.go
+++ b/cmd/ingitdb/tui/collection_data_panel.go
@@ -103,16 +103,7 @@ func (m collectionModel) renderRecords(width, height int) string {
 	if end > len(m.records) {
 		end = len(m.records)
 	}
-	numericCol := make([]bool, len(cols))
-	if len(m.records) > 0 {
-		for i, c := range cols {
-			if m.isL10NDisplayCol(c) {
-				numericCol[i] = false
-			} else {
-				numericCol[i] = isNumeric(m.records[0][c])
-			}
-		}
-	}
+	numericCol := m.numericColumns(cols)
 	for ri := m.recordOffset; ri < end; ri++ {
 		cells := make([]string, len(visIdx))
 		for vi, i := range visIdx {
@@ -255,19 +246,31 @@ func stripAnsi(s string) string {
 	return b.String()
 }
 
-// computeColWidths calculates the display width for each column, capped at 30,
-// considering both column names and all record values.
+// computeColWidths calculates the display width for each column, capped at 30.
+// A stored column is sized from its header and all record values, as before. A
+// computed (FORMULA) column is sized from its header and declared length only —
+// its values are never sampled, because sampling would force evaluation.
 func (m collectionModel) computeColWidths() []int {
 	cols := m.columns
 	if len(cols) == 0 {
 		return nil
 	}
 	widths := make([]int, len(cols))
+	computed := make([]bool, len(cols))
 	for i, c := range cols {
 		widths[i] = uniseg.StringWidth(c)
+		if col := m.displayColDef(c); col != nil && col.Formula != "" {
+			computed[i] = true
+			if col.Length > widths[i] {
+				widths[i] = col.Length
+			}
+		}
 	}
 	for _, row := range m.records {
 		for i, c := range cols {
+			if computed[i] {
+				continue // never sample a computed column's value
+			}
 			raw := m.cellValue(row, c)
 			v := replaceRegionalIndicators(raw)
 			if w := uniseg.StringWidth(v); w > widths[i] {
@@ -281,6 +284,44 @@ func (m collectionModel) computeColWidths() []int {
 		}
 	}
 	return widths
+}
+
+// numericColumns reports, per display column, whether it should be right-aligned
+// as numeric. A computed column's alignment comes from its declared ColumnType
+// (never from sampling a value, which would force evaluation); a stored column's
+// alignment is detected from the first record's stored value, as before; an L10N
+// display column is never numeric.
+func (m collectionModel) numericColumns(cols []string) []bool {
+	numeric := make([]bool, len(cols))
+	for i, c := range cols {
+		if m.isL10NDisplayCol(c) {
+			continue
+		}
+		if col := m.displayColDef(c); col != nil && col.Formula != "" {
+			numeric[i] = isNumericType(col.Type)
+			continue
+		}
+		if len(m.records) > 0 {
+			numeric[i] = isNumeric(m.records[0][c])
+		}
+	}
+	return numeric
+}
+
+// displayColDef returns the column definition backing a display column, resolving
+// the "field.locale" form of an L10N display column to its base field. It returns
+// nil when the (base) field is not a declared column.
+func (m collectionModel) displayColDef(displayCol string) *ingitdb.ColumnDef {
+	baseField := displayCol
+	if dotIdx := strings.Index(displayCol, "."); dotIdx > 0 {
+		baseField = displayCol[:dotIdx]
+	}
+	return m.colDef.Columns[baseField]
+}
+
+// isNumericType reports whether a declared column type is right-aligned numeric.
+func isNumericType(t ingitdb.ColumnType) bool {
+	return t == ingitdb.ColumnTypeInt || t == ingitdb.ColumnTypeFloat
 }
 
 // visibleColumns returns the slice of column indices that fit within width,

--- a/cmd/ingitdb/tui/collection_data_panel.go
+++ b/cmd/ingitdb/tui/collection_data_panel.go
@@ -12,6 +12,11 @@ import (
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
 
+// computedCellError is the bounded indicator rendered in place of a painted
+// computed cell whose evaluation or coercion failed. It is a short, fixed string
+// so it is truncated to the column width like any other cell value.
+const computedCellError = "#ERR!"
+
 func (m collectionModel) renderRecords(width, height int) string {
 	if m.loading {
 		return mutedStyle.Render("Loading records…")
@@ -108,7 +113,12 @@ func (m collectionModel) renderRecords(width, height int) string {
 		cells := make([]string, len(visIdx))
 		for vi, i := range visIdx {
 			c := cols[i]
-			raw, _ := m.cellValueAt(ri, c)
+			raw, cellErr := m.cellValueAt(ri, c)
+			if cellErr != nil {
+				// A painted computed cell that errors renders a bounded error
+				// indicator; the rest of the screen keeps rendering.
+				raw = computedCellError
+			}
 			v := replaceRegionalIndicators(raw)
 			if uniseg.StringWidth(v) > colWidths[i] {
 				v = truncateToWidth(v, colWidths[i]-1) + "…"
@@ -119,8 +129,11 @@ func (m collectionModel) renderRecords(width, height int) string {
 			} else {
 				cell = padRight(v, colWidths[i])
 			}
-			if ri == m.recordCursor && i == m.colCursor {
+			switch {
+			case ri == m.recordCursor && i == m.colCursor:
 				cell = selectedItemStyle.Render(cell)
+			case cellErr != nil:
+				cell = errorCellStyle.Render(cell)
 			}
 			cells[vi] = cell
 		}

--- a/cmd/ingitdb/tui/collection_data_panel.go
+++ b/cmd/ingitdb/tui/collection_data_panel.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/rivo/uniseg"
 
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
 
@@ -113,11 +114,10 @@ func (m collectionModel) renderRecords(width, height int) string {
 		}
 	}
 	for ri := m.recordOffset; ri < end; ri++ {
-		row := m.records[ri]
 		cells := make([]string, len(visIdx))
 		for vi, i := range visIdx {
 			c := cols[i]
-			raw := m.cellValue(row, c)
+			raw, _ := m.cellValueAt(ri, c)
 			v := replaceRegionalIndicators(raw)
 			if uniseg.StringWidth(v) > colWidths[i] {
 				v = truncateToWidth(v, colWidths[i]-1) + "…"
@@ -465,6 +465,27 @@ func (m collectionModel) cellValue(row map[string]any, displayCol string) string
 		}
 	}
 	return fmt.Sprintf("%v", row[displayCol])
+}
+
+// cellValueAt resolves the display value for the painted cell at record index
+// rowIdx and column displayCol. Stored and L10N columns are read from the
+// retained stored-value map (identical to cellValue). A computed (FORMULA)
+// column is evaluated lazily through dalgo2ingitdb.AccessValue on the retained
+// row handle, so only painted computed cells are ever evaluated and dalgo's
+// per-row memoization is preserved across re-renders and scroll-back.
+func (m collectionModel) cellValueAt(rowIdx int, displayCol string) (string, error) {
+	baseField := displayCol
+	if dotIdx := strings.Index(displayCol, "."); dotIdx > 0 {
+		baseField = displayCol[:dotIdx]
+	}
+	if col, ok := m.colDef.Columns[baseField]; ok && col.Formula != "" {
+		v, err := dalgo2ingitdb.AccessValue(m.rows[rowIdx], m.rs, m.colDef.ID, m.recordKeys[rowIdx], baseField, col)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%v", v), nil
+	}
+	return m.cellValue(m.records[rowIdx], displayCol), nil
 }
 
 // isL10NDisplayCol returns true if the display column name corresponds to an

--- a/cmd/ingitdb/tui/collection_screen.go
+++ b/cmd/ingitdb/tui/collection_screen.go
@@ -6,13 +6,20 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/recordset"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
 
-// recordsLoadedMsg carries all records loaded from disk for a collection.
+// recordsLoadedMsg carries the records loaded from disk for a collection. It
+// holds the query recordset and its retained per-record row handles (so computed
+// columns resolve lazily, at paint time) plus each record's stored (non-computed)
+// field values for layout and locale discovery — never pre-evaluated computed
+// values.
 type recordsLoadedMsg struct {
+	rs      recordset.Recordset
+	rows    []recordset.Row
 	records []map[string]any
 	keys    []string
 	err     error
@@ -32,7 +39,9 @@ type collectionModel struct {
 	schemaOffset int
 
 	// right panel: records + scroll
-	records      []map[string]any
+	rs           recordset.Recordset // query recordset; computed columns resolve lazily on access
+	rows         []recordset.Row     // retained row handles so dalgo's per-row memoization survives re-renders
+	records      []map[string]any    // each record's stored (non-computed) values; computed cells resolve via rs/rows
 	recordKeys   []string
 	recordCursor int
 	recordOffset int
@@ -80,6 +89,8 @@ func (m collectionModel) Update(msg tea.Msg) (collectionModel, tea.Cmd) {
 
 	case recordsLoadedMsg:
 		m.loading = false
+		m.rs = msg.rs
+		m.rows = msg.rows
 		m.records = msg.records
 		m.recordKeys = msg.keys
 		m.locales = discoverLocales(m.records, m.colDef)
@@ -214,6 +225,8 @@ func loadRecordsCmd(db dal.DB, colDef *ingitdb.CollectionDef) tea.Cmd {
 		})
 
 		var (
+			rs      recordset.Recordset
+			rows    []recordset.Row
 			records []map[string]any
 			keys    []string
 		)
@@ -223,25 +236,31 @@ func loadRecordsCmd(db dal.DB, colDef *ingitdb.CollectionDef) tea.Cmd {
 				return txErr
 			}
 			defer func() { _ = reader.Close() }()
-			var names []string
+			var storedNames []string
 			for {
-				row, rs, nextErr := reader.Next()
+				row, rsLocal, nextErr := reader.Next()
 				if nextErr != nil {
 					break
 				}
-				if names == nil {
-					names = dalgo2ingitdb.AllColumnNames(rs)
+				rs = rsLocal
+				if storedNames == nil {
+					// Read only stored (non-computed) columns: computed columns are
+					// resolved lazily at paint time, never eagerly at load.
+					storedNames = dalgo2ingitdb.StoredColumnNames(rs)
 				}
 				recKey := dalgo2ingitdb.RowKey(row, rs)
-				data, derr := dalgo2ingitdb.RowData(row, rs, colID, recKey, colDef, names)
+				stored, derr := dalgo2ingitdb.RowData(row, rs, colID, recKey, colDef, storedNames)
 				if derr != nil {
 					return derr
 				}
+				// Retain the row handle so dalgo's per-row memoization of computed
+				// values survives re-renders and scroll-back.
+				rows = append(rows, row)
 				keys = append(keys, recKey)
-				records = append(records, data)
+				records = append(records, stored)
 			}
 			return nil
 		})
-		return recordsLoadedMsg{records: records, keys: keys, err: err}
+		return recordsLoadedMsg{rs: rs, rows: rows, records: records, keys: keys, err: err}
 	}
 }

--- a/cmd/ingitdb/tui/coverage_gaps_test.go
+++ b/cmd/ingitdb/tui/coverage_gaps_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -90,6 +91,52 @@ func (mockDB) RunReadonlyTransaction(_ context.Context, f dal.ROTxWorker, _ ...d
 }
 func (mockDB) RunReadwriteTransaction(_ context.Context, _ dal.RWTxWorker, _ ...dal.TransactionOption) error {
 	return errors.New("not implemented")
+}
+
+// boomColumn is a stored recordset column whose value read always fails, used to
+// exercise loadRecordsCmd's per-row read-error path.
+type boomColumn struct{}
+
+func (boomColumn) Name() string              { return "boom" }
+func (boomColumn) DefaultValue() any         { return nil }
+func (boomColumn) GetValue(int) (any, error) { return nil, errors.New("boom") }
+func (boomColumn) SetValue(int, any) error   { return nil }
+func (boomColumn) DbType() string            { return "" }
+func (boomColumn) ValueType() reflect.Type   { return reflect.TypeOf((*any)(nil)).Elem() }
+func (boomColumn) IsBitmap() bool            { return false }
+func (boomColumn) Add(any) error             { return nil }
+func (boomColumn) Values() []any             { return nil }
+
+// boomRecordsetReader yields one row over a recordset whose only stored column
+// errors on read.
+type boomRecordsetReader struct {
+	rs   recordset.Recordset
+	done bool
+}
+
+func (r *boomRecordsetReader) Next() (recordset.Row, recordset.Recordset, error) {
+	if r.done {
+		return nil, r.rs, dal.ErrNoMoreRecords
+	}
+	r.done = true
+	return r.rs.GetRow(0), r.rs, nil
+}
+func (r *boomRecordsetReader) Recordset() recordset.Recordset { return r.rs }
+func (r *boomRecordsetReader) Cursor() (string, error)        { return "", nil }
+func (r *boomRecordsetReader) Close() error                   { return nil }
+
+type boomTx struct{ mockTx }
+
+func (boomTx) ExecuteQueryToRecordsetReader(_ context.Context, _ dal.Query, _ ...recordset.Option) (dal.RecordsetReader, error) {
+	rs := recordset.NewColumnarRecordset("people", boomColumn{})
+	rs.NewRow()
+	return &boomRecordsetReader{rs: rs}, nil
+}
+
+type boomDB struct{ mockDB }
+
+func (boomDB) RunReadonlyTransaction(_ context.Context, f dal.ROTxWorker, _ ...dal.TransactionOption) error {
+	return f(context.Background(), boomTx{})
 }
 
 // ---------------------------------------------------------------------------
@@ -178,10 +225,12 @@ func TestLoadRecordsCmd_Success(t *testing.T) {
 	}
 }
 
-// TestLoadRecordsCmd_ComputedError exercises the per-row RowData error path: a
-// computed column whose formula raises at runtime aborts the load (the cells the
-// TUI would render are read through the shared coerce-on-access accessor).
-func TestLoadRecordsCmd_ComputedError(t *testing.T) {
+// TestLoadRecordsCmd_ComputedColumnNotEvaluatedAtLoad proves the lazy load: a
+// computed column whose formula raises at runtime does NOT abort the load,
+// because loadRecordsCmd reads only stored columns. The erroring formula is
+// never evaluated at load time (it would surface only if its cell were painted),
+// and the load retains the recordset + row handles for lazy paint-time access.
+func TestLoadRecordsCmd_ComputedColumnNotEvaluatedAtLoad(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -217,8 +266,36 @@ func TestLoadRecordsCmd_ComputedError(t *testing.T) {
 	if !ok {
 		t.Fatalf("cmd() returned %T, want recordsLoadedMsg", msg)
 	}
+	if loaded.err != nil {
+		t.Fatalf("load must not abort on an erroring computed column: %v", loaded.err)
+	}
+	if len(loaded.records) != 1 {
+		t.Fatalf("loaded %d records, want 1", len(loaded.records))
+	}
+	if _, ok := loaded.records[0]["ratio"]; ok {
+		t.Error(`computed column "ratio" must not be evaluated or materialized at load time`)
+	}
+	if loaded.records[0]["qty"] == nil {
+		t.Error(`stored column "qty" should be loaded`)
+	}
+	if loaded.rs == nil || len(loaded.rows) != 1 {
+		t.Error("load should retain the recordset and row handles for lazy paint-time evaluation")
+	}
+}
+
+// TestLoadRecordsCmd_StoredReadError covers loadRecordsCmd's per-row read-error
+// path: a stored column whose value read fails surfaces as the load's error.
+func TestLoadRecordsCmd_StoredReadError(t *testing.T) {
+	t.Parallel()
+
+	colDef := simpleColDef("people", "boom")
+	msg := loadRecordsCmd(boomDB{}, colDef)()
+	loaded, ok := msg.(recordsLoadedMsg)
+	if !ok {
+		t.Fatalf("cmd() returned %T, want recordsLoadedMsg", msg)
+	}
 	if loaded.err == nil {
-		t.Fatal("expected error from erroring computed column")
+		t.Fatal("expected the load to surface the stored-column read error")
 	}
 }
 

--- a/cmd/ingitdb/tui/lazy_eval_test.go
+++ b/cmd/ingitdb/tui/lazy_eval_test.go
@@ -156,3 +156,129 @@ func TestCellValueAt_ComputedErrorPropagated(t *testing.T) {
 		t.Errorf("cellValueAt(qty) = (%q, %v), want (\"1\", nil)", v, err)
 	}
 }
+
+// AC: width-sizing-does-not-evaluate — computeColWidths never invokes the
+// evaluator, and a computed column's width derives from its header label.
+func TestLazy_WidthSizingDoesNotEvaluate(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	m := newLazyModel(5, &calls)
+
+	widths := m.computeColWidths()
+
+	if calls != 0 {
+		t.Fatalf("computeColWidths invoked the evaluator %d times, want 0", calls)
+	}
+	// columns: [qty, ratio]; ratio has no declared length, so its width is its
+	// header label width.
+	if want := len("ratio"); widths[1] != want {
+		t.Errorf("computed column width = %d, want %d (header-derived, no value sampling)", widths[1], want)
+	}
+}
+
+// AC: width-sizing-does-not-evaluate (declared-length path) — a computed
+// column's width honors its declared length without sampling any value.
+func TestLazy_ComputedWidthFromDeclaredLength(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	colDef := &ingitdb.CollectionDef{
+		ID: "items",
+		Columns: map[string]*ingitdb.ColumnDef{
+			"x":     {Type: ingitdb.ColumnTypeString},
+			"label": {Type: ingitdb.ColumnTypeString, Formula: "x", Length: 12},
+		},
+		ColumnsOrder: []string{"x", "label"},
+	}
+	rs := recordset.NewColumnarRecordset(colDef.ID,
+		recordset.NewColumn[string]("x", ""),
+		recordset.NewComputedColumn("label", countingTUIEvaluator{&calls}),
+	)
+	row := rs.NewRow()
+	_ = row.SetValueByName("x", "hi", rs)
+	m := collectionModel{
+		colDef:     colDef,
+		columns:    []string{"x", "label"},
+		rs:         rs,
+		rows:       []recordset.Row{row},
+		records:    []map[string]any{{"x": "hi"}},
+		recordKeys: []string{"r0"},
+	}
+
+	widths := m.computeColWidths()
+
+	if calls != 0 {
+		t.Fatalf("computeColWidths invoked the evaluator %d times, want 0", calls)
+	}
+	if widths[1] != 12 {
+		t.Errorf("computed column width = %d, want 12 (declared length)", widths[1])
+	}
+}
+
+// AC: numeric-alignment-does-not-evaluate — an int computed column is
+// right-aligned (numeric) from its declared type, with no evaluator call.
+func TestLazy_NumericAlignmentFromTypeDoesNotEvaluate(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	m := newLazyModel(5, &calls)
+
+	numeric := m.numericColumns(m.columns)
+
+	if calls != 0 {
+		t.Fatalf("alignment determination invoked the evaluator %d times, want 0", calls)
+	}
+	// columns: [qty (stored int), ratio (computed int)] — both numeric.
+	if !numeric[1] {
+		t.Error("int computed column should be right-aligned (numeric) from its declared type")
+	}
+}
+
+// A non-numeric computed column is not right-aligned, decided from its declared
+// type without evaluation.
+func TestNumericColumns_ComputedStringNotNumeric(t *testing.T) {
+	t.Parallel()
+	colDef := &ingitdb.CollectionDef{
+		ID: "items",
+		Columns: map[string]*ingitdb.ColumnDef{
+			"x":    {Type: ingitdb.ColumnTypeString},
+			"name": {Type: ingitdb.ColumnTypeString, Formula: "x"},
+		},
+		ColumnsOrder: []string{"x", "name"},
+	}
+	m := collectionModel{
+		colDef:  colDef,
+		columns: []string{"x", "name"},
+		records: []map[string]any{{"x": "hi"}},
+	}
+
+	numeric := m.numericColumns(m.columns)
+
+	if numeric[1] {
+		t.Error("string computed column must not be right-aligned")
+	}
+}
+
+// AC: stored-locale-discovery-unchanged — locale keys present only on an
+// off-viewport record still appear; locale discovery scans every record's
+// stored values, exactly as before this Feature.
+func TestLazy_StoredLocaleDiscoveryScansAllRecords(t *testing.T) {
+	t.Parallel()
+	colDef := &ingitdb.CollectionDef{
+		ID: "things",
+		Columns: map[string]*ingitdb.ColumnDef{
+			"title": {Type: ingitdb.ColumnTypeL10N},
+		},
+		ColumnsOrder: []string{"title"},
+	}
+	// "fr" appears only on the second record — the one that would sit outside a
+	// short visible window.
+	records := []map[string]any{
+		{"title": map[string]any{"en": "Hello"}},
+		{"title": map[string]any{"en": "Hi", "fr": "Bonjour"}},
+	}
+
+	got := discoverLocales(records, colDef)
+
+	if len(got) != 2 || got[0] != "en" || got[1] != "fr" {
+		t.Errorf("discoverLocales = %v, want [en fr] (off-viewport locale must be discovered)", got)
+	}
+}

--- a/cmd/ingitdb/tui/lazy_eval_test.go
+++ b/cmd/ingitdb/tui/lazy_eval_test.go
@@ -1,0 +1,158 @@
+package tui
+
+// lazy_eval_test.go drives the collection model with a counting recordset
+// evaluator (as in pkg/dalgo2ingitdb's recordset tests) to prove that computed
+// columns are evaluated only for painted cells — never for off-viewport rows —
+// and that per-row memoization survives re-renders and scroll-back.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dal-go/dalgo/recordset"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// countingTUIEvaluator records how many times a computed column is evaluated.
+type countingTUIEvaluator struct{ calls *int }
+
+func (e countingTUIEvaluator) Eval(_ map[string]any) (any, error) {
+	*e.calls++
+	return int64(99), nil
+}
+
+// erroringTUIEvaluator always fails, so a painted computed cell surfaces an error.
+type erroringTUIEvaluator struct{}
+
+func (erroringTUIEvaluator) Eval(_ map[string]any) (any, error) {
+	return nil, fmt.Errorf("boom")
+}
+
+// lazyTestColDef is a collection with one stored column (qty) and one computed
+// column (ratio).
+func lazyModelColDef() *ingitdb.CollectionDef {
+	return &ingitdb.CollectionDef{
+		ID: "items",
+		Columns: map[string]*ingitdb.ColumnDef{
+			"qty":   {Type: ingitdb.ColumnTypeInt},
+			"ratio": {Type: ingitdb.ColumnTypeInt, Formula: "qty * 2"},
+		},
+		ColumnsOrder: []string{"qty", "ratio"},
+	}
+}
+
+// newLazyModel builds a collection model backed by a recordset whose computed
+// "ratio" column is bound to the counting evaluator. The row handles are
+// retained on the model exactly as loadRecordsCmd retains them, so the test
+// exercises real per-row memoization.
+func newLazyModel(total int, calls *int) collectionModel {
+	colDef := lazyModelColDef()
+	qtyCol := recordset.NewColumn[int64]("qty", 0)
+	ratioCol := recordset.NewComputedColumn("ratio", countingTUIEvaluator{calls})
+	rs := recordset.NewColumnarRecordset(colDef.ID, qtyCol, ratioCol)
+
+	rows := make([]recordset.Row, total)
+	records := make([]map[string]any, total)
+	keys := make([]string, total)
+	for i := 0; i < total; i++ {
+		row := rs.NewRow()
+		_ = row.SetValueByName("qty", int64(i+1), rs)
+		rows[i] = row
+		records[i] = map[string]any{"qty": int64(i + 1)}
+		keys[i] = fmt.Sprintf("r%d", i)
+	}
+
+	m := collectionModel{
+		colDef:     colDef,
+		columns:    []string{"qty", "ratio"},
+		rs:         rs,
+		rows:       rows,
+		records:    records,
+		recordKeys: keys,
+	}
+	m.colWidths = m.computeColWidths()
+	return m
+}
+
+// AC: off-viewport-rows-not-evaluated — rendering without scrolling evaluates
+// the computed column only for the V visible records, never for off-viewport
+// records; and load + width sizing evaluate nothing.
+func TestLazy_OffViewportRowsNotEvaluated(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	const total, height = 10, 7 // renderRecords: visibleRows = height-4 = 3
+	const wantVisible = 3
+	m := newLazyModel(total, &calls)
+
+	if calls != 0 {
+		t.Fatalf("load and width sizing evaluated %d computed cells, want 0", calls)
+	}
+
+	_ = m.renderRecords(80, height)
+
+	if calls != wantVisible {
+		t.Errorf("evaluator invoked %d times, want %d (one per visible record, zero for the %d off-viewport records)",
+			calls, wantVisible, total-wantVisible)
+	}
+}
+
+// AC: scroll-evaluates-only-newly-visible — after scrolling so a previously
+// off-viewport record becomes visible, only that newly-visible record is
+// evaluated; repainted records are not evaluated a second time (retained row
+// handles preserve dalgo's per-row memoization).
+func TestLazy_ScrollEvaluatesOnlyNewlyVisible(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	const total, height = 10, 7 // V = 3
+	m := newLazyModel(total, &calls)
+
+	_ = m.renderRecords(80, height) // paints records 0,1,2
+	if calls != 3 {
+		t.Fatalf("first render evaluated %d computed cells, want 3", calls)
+	}
+
+	// Scroll down by one row: records 1,2,3 are now visible. Record 3 is newly
+	// visible; records 1 and 2 are repainted from their retained, memoized row
+	// handles and must not be evaluated again.
+	m.recordOffset = 1
+	_ = m.renderRecords(80, height)
+
+	if calls != 4 {
+		t.Errorf("after scroll evaluator invoked %d times total, want 4 (only newly-visible record 3 evaluated; repainted records 1,2 memoized)", calls)
+	}
+}
+
+// cellValueAt resolves a computed cell through AccessValue and propagates an
+// evaluation error to its caller (the render path decides how to surface it).
+func TestCellValueAt_ComputedErrorPropagated(t *testing.T) {
+	t.Parallel()
+	colDef := lazyModelColDef()
+	rs := recordset.NewColumnarRecordset(colDef.ID,
+		recordset.NewColumn[int64]("qty", 0),
+		recordset.NewComputedColumn("ratio", erroringTUIEvaluator{}),
+	)
+	row := rs.NewRow()
+	_ = row.SetValueByName("qty", int64(1), rs)
+	m := collectionModel{
+		colDef:     colDef,
+		columns:    []string{"qty", "ratio"},
+		rs:         rs,
+		rows:       []recordset.Row{row},
+		records:    []map[string]any{{"qty": int64(1)}},
+		recordKeys: []string{"r0"},
+	}
+
+	got, err := m.cellValueAt(0, "ratio")
+	if err == nil {
+		t.Fatalf("cellValueAt(ratio) error = nil, want an error; value=%q", got)
+	}
+	if got != "" {
+		t.Errorf("cellValueAt(ratio) value = %q on error, want empty", got)
+	}
+
+	// A stored column on the same row resolves without error.
+	if v, err := m.cellValueAt(0, "qty"); err != nil || v != "1" {
+		t.Errorf("cellValueAt(qty) = (%q, %v), want (\"1\", nil)", v, err)
+	}
+}

--- a/cmd/ingitdb/tui/lazy_eval_test.go
+++ b/cmd/ingitdb/tui/lazy_eval_test.go
@@ -7,6 +7,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/dal-go/dalgo/recordset"
@@ -29,6 +30,19 @@ func (erroringTUIEvaluator) Eval(_ map[string]any) (any, error) {
 	return nil, fmt.Errorf("boom")
 }
 
+// qtyZeroErrorEvaluator counts calls and fails only when the row's stored qty is
+// zero — modelling a formula like "100 / qty" that raises on some rows but not
+// others, so the error is row-positioned.
+type qtyZeroErrorEvaluator struct{ calls *int }
+
+func (e qtyZeroErrorEvaluator) Eval(stored map[string]any) (any, error) {
+	*e.calls++
+	if stored["qty"] == int64(0) {
+		return nil, fmt.Errorf("division by zero")
+	}
+	return int64(99), nil
+}
+
 // lazyTestColDef is a collection with one stored column (qty) and one computed
 // column (ratio).
 func lazyModelColDef() *ingitdb.CollectionDef {
@@ -42,24 +56,25 @@ func lazyModelColDef() *ingitdb.CollectionDef {
 	}
 }
 
-// newLazyModel builds a collection model backed by a recordset whose computed
-// "ratio" column is bound to the counting evaluator. The row handles are
-// retained on the model exactly as loadRecordsCmd retains them, so the test
-// exercises real per-row memoization.
-func newLazyModel(total int, calls *int) collectionModel {
+// buildModelWithQtys builds a collection model over a recordset with one stored
+// "qty" column (one row per supplied value) and a computed "ratio" column bound
+// to eval. Row handles are retained on the model exactly as loadRecordsCmd
+// retains them, so the tests exercise real per-row memoization.
+func buildModelWithQtys(qtys []int64, eval recordset.Evaluator) collectionModel {
 	colDef := lazyModelColDef()
-	qtyCol := recordset.NewColumn[int64]("qty", 0)
-	ratioCol := recordset.NewComputedColumn("ratio", countingTUIEvaluator{calls})
-	rs := recordset.NewColumnarRecordset(colDef.ID, qtyCol, ratioCol)
+	rs := recordset.NewColumnarRecordset(colDef.ID,
+		recordset.NewColumn[int64]("qty", 0),
+		recordset.NewComputedColumn("ratio", eval),
+	)
 
-	rows := make([]recordset.Row, total)
-	records := make([]map[string]any, total)
-	keys := make([]string, total)
-	for i := 0; i < total; i++ {
+	rows := make([]recordset.Row, len(qtys))
+	records := make([]map[string]any, len(qtys))
+	keys := make([]string, len(qtys))
+	for i, q := range qtys {
 		row := rs.NewRow()
-		_ = row.SetValueByName("qty", int64(i+1), rs)
+		_ = row.SetValueByName("qty", q, rs)
 		rows[i] = row
-		records[i] = map[string]any{"qty": int64(i + 1)}
+		records[i] = map[string]any{"qty": q}
 		keys[i] = fmt.Sprintf("r%d", i)
 	}
 
@@ -73,6 +88,16 @@ func newLazyModel(total int, calls *int) collectionModel {
 	}
 	m.colWidths = m.computeColWidths()
 	return m
+}
+
+// newLazyModel builds a model of `total` records (qty = 1..total) whose computed
+// column is bound to the counting evaluator.
+func newLazyModel(total int, calls *int) collectionModel {
+	qtys := make([]int64, total)
+	for i := range qtys {
+		qtys[i] = int64(i + 1)
+	}
+	return buildModelWithQtys(qtys, countingTUIEvaluator{calls})
 }
 
 // AC: off-viewport-rows-not-evaluated — rendering without scrolling evaluates
@@ -280,5 +305,47 @@ func TestLazy_StoredLocaleDiscoveryScansAllRecords(t *testing.T) {
 
 	if len(got) != 2 || got[0] != "en" || got[1] != "fr" {
 		t.Errorf("discoverLocales = %v, want [en fr] (off-viewport locale must be discovered)", got)
+	}
+}
+
+// AC: visible-computed-error-non-fatal — a painted computed cell whose
+// evaluation fails renders a bounded error indicator, and the rest of the screen
+// keeps rendering (no crash, no aborted load).
+func TestLazy_VisibleComputedErrorNonFatal(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	// Record 0's computed cell errors (qty=0); records 1 and 2 compute fine. All
+	// three are within the visible window (visibleRows = height-4 = 3).
+	m := buildModelWithQtys([]int64{0, 2, 3}, qtyZeroErrorEvaluator{&calls})
+
+	out := m.renderRecords(80, 7)
+
+	if !strings.Contains(out, computedCellError) {
+		t.Errorf("expected bounded error indicator %q in render output, got:\n%s", computedCellError, out)
+	}
+	// The screen keeps rendering its other cells — the non-erroring computed
+	// values (99) and the stored qty values are all present.
+	if !strings.Contains(out, "99") {
+		t.Error("screen should keep rendering the non-erroring rows around the erroring cell")
+	}
+}
+
+// AC: off-viewport-error-never-evaluated — an erroring computed column on
+// off-viewport records is never evaluated, so the screen renders normally and no
+// error surfaces.
+func TestLazy_OffViewportErrorNeverEvaluated(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	// Visible window (3 rows) shows records 0..2 with qty 1,2,3 (compute fine).
+	// Records 3..5 have qty=0 and would error — but they are off-viewport.
+	m := buildModelWithQtys([]int64{1, 2, 3, 0, 0, 0}, qtyZeroErrorEvaluator{&calls})
+
+	out := m.renderRecords(80, 7)
+
+	if strings.Contains(out, computedCellError) {
+		t.Errorf("off-viewport erroring rows must not surface an error indicator; output:\n%s", out)
+	}
+	if calls != 3 {
+		t.Errorf("evaluator invoked %d times, want 3 (only the visible non-erroring rows; off-viewport erroring rows never evaluated)", calls)
 	}
 }

--- a/cmd/ingitdb/tui/styles.go
+++ b/cmd/ingitdb/tui/styles.go
@@ -15,6 +15,7 @@ var (
 	colorText      = lipgloss.Color("#F9FAFB")
 	colorAccent    = lipgloss.Color("#A78BFA")
 	colorGreen     = lipgloss.Color("#34D399")
+	colorError     = lipgloss.Color("#F87171")
 
 	// white is a plain color.Color used for the header text.
 	white color.Color = lipgloss.Color("#FFFFFF")
@@ -76,4 +77,7 @@ var (
 
 	helpStyle = lipgloss.NewStyle().
 			Foreground(colorMuted)
+
+	errorCellStyle = lipgloss.NewStyle().
+			Foreground(colorError)
 )

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -44,6 +44,7 @@ This directory tracks the SpecScore feature specifications for the **ingitdb-cli
 | [record-key](record-key/README.md) | Draft | Umbrella for canonical record identity behavior across schema validation, storage paths, writes, and CLI key surfaces. |
 | [computed-columns](computed-columns/README.md) | Approved | TODO: Add description. |
 | [computed-columns-via-dalgo](computed-columns-via-dalgo/README.md) | Approved | TODO: Add description. |
+| [tui-lazy-computed-cells](tui-lazy-computed-cells/README.md) | Approved | TODO: Add description. |
 
 ## Feature Summaries
 

--- a/spec/features/tui-lazy-computed-cells/README.md
+++ b/spec/features/tui-lazy-computed-cells/README.md
@@ -1,0 +1,211 @@
+# Feature: TUI lazy computed-cell evaluation
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=request-change) |
+**Status:** Approved
+**Date:** 2026-06-03
+**Owner:** alex
+**Source Ideas:** —
+**Supersedes:** —
+**Grade:** A
+
+## Summary
+
+Makes the TUI collection screen evaluate a computed (FORMULA) column only for
+the cells it actually paints — the visible row × column window — so hidden and
+off-viewport computed columns are never evaluated. It serves ingitdb users
+browsing collections with expensive computed columns by keeping the screen
+responsive regardless of row count.
+
+## Problem
+
+`computed-columns-via-dalgo` moved read consumers onto dalgo's lazy
+`recordset.Evaluator`, but the TUI collection screen was migrated
+byte-identically: `loadRecordsCmd` pre-builds a full `map[string]any` per record
+(reading every column), and `computeColWidths`/`numericCol` scan all rows ×
+columns. So every computed column is evaluated up front for every record, even
+ones never scrolled into view — exactly what `computed-columns-via-dalgo`'s
+`REQ:all-consumers-via-recordset` says the TUI must avoid ("The TUI MUST read
+only the cells it renders, so hidden or off-viewport computed columns are not
+evaluated"). Captured as seed
+`spec/ideas/seeds/tui-collection-screen-should-evaluate-only-painted-visible.md`.
+
+The screen already virtualizes row rendering to the visible window; the parts
+that force full computed evaluation are (1) the pre-built per-record maps, (2)
+column-width sizing across all rows, and (3) numeric-alignment sampling of the
+first row. Locale discovery and stored-column sizing read only stored values, so
+they never trigger formula evaluation and stay as they are.
+
+## Behavior
+
+### Lazy computed-cell evaluation
+
+The collection screen holds the recordset and its row handles and resolves
+computed values at paint time through the shared coerce-on-access accessor.
+
+#### REQ: model-holds-recordset
+
+The collection screen model MUST hold the query's `recordset.Recordset` and its
+per-record row handles (plus record keys), rather than pre-evaluated
+`map[string]any` records for computed columns. `loadRecordsCmd` MUST NOT eagerly
+evaluate computed columns at load time.
+
+#### REQ: render-time-computed-eval
+
+A computed column's value MUST be produced only when its cell is painted — i.e.
+the record is within the visible row window AND the column is within the visible
+column window. A computed column for an off-viewport row or an off-viewport
+column MUST NOT be evaluated.
+
+#### REQ: per-row-memoization
+
+The model MUST retain the recordset row handles across re-renders so that
+dalgo's per-row memoization holds: a given record's computed cell is evaluated at
+most once regardless of how many times it is repainted (re-render, scroll away
+and back). The model MUST NOT reconstruct row handles per render frame.
+
+### Sizing and layout without forcing evaluation
+
+Computed columns must not be evaluated merely to lay out the table.
+
+#### REQ: computed-width-from-schema
+
+A computed (FORMULA) column's display width MUST be derived from its header label
+and declared `ColumnType`/length, without sampling any row's value. Width sizing
+MUST NOT evaluate a computed column. (Long computed values may therefore be
+truncated to that width with the existing ellipsis behavior.)
+
+#### REQ: numeric-alignment-from-type
+
+A computed column's numeric (right) alignment MUST be determined from its
+declared `ColumnType` (numeric types align right), not by sampling a record's
+value. Determining alignment MUST NOT evaluate a computed column.
+
+#### REQ: stored-columns-unchanged
+
+Stored (non-computed) columns MUST retain today's behavior: column-width sizing,
+locale discovery (the locale dropdown contents), and numeric-alignment detection
+MAY scan all records' stored values. Reading stored values never triggers
+formula evaluation, so these scans stay full and observably unchanged.
+
+### Error surfacing
+
+Because evaluation is lazy, a formula error can only occur for a painted cell.
+
+#### REQ: visible-error-non-fatal
+
+If a painted computed cell's evaluation (or coercion) errors, the cell MUST
+render a bounded error indicator and the collection screen MUST continue to
+render its other rows and columns — the error MUST NOT abort the screen or crash
+the TUI. An off-viewport erroring computed column is never evaluated and
+therefore MUST NOT affect the screen.
+
+## Acceptance Criteria
+
+### AC: off-viewport-rows-not-evaluated (verifies REQ:model-holds-recordset, REQ:render-time-computed-eval)
+
+**Given** a collection with a computed column bound to a counting evaluator and more records than fit the visible row window of height `V`
+**When** the collection screen renders without scrolling
+**Then** the evaluator is invoked only for the computed cells of the `V` visible records, and zero times for the off-viewport records
+
+### AC: scroll-evaluates-only-newly-visible (verifies REQ:render-time-computed-eval, REQ:per-row-memoization)
+
+**Given** the same collection rendered once at the top
+**When** the user scrolls so a previously off-viewport record becomes visible and a previously visible record is repainted
+**Then** the newly-visible record's computed cell is evaluated, and the repainted record's computed cell is not evaluated a second time
+
+### AC: width-sizing-does-not-evaluate (verifies REQ:computed-width-from-schema)
+
+**Given** a collection with a computed column bound to a counting evaluator
+**When** the screen computes column widths
+**Then** the evaluator is not invoked during width computation, and the computed column's width equals the width derived from its header label and declared type
+
+### AC: numeric-alignment-does-not-evaluate (verifies REQ:numeric-alignment-from-type)
+
+**Given** an `int` computed column bound to a counting evaluator
+**When** the screen determines column alignment
+**Then** the column is right-aligned (numeric) and the evaluator is not invoked to decide alignment
+
+### AC: stored-locale-discovery-unchanged (verifies REQ:stored-columns-unchanged)
+
+**Given** a collection with an L10N stored column whose locale keys appear only on records outside the visible window
+**When** the locale dropdown is built
+**Then** every locale present across all records — including off-viewport ones — appears in the dropdown, exactly as before this Feature
+
+### AC: visible-computed-error-non-fatal (verifies REQ:visible-error-non-fatal)
+
+**Given** a collection with a computed column whose formula raises at runtime, positioned within the visible window
+**When** the collection screen renders
+**Then** the erroring cell shows a bounded error indicator and the screen still renders its other cells without crashing or aborting the load
+
+### AC: off-viewport-error-never-evaluated (verifies REQ:render-time-computed-eval, REQ:visible-error-non-fatal)
+
+**Given** a collection with a computed column whose formula raises at runtime, positioned only on off-viewport records
+**When** the collection screen renders
+**Then** the screen renders normally and the erroring computed column is never evaluated
+
+## Architecture & Components
+
+| Unit | What it does | Depends on |
+|------|--------------|-----------|
+| `collectionModel` (refactor, `cmd/ingitdb/tui`) | Holds `recordset.Recordset` + row handles + keys instead of `[]map[string]any` for computed values. | `dalgo2ingitdb` recordset reader, `AccessValue` |
+| `loadRecordsCmd` (refactor) | Returns the recordset + row handles; stops pre-evaluating computed columns. | `ExecuteQueryToRecordsetReader` |
+| `cellValue` (refactor) | Resolves a cell at paint time via `dalgo2ingitdb.AccessValue` (stored = pass-through, computed = lazy evaluate+coerce). | `AccessValue` |
+| `computeColWidths` / numeric/locale helpers (refactor) | Computed columns sized/aligned from schema; stored columns keep scanning stored values. | `ColumnDef`, recordset stored columns |
+
+## Data Flow
+
+1. `loadRecordsCmd` opens `ExecuteQueryToRecordsetReader`, collects the row
+   handles + keys + the recordset, and hands them to the model (no computed
+   evaluation).
+2. On render, the panel paints the visible row × column window; each painted
+   cell calls `cellValue` → `AccessValue` (computed columns evaluate lazily and
+   memoize per row; stored columns pass through).
+3. Width/alignment for computed columns come from the schema; for stored columns
+   from the existing stored-value scans. Locale discovery scans stored L10N
+   columns across all records (no formula evaluation).
+
+## Error Handling & Failure Modes
+
+- **Painted computed cell errors** → bounded error indicator in that cell; screen
+  keeps rendering (REQ:visible-error-non-fatal). No load abort.
+- **Off-viewport computed column errors** → never evaluated, no effect.
+- **Stored-value read** → unchanged; cannot trigger formula evaluation.
+
+## Testing Strategy
+
+Go tests in `cmd/ingitdb/tui` drive the model with a counting `recordset.Evaluator`
+(as in `pkg/dalgo2ingitdb`'s recordset tests) and assert evaluation counts for
+the visible vs off-viewport windows, width/alignment without evaluation, locale
+discovery parity, and non-fatal visible-error rendering. Row virtualization is
+already exercised by existing scroll tests.
+
+## Rehearse Integration
+
+Every AC has a concrete unit surface (the collection model's render/layout
+functions with a counting evaluator and a bounded viewport), so one Rehearse
+Scenario stub per AC is scaffolded under `_tests/`.
+
+## Not Doing / Out of Scope
+
+- Bounding stored-column scans (locale discovery, stored-column widths, numeric
+  detection) to the viewport — stored reads never evaluate formulas, so they stay
+  full and unchanged.
+- Changing the data-layer lazy contract (`recordset.Evaluator`, `AccessValue`) —
+  unchanged; this Feature only changes how the TUI consumes it.
+- Caching computed values beyond dalgo's per-row memoization.
+- Horizontal/vertical scrollbar or viewport UX changes beyond what evaluation
+  laziness requires.
+
+## Assumption Carryover
+
+From `computed-columns-via-dalgo` (shipped): `AccessValue` coerces computed
+columns and passes stored values through; dalgo memoizes computed values per row
+instance. This Feature relies on both and additionally requires the model to
+retain row instances so memoization survives re-renders.
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/features/tui-lazy-computed-cells/_tests/README.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/README.md
@@ -1,0 +1,27 @@
+# Rehearse Scenarios: TUI lazy computed-cell evaluation
+
+**Status:** Draft
+**Date:** 2026-06-03
+**Owner:** alexander.trakhimenok@gmail.com
+
+Pending Rehearse Scenario stubs for the [tui-lazy-computed-cells](../README.md) Feature.
+One stub per acceptance criterion; each carries a `## TODO` checklist until wired up.
+
+## Contents
+
+| Scenario | Verifies REQ |
+|----------|--------------|
+| [off-viewport-rows-not-evaluated](render-time-computed-eval-off-viewport-rows-not-evaluated.md) | render-time-computed-eval |
+| [scroll-evaluates-only-newly-visible](per-row-memoization-scroll-evaluates-only-newly-visible.md) | per-row-memoization |
+| [width-sizing-does-not-evaluate](computed-width-from-schema-width-sizing-does-not-evaluate.md) | computed-width-from-schema |
+| [numeric-alignment-does-not-evaluate](numeric-alignment-from-type-numeric-alignment-does-not-evaluate.md) | numeric-alignment-from-type |
+| [stored-locale-discovery-unchanged](stored-columns-unchanged-stored-locale-discovery-unchanged.md) | stored-columns-unchanged |
+| [visible-computed-error-non-fatal](visible-error-non-fatal-visible-computed-error-non-fatal.md) | visible-error-non-fatal |
+| [off-viewport-error-never-evaluated](render-time-computed-eval-off-viewport-error-never-evaluated.md) | render-time-computed-eval |
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/scenarios-index-specification*

--- a/spec/features/tui-lazy-computed-cells/_tests/computed-width-from-schema-width-sizing-does-not-evaluate.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/computed-width-from-schema-width-sizing-does-not-evaluate.md
@@ -1,0 +1,22 @@
+# Scenario: width-sizing-does-not-evaluate
+
+**Validates:** [tui-lazy-computed-cells#req:computed-width-from-schema](../README.md#req-computed-width-from-schema)
+
+## Steps
+
+GIVEN a collection with a computed column bound to a counting evaluator
+WHEN the screen computes column widths
+THEN the evaluator is not invoked and the computed width equals the header/declared-type width
+
+## Detected Surface
+
+pure-fn
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/tui-lazy-computed-cells/_tests/numeric-alignment-from-type-numeric-alignment-does-not-evaluate.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/numeric-alignment-from-type-numeric-alignment-does-not-evaluate.md
@@ -1,0 +1,22 @@
+# Scenario: numeric-alignment-does-not-evaluate
+
+**Validates:** [tui-lazy-computed-cells#req:numeric-alignment-from-type](../README.md#req-numeric-alignment-from-type)
+
+## Steps
+
+GIVEN an int computed column bound to a counting evaluator
+WHEN the screen determines column alignment
+THEN the column is right-aligned and the evaluator is not invoked
+
+## Detected Surface
+
+pure-fn
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/tui-lazy-computed-cells/_tests/per-row-memoization-scroll-evaluates-only-newly-visible.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/per-row-memoization-scroll-evaluates-only-newly-visible.md
@@ -1,0 +1,22 @@
+# Scenario: scroll-evaluates-only-newly-visible
+
+**Validates:** [tui-lazy-computed-cells#req:per-row-memoization](../README.md#req-per-row-memoization)
+
+## Steps
+
+GIVEN the same collection rendered once at the top
+WHEN the user scrolls so a previously off-viewport record becomes visible and a previously visible record is repainted
+THEN the newly-visible record's computed cell is evaluated and the repainted record's is not evaluated again
+
+## Detected Surface
+
+pure-fn
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/tui-lazy-computed-cells/_tests/render-time-computed-eval-off-viewport-error-never-evaluated.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/render-time-computed-eval-off-viewport-error-never-evaluated.md
@@ -1,0 +1,22 @@
+# Scenario: off-viewport-error-never-evaluated
+
+**Validates:** [tui-lazy-computed-cells#req:render-time-computed-eval](../README.md#req-render-time-computed-eval)
+
+## Steps
+
+GIVEN a computed column whose formula raises, positioned only on off-viewport records
+WHEN the collection screen renders
+THEN the screen renders normally and the erroring computed column is never evaluated
+
+## Detected Surface
+
+pure-fn
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/tui-lazy-computed-cells/_tests/render-time-computed-eval-off-viewport-rows-not-evaluated.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/render-time-computed-eval-off-viewport-rows-not-evaluated.md
@@ -1,0 +1,22 @@
+# Scenario: off-viewport-rows-not-evaluated
+
+**Validates:** [tui-lazy-computed-cells#req:render-time-computed-eval](../README.md#req-render-time-computed-eval)
+
+## Steps
+
+GIVEN a collection with a computed column bound to a counting evaluator and more records than fit the visible row window of height V
+WHEN the collection screen renders without scrolling
+THEN the evaluator is invoked only for the V visible records and zero times for off-viewport records
+
+## Detected Surface
+
+pure-fn
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/tui-lazy-computed-cells/_tests/stored-columns-unchanged-stored-locale-discovery-unchanged.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/stored-columns-unchanged-stored-locale-discovery-unchanged.md
@@ -1,0 +1,22 @@
+# Scenario: stored-locale-discovery-unchanged
+
+**Validates:** [tui-lazy-computed-cells#req:stored-columns-unchanged](../README.md#req-stored-columns-unchanged)
+
+## Steps
+
+GIVEN a collection with an L10N stored column whose locale keys appear only on off-viewport records
+WHEN the locale dropdown is built
+THEN every locale across all records appears, exactly as before this Feature
+
+## Detected Surface
+
+pure-fn
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/features/tui-lazy-computed-cells/_tests/visible-error-non-fatal-visible-computed-error-non-fatal.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/visible-error-non-fatal-visible-computed-error-non-fatal.md
@@ -1,0 +1,22 @@
+# Scenario: visible-computed-error-non-fatal
+
+**Validates:** [tui-lazy-computed-cells#req:visible-error-non-fatal](../README.md#req-visible-error-non-fatal)
+
+## Steps
+
+GIVEN a computed column whose formula raises, positioned within the visible window
+WHEN the collection screen renders
+THEN the erroring cell shows a bounded error indicator and the screen renders other cells without crashing
+
+## Detected Surface
+
+pure-fn
+
+## TODO
+
+- [ ] Pick Rehearse driver
+- [ ] Wire up fixtures
+- [ ] Implement assertion
+
+---
+*This document follows the https://specscore.md/scenario-specification*

--- a/spec/plans/2026-06-03-tui-lazy-computed-cells.md
+++ b/spec/plans/2026-06-03-tui-lazy-computed-cells.md
@@ -1,10 +1,11 @@
 # Plan: TUI lazy computed-cell evaluation
 
-**Status:** Approved
+**Status:** Implementing
 **Source Feature:** tui-lazy-computed-cells
 **Date:** 2026-06-03
 **Owner:** alex
 **Supersedes:** —
+**Mode:** full
 
 ## Summary
 
@@ -32,6 +33,7 @@ cell's evaluation error render a bounded indicator instead of aborting the scree
 ### Task 1: Lazy model, load, and render-time computed evaluation
 
 **Verifies:** tui-lazy-computed-cells#ac:off-viewport-rows-not-evaluated, tui-lazy-computed-cells#ac:scroll-evaluates-only-newly-visible
+**Status:** done
 
 Refactor `loadRecordsCmd` to return the query `recordset.Recordset` plus retained
 per-record row handles and keys (no eager computed evaluation), have the collection
@@ -42,6 +44,7 @@ columns evaluate and dalgo's per-row memoization survives re-renders and scroll-
 ### Task 2: Schema-based sizing and alignment for computed columns
 
 **Verifies:** tui-lazy-computed-cells#ac:width-sizing-does-not-evaluate, tui-lazy-computed-cells#ac:numeric-alignment-does-not-evaluate, tui-lazy-computed-cells#ac:stored-locale-discovery-unchanged
+**Status:** pending
 
 Derive a computed column's width from its header label and declared
 `ColumnType`/length and its numeric alignment from the declared type, so neither
@@ -52,6 +55,7 @@ values exactly as today.
 ### Task 3: Non-fatal rendering of erroring visible computed cells
 
 **Verifies:** tui-lazy-computed-cells#ac:visible-computed-error-non-fatal, tui-lazy-computed-cells#ac:off-viewport-error-never-evaluated
+**Status:** pending
 
 Render a bounded error indicator in a painted computed cell whose evaluation or
 coercion fails, keeping the rest of the screen rendering without aborting the load

--- a/spec/plans/2026-06-03-tui-lazy-computed-cells.md
+++ b/spec/plans/2026-06-03-tui-lazy-computed-cells.md
@@ -44,7 +44,7 @@ columns evaluate and dalgo's per-row memoization survives re-renders and scroll-
 ### Task 2: Schema-based sizing and alignment for computed columns
 
 **Verifies:** tui-lazy-computed-cells#ac:width-sizing-does-not-evaluate, tui-lazy-computed-cells#ac:numeric-alignment-does-not-evaluate, tui-lazy-computed-cells#ac:stored-locale-discovery-unchanged
-**Status:** pending
+**Status:** done
 
 Derive a computed column's width from its header label and declared
 `ColumnType`/length and its numeric alignment from the declared type, so neither

--- a/spec/plans/2026-06-03-tui-lazy-computed-cells.md
+++ b/spec/plans/2026-06-03-tui-lazy-computed-cells.md
@@ -1,6 +1,6 @@
 # Plan: TUI lazy computed-cell evaluation
 
-**Status:** Implementing
+**Status:** Completed
 **Source Feature:** tui-lazy-computed-cells
 **Date:** 2026-06-03
 **Owner:** alex
@@ -55,7 +55,7 @@ values exactly as today.
 ### Task 3: Non-fatal rendering of erroring visible computed cells
 
 **Verifies:** tui-lazy-computed-cells#ac:visible-computed-error-non-fatal, tui-lazy-computed-cells#ac:off-viewport-error-never-evaluated
-**Status:** pending
+**Status:** done
 
 Render a bounded error indicator in a painted computed cell whose evaluation or
 coercion fails, keeping the rest of the screen rendering without aborting the load

--- a/spec/plans/2026-06-03-tui-lazy-computed-cells.md
+++ b/spec/plans/2026-06-03-tui-lazy-computed-cells.md
@@ -1,0 +1,68 @@
+# Plan: TUI lazy computed-cell evaluation
+
+**Status:** Approved
+**Source Feature:** tui-lazy-computed-cells
+**Date:** 2026-06-03
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `tui-lazy-computed-cells` Feature into three linear tasks that make
+the TUI collection screen evaluate computed columns only for painted cells: first
+the lazy model/load/render core, then schema-based sizing/alignment so layout
+never evaluates, then non-fatal rendering of an erroring visible cell. All seven
+acceptance criteria are covered; none are deferred.
+
+## Approach
+
+Tasks follow the dependency chain. Task 1 lands the lazy core — `loadRecordsCmd`
+hands the model the recordset + retained row handles (no eager evaluation) and
+`cellValue` resolves each painted cell through `AccessValue`, so off-viewport rows
+are never evaluated and per-row memoization survives re-renders. Task 2 removes the
+remaining forced-evaluation sites by sizing/aligning computed columns from the
+schema (header + declared `ColumnType`) while leaving stored-column scans — widths,
+locale discovery, numeric detection — unchanged. Task 3 makes a painted computed
+cell's evaluation error render a bounded indicator instead of aborting the screen
+(off-viewport erroring columns are never evaluated, so they cannot affect it). Task
+2 and Task 3 both build on Task 1's lazy `cellValue`/model.
+
+## Tasks
+
+### Task 1: Lazy model, load, and render-time computed evaluation
+
+**Verifies:** tui-lazy-computed-cells#ac:off-viewport-rows-not-evaluated, tui-lazy-computed-cells#ac:scroll-evaluates-only-newly-visible
+
+Refactor `loadRecordsCmd` to return the query `recordset.Recordset` plus retained
+per-record row handles and keys (no eager computed evaluation), have the collection
+model hold them instead of pre-built `map[string]any` records, and resolve each
+painted cell through `dalgo2ingitdb.AccessValue` so only visible rows' computed
+columns evaluate and dalgo's per-row memoization survives re-renders and scroll-back.
+
+### Task 2: Schema-based sizing and alignment for computed columns
+
+**Verifies:** tui-lazy-computed-cells#ac:width-sizing-does-not-evaluate, tui-lazy-computed-cells#ac:numeric-alignment-does-not-evaluate, tui-lazy-computed-cells#ac:stored-locale-discovery-unchanged
+
+Derive a computed column's width from its header label and declared
+`ColumnType`/length and its numeric alignment from the declared type, so neither
+width computation nor alignment detection evaluates a computed column; leave
+stored-column width sizing, locale discovery, and numeric detection scanning stored
+values exactly as today.
+
+### Task 3: Non-fatal rendering of erroring visible computed cells
+
+**Verifies:** tui-lazy-computed-cells#ac:visible-computed-error-non-fatal, tui-lazy-computed-cells#ac:off-viewport-error-never-evaluated
+
+Render a bounded error indicator in a painted computed cell whose evaluation or
+coercion fails, keeping the rest of the screen rendering without aborting the load
+or crashing; because evaluation is lazy (Task 1), an off-viewport erroring computed
+column is never evaluated and never affects the screen.
+
+## Open Questions
+
+- Task 1 should pin a concrete visible-window height in the test harness so the
+  "zero off-viewport invocations" assertions are deterministic (AI-reviewer advisory
+  from the Feature gate).
+
+---
+*This document follows the https://specscore.md/plan-specification*


### PR DESCRIPTION
Implements the **`tui-lazy-computed-cells`** Feature (Status: Approved, grade A) per plan `spec/plans/2026-06-03-tui-lazy-computed-cells.md`.

## Problem
`computed-columns-via-dalgo` moved read consumers onto dalgo's lazy `recordset.Evaluator`, but the TUI collection screen was migrated byte-identically: `loadRecordsCmd` pre-built a full `map[string]any` per record (reading every column) and layout scanned all rows × columns — so every computed (FORMULA) column was evaluated up front for every record, even ones never scrolled into view.

## What changed
The collection screen now evaluates a computed column **only for the cells it actually paints**.

- **Lazy core** — the model holds the query `recordset.Recordset` and its **retained per-record row handles** (plus keys) instead of pre-evaluated maps. `loadRecordsCmd` reads stored columns only; computed columns resolve lazily through `dalgo2ingitdb.AccessValue` when a cell is painted. Retaining the row handles preserves dalgo's per-row memoization across re-renders and scroll-back.
- **Schema-based layout** — a computed column's width derives from its header label and declared length, and its numeric (right) alignment from its declared `ColumnType` — never by sampling a value. Stored-column width sizing, locale discovery, and numeric detection still scan stored values, byte-identical to before.
- **Non-fatal errors** — a painted computed cell whose evaluation/coercion fails renders a bounded `#ERR!` indicator; the screen keeps rendering. (This replaces the old "whole load fails on a computed error" behavior, which no longer applies since the load no longer evaluates.) Off-viewport erroring columns are never evaluated.

## Acceptance criteria (all 7 covered)
Each commit carries a `Verifies:` trailer mapping to its ACs:
- `feat(tui): evaluate computed columns lazily at paint time` → off-viewport-rows-not-evaluated, scroll-evaluates-only-newly-visible
- `feat(tui): size and align computed columns from the schema` → width-sizing-does-not-evaluate, numeric-alignment-does-not-evaluate, stored-locale-discovery-unchanged
- `feat(tui): render erroring computed cells non-fatally` → visible-computed-error-non-fatal, off-viewport-error-never-evaluated

Tests drive the collection model with a counting `recordset.Evaluator` and assert evaluation counts for visible vs off-viewport windows, width/alignment without evaluation, locale-discovery parity, and non-fatal visible-error rendering.

## Verification
- `go build ./...`, `go test ./...`, `golangci-lint run`, `specscore spec lint` — all clean.
- `cmd/ingitdb/tui` package coverage: 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)