### PR TITLE
docs(spec): reconcile feature statuses with code; capture gaps as seeds

### DIFF
--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -34,17 +34,17 @@ This directory tracks the SpecScore feature specifications for the **ingitdb-cli
 | [cli/truncate](cli/truncate/README.md) | Withdrawn — use `delete --all` | `ingitdb truncate` (not implemented). |
 | [cli/migrate](cli/migrate/README.md) | Withdrawn (deferred) | `ingitdb migrate` (not implemented). |
 | [id-flag-format](id-flag-format/README.md) | Implementing | Cross-cutting `--id=<collection-id>/<record-key>` syntax. |
-| [output-formats](output-formats/README.md) | Implementing | Cross-cutting `--format=yaml|json` flag and YAML default. |
-| [path-targeting](path-targeting/README.md) | Implementing | Cross-cutting `--path` flag and its relation to `--remote`. |
+| [output-formats](output-formats/README.md) | Stable | Cross-cutting `--format=yaml|json` flag and YAML default. |
+| [path-targeting](path-targeting/README.md) | Stable | Cross-cutting `--path` flag and its relation to `--remote`. |
 | [remote-repo-access](remote-repo-access/README.md) | Implementing | Cross-cutting `--remote=<URL>` flag, provider dispatch, and token resolution for remote Git hosting services. |
 | [shared-cli-flags](shared-cli-flags/README.md) | Single source of truth for the CLI flag grammar shared across select, insert, update, delete, and drop verbs: --from, --into, --where, --set, --id, --all, --order-by, --fields. Defines parsing rules, operator semantics (==, ===, !=, !==, >=, <=, >, <), value-type model, and flag mutual-exclusion rules. |
 | [cli](cli/README.md) | Unknown | TODO: Add description. |
 | [dalgo2ingitdb-dbschema-ddl-coverage](dalgo2ingitdb-dbschema-ddl-coverage/README.md) | Draft | TODO: Add description. |
-| [dalgo2ingitdb-referential-integrity](dalgo2ingitdb-referential-integrity/README.md) | Approved | DALgo write transactions enforce existing `foreign_key` metadata on Set, Insert, Update, and Delete. |
+| [dalgo2ingitdb-referential-integrity](dalgo2ingitdb-referential-integrity/README.md) | Stable | DALgo write transactions enforce existing `foreign_key` metadata on Set, Insert, Update, and Delete. |
 | [record-key](record-key/README.md) | Draft | Umbrella for canonical record identity behavior across schema validation, storage paths, writes, and CLI key surfaces. |
-| [computed-columns](computed-columns/README.md) | Approved | TODO: Add description. |
-| [computed-columns-via-dalgo](computed-columns-via-dalgo/README.md) | Approved | TODO: Add description. |
-| [tui-lazy-computed-cells](tui-lazy-computed-cells/README.md) | Approved | TODO: Add description. |
+| [computed-columns](computed-columns/README.md) | Stable | TODO: Add description. |
+| [computed-columns-via-dalgo](computed-columns-via-dalgo/README.md) | Stable | TODO: Add description. |
+| [tui-lazy-computed-cells](tui-lazy-computed-cells/README.md) | Stable | TODO: Add description. |
 
 ## Feature Summaries
 

--- a/spec/features/cli/delete/README.md
+++ b/spec/features/cli/delete/README.md
@@ -1,7 +1,7 @@
 # Feature: Delete
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/cli/describe/README.md
+++ b/spec/features/cli/describe/README.md
@@ -1,7 +1,7 @@
 # Feature: Describe Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/describe?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/describe?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/describe?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/describe?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/cli/drop/README.md
+++ b/spec/features/cli/drop/README.md
@@ -1,7 +1,7 @@
 # Feature: Drop
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/drop?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/drop?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/drop?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/drop?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/cli/insert/README.md
+++ b/spec/features/cli/insert/README.md
@@ -2,7 +2,7 @@
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/insert?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/insert?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/insert?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/insert?op=request-change) |
 
-**Status:** Approved
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/cli/resolve/auto-resolve/README.md
+++ b/spec/features/cli/resolve/auto-resolve/README.md
@@ -1,7 +1,7 @@
 # Feature: Auto-Resolve Generated Conflicts
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 **Parent Feature:** [`cli/resolve`](../README.md)
 
 ## Summary

--- a/spec/features/cli/select/README.md
+++ b/spec/features/cli/select/README.md
@@ -1,7 +1,7 @@
 # Feature: Select
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/select?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/select?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/select?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/select?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/cli/update/README.md
+++ b/spec/features/cli/update/README.md
@@ -1,7 +1,7 @@
 # Feature: Update
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/computed-columns-via-dalgo/README.md
+++ b/spec/features/computed-columns-via-dalgo/README.md
@@ -1,7 +1,7 @@
 # Feature: Computed Columns via dalgo (lazy delegation)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 **Date:** 2026-06-03
 **Owner:** alex
 **Source Ideas:** —

--- a/spec/features/computed-columns/README.md
+++ b/spec/features/computed-columns/README.md
@@ -1,7 +1,7 @@
 # Feature: Computed Columns (Inline Starlark Formulas)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 **Date:** 2026-06-02
 **Owner:** alexander.trakhimenok@gmail.com
 **Source Ideas:** scripted-formulas-and-views

--- a/spec/features/dalgo2ingitdb-referential-integrity/README.md
+++ b/spec/features/dalgo2ingitdb-referential-integrity/README.md
@@ -1,7 +1,7 @@
 # Feature: DALgo Referential Integrity
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-referential-integrity?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-referential-integrity?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-referential-integrity?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-referential-integrity?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 **Date:** 2026-05-30
 **Owner:** @trakhimenok
 **Source Idea:** [`dalgo2ingitdb-referential-integrity`](../../ideas/dalgo2ingitdb-referential-integrity.md)

--- a/spec/features/output-formats/README.md
+++ b/spec/features/output-formats/README.md
@@ -1,7 +1,7 @@
 # Feature: Output Formats
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/output-formats?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/output-formats?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/output-formats?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/output-formats?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/path-targeting/README.md
+++ b/spec/features/path-targeting/README.md
@@ -1,7 +1,7 @@
 # Feature: Path Targeting
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/path-targeting?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/path-targeting?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/path-targeting?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/path-targeting?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/record-format/list-of-records/README.md
+++ b/spec/features/record-format/list-of-records/README.md
@@ -1,7 +1,7 @@
 # Feature: List-of-Records Files (YAML/JSON Sequences + JSONL)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/list-of-records?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/list-of-records?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/list-of-records?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/list-of-records?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 **Parent Feature:** [`record-format`](../README.md)
 **Source Idea:** [`list-of-records-files`](../../../ideas/list-of-records-files.md)
 

--- a/spec/features/record-key/derived-keys/README.md
+++ b/spec/features/record-key/derived-keys/README.md
@@ -1,7 +1,7 @@
 # Feature: Derived Record Keys
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key/derived-keys?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key/derived-keys?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key/derived-keys?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key/derived-keys?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 **Date:** 2026-05-30
 **Owner:** alexander.trakhimenok@gmail.com
 **Source Idea:** [`derived-record-keys`](../../../ideas/derived-record-keys.md)

--- a/spec/features/shared-cli-flags/README.md
+++ b/spec/features/shared-cli-flags/README.md
@@ -1,7 +1,7 @@
 # Feature: Shared CLI Flags
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/shared-cli-flags?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/shared-cli-flags?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/shared-cli-flags?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/shared-cli-flags?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/tui-lazy-computed-cells/README.md
+++ b/spec/features/tui-lazy-computed-cells/README.md
@@ -1,7 +1,7 @@
 # Feature: TUI lazy computed-cell evaluation
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 **Date:** 2026-06-03
 **Owner:** alex
 **Source Ideas:** —

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -18,7 +18,7 @@ Use `specscore idea new <slug>` to scaffold a new idea.
 | [derived-record-keys](derived-record-keys.md) | Approved | 2026-05-30 | alexander.trakhimenok@gmail.com | — |
 | [list-of-records-files](list-of-records-files.md) | Approved | 2026-05-29 | alexander.trakhimenok@gmail.com | — |
 | [markdown-insert-ux](markdown-insert-ux.md) | Draft | 2026-05-12 | alexander.trakhimenok@gmail.com | — |
-| [scripted-formulas-and-views](scripted-formulas-and-views.md) | Implementing | 2026-06-02 | alexander.trakhimenok@gmail.com | computed-columns |
+| [scripted-formulas-and-views](scripted-formulas-and-views.md) | Specified | 2026-06-02 | alexander.trakhimenok@gmail.com | computed-columns |
 | [where-like-regex](where-like-regex.md) | Draft | 2026-05-12 | alexander.trakhimenok@gmail.com | — |
 
 ## Open Questions

--- a/spec/ideas/scripted-formulas-and-views.md
+++ b/spec/ideas/scripted-formulas-and-views.md
@@ -1,6 +1,6 @@
 # Idea: Scripted Computed Fields & Materialized Views (Starlark)
 
-**Status:** Implementing
+**Status:** Specified
 **Date:** 2026-06-02
 **Owner:** alexander.trakhimenok@gmail.com
 **Promotes To:** computed-columns

--- a/spec/ideas/seeds/assert-version-command-output-fields-in-tests.md
+++ b/spec/ideas/seeds/assert-version-command-output-fields-in-tests.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: assert-version-command-output-fields-in-tests
+captured_at: 2026-06-03T14:25:20Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Add a test that captures `ingitdb version` stdout and asserts all three fields (version, commit, date) are present
+
+Gap found while reconciling cli/version (1/2 ACs). The implementation in `cmd/ingitdb/commands/version.go` prints all three fields via `fmt.Printf("ingitdb %s (%s) @ %s", ...)` to stdout, but the tests (`TestVersion_PrintsVersionInfo`, `TestVersion_EmptyValues`) only assert that RunE returns no error — they never capture stdout. So `AC:version-prints-three-fields` ("a reader can identify each of the three fields") is implemented but unverified. The test helper `runCobraCommand` does not capture output. Closing this gap (capture stdout, assert version/commit/date appear) is the only thing keeping cli/version out of Stable.

--- a/spec/ideas/seeds/enforce-token-for-remote-writes-and-github-enterprise-provider.md
+++ b/spec/ideas/seeds/enforce-token-for-remote-writes-and-github-enterprise-provider.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: enforce-token-for-remote-writes-and-github-enterprise-provider
+captured_at: 2026-06-03T14:25:20Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Enforce a local token-required pre-flight for remote writes, and add the github-enterprise provider to the registry
+
+Two gaps found while reconciling remote-repo-access (7/9 ACs). (1) REQ:token-required-for-writes is unenforced: no CLI/library pre-flight rejects a write when no token resolves (flag and all *_TOKEN env vars empty). `remoteToken` may return "" and writes proceed unauthenticated, failing only at the GitHub API (401) instead of with the spec-mandated local "token required" error; no test covers "write without token must fail". (2) `AC:self-hosted-host-token` is written against `--provider=github-enterprise`, but that id is not in `registeredProviders` (only github/gitlab/bitbucket), so the AC's literal invocation fails with "unknown --provider" before token resolution runs. Token resolution for self-hosted hosts (`TestResolveRemoteToken`, `TestHostTokenEnvName`) is otherwise implemented. Either register a `github-enterprise` provider/adapter or fix the spec to use a registered provider, then add the end-to-end test.

--- a/spec/ideas/seeds/implement-incremental-validation-commit-range.md
+++ b/spec/ideas/seeds/implement-incremental-validation-commit-range.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: implement-incremental-validation-commit-range
+captured_at: 2026-06-03T14:25:20Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Implement IncrementalValidator so `validate --from-commit/--to-commit` scopes validation to changed records instead of returning not-implemented
+
+Gap found while reconciling cli/validate (2/3 ACs). `AC:scoped-validation` (commit-range, `--only=records --from-commit=A --to-commit=B`) is not functionally implemented: the `IncrementalValidator` interface (`pkg/ingitdb/datavalidator/interfaces.go`) has no production implementation, and `cmd/ingitdb/main.go` wires it as `nil`, so the real CLI returns "incremental validation (--from-commit/--to-commit) is not yet implemented". The "records outside the commit range are not opened" guarantee is unsatisfiable today. Tests only exercise a `mockIncrementalValidator`, so command plumbing is covered but the actual git-diff-driven behavior is not. Implement a real IncrementalValidator (diff the commit range, validate only changed record files) and test against real git/file logic. Note: the commit-range branch currently runs before `--only` scoping and ignores record-vs-definition selection.

--- a/spec/ideas/seeds/implement-or-remove-list-collections-scoping-flags.md
+++ b/spec/ideas/seeds/implement-or-remove-list-collections-scoping-flags.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: implement-or-remove-list-collections-scoping-flags
+captured_at: 2026-06-03T14:25:20Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Implement --in and --filter-name scoped filtering for `list collections` (or remove the dead flags from the command and spec)
+
+Gap found while reconciling cli/list-collections (1/2 ACs). The `--in` and `--filter-name` flags are registered in `collections()` (`cmd/ingitdb/commands/list.go`) but their values are never read via `GetString` and no glob/regex filtering is applied in `listCollectionsLocal` or `listCollectionsRemoteWithSpec` — they are dead no-op flags, leaving `AC:scoped-listing` (REQ:in-flag, REQ:filter-name-flag) unsatisfied and untested. Sibling commands `describe.go` and `drop.go` already read `--in` via `GetString("in")`, so the pattern exists. Either wire the flags up (and add a filtered-output test) or remove them from both the command and the spec.

--- a/spec/ideas/seeds/rebase-abort-on-unresolvable-source-conflicts.md
+++ b/spec/ideas/seeds/rebase-abort-on-unresolvable-source-conflicts.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: rebase-abort-on-unresolvable-source-conflicts
+captured_at: 2026-06-03T14:25:20Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Make `ingitdb rebase` run `git rebase --abort` and report unresolved paths on conflicts outside the --resolve scope, with a test
+
+Gap found while reconciling cli/rebase (1/2 ACs). `AC:aborts-on-source-conflict` (REQ:aborts-on-unresolvable) says the command MUST abort the rebase when a conflict falls outside `--resolve`, but `Rebase()` in `cmd/ingitdb/commands/rebase.go` never calls `git rebase --abort` — on an unresolved/source conflict it returns an error and leaves the rebase halted in progress. No test feeds a non-README (source) conflict to verify the abort + unresolved-paths report. The underlying detection (`FindCollectionsForConflictingFiles`, `resolveGeneratedConflicts` returning `unresolved`) is unit-tested, but the command's abort/report path is not. Also the error text says "files other than README.md" even though `--resolve` is generically categorized — reword.

--- a/spec/ideas/seeds/revalidate-auto-merged-records-against-schema.md
+++ b/spec/ideas/seeds/revalidate-auto-merged-records-against-schema.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: revalidate-auto-merged-records-against-schema
+captured_at: 2026-06-03T14:25:20Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Re-validate auto-merged records against the collection schema and escalate invalid merges instead of staging them
+
+Gap found while reconciling cli/resolve/auto-resolve/record-merge (5/7 ACs). The Concept and REQ:three-way-record-merge require the merge to "re-parse and re-validate against the collection schema," and `AC:invalid-merge-escalates` requires escalation when a merge would produce a schema-invalid file. But `mergeAndSerialize` (`cmd/ingitdb/commands/record_merge_resolver.go`) only re-parses during serialization — it never validates against the schema (grep for validate/validator across the record-merge path returns nothing). A serializable-but-schema-invalid merge (required-field/type/enum violation) is staged rather than escalated. Wire schema validation into the merge result and escalate on failure; add a test for a schema-invalid merge. The README's "Open Questions: None outstanding" is stale relative to this. (Related: the queued `wire-write-time-validations...` seed — both want shared write-time validation hooks.)

--- a/spec/ideas/seeds/wire-collection-id-charset-validation-into-id-flag-parsing.md
+++ b/spec/ideas/seeds/wire-collection-id-charset-validation-into-id-flag-parsing.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: wire-collection-id-charset-validation-into-id-flag-parsing
+captured_at: 2026-06-03T14:25:20Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Wire ValidateCollectionID into the --id resolution path so invalid collection segments yield a syntax diagnostic, and reconcile the underscore charset discrepancy
+
+Gap found while reconciling id-flag-format (1/2 ACs). `ValidateCollectionID` (`pkg/ingitdb/collection_id.go`) enforces the collection-segment charset and start/end-alphanumeric rules, but it is only called for declared collection IDs (`pkg/ingitdb/config/root_config.go`) — never on the `--id` parse path. `CollectionForKey` (`pkg/dalgo2ingitdb/collection.go`) does longest-prefix resolution without charset checks, so an `--id` with an invalid collection segment is rejected only by a generic "collection not found for ID" error, not the clear syntax diagnostic `AC:id-syntax-rejects-invalid` requires. Add a test feeding a charset-invalid / no-slash collection segment through `--id`. Also reconcile a discrepancy: `ValidateCollectionID` permits `_` (and tests assert it), but REQ:collection-id-charset lists only alphanumeric and `.` — decide whether spec or code is authoritative.


### PR DESCRIPTION
## Summary

Reconciles SpecScore feature lifecycle statuses against the actual implementation, and captures the remaining gaps as queued sidekick seeds. Docs/spec only — no code changes.

### Status reconciliation (commit 1)
Verified each `Approved`/`Implementing` feature against code + tests, then advanced the lifecycle status to match reality:

- **`Approved → Stable`** (built + tested): `computed-columns`, `computed-columns-via-dalgo`, `dalgo2ingitdb-referential-integrity`, `record-key/derived-keys`, `cli/{insert,select,update,delete,drop,describe}`, `shared-cli-flags`, `tui-lazy-computed-cells`
- **`Implementing → Stable`** (all ACs implemented + covered): `cli/resolve/auto-resolve`, `output-formats`, `path-targeting`, `record-format/list-of-records`
- Lint `--fix` side effect: `scripted-formulas-and-views` idea re-derived `Implementing → Specified` (its promoted feature `computed-columns` is now Stable)

`computed-columns` was confirmed via its formal verify report (16/16 ACs). The four `Implementing → Stable` promotions were each confirmed by running their targeted tests.

### Gap capture (commit 2)
Seven features stayed `Implementing` because verification found concrete spec-vs-code gaps. Each is captured as a queued seed under `spec/ideas/seeds/`:

| Feature | Gap |
|---|---|
| cli/version | output fields not asserted in tests |
| id-flag-format | charset validation not wired into `--id` parsing |
| cli/list-collections | `--in`/`--filter-name` are dead no-op flags |
| cli/rebase | no `git rebase --abort` on unresolvable source conflicts |
| record-merge | merged records not re-validated against the schema |
| cli/validate | incremental `--from-commit/--to-commit` not implemented (wired as `nil`) |
| remote-repo-access | writes not gated on token; `github-enterprise` provider missing |

## Verification
- `specscore spec lint`: **0 violations**
- `go test ./...`: green (baseline, unaffected — no code changed)

## Not addressed (follow-ups)
- `record-format` + children use a non-matrix `Implemented` status (vs. lifecycle `Stable`)
- Several specs have stale `specscore:` traceability annotations pointing at the wrong files

🤖 Generated with [Claude Code](https://claude.com/claude-code)