### PR TITLE
fix(cli): close cli/version and id-flag-format spec gaps

### DIFF
--- a/cmd/ingitdb/commands/version.go
+++ b/cmd/ingitdb/commands/version.go
@@ -13,9 +13,9 @@ func Version(ver, commit, date string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print build version, commit hash, and build date",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			fmt.Printf("ingitdb %s (%s) @ %s\n", ver, commit, date)
-			return nil
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "ingitdb %s (%s) @ %s\n", ver, commit, date)
+			return err
 		},
 	}
 }

--- a/cmd/ingitdb/commands/version_test.go
+++ b/cmd/ingitdb/commands/version_test.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -36,5 +38,24 @@ func TestVersion_EmptyValues(t *testing.T) {
 	err := runCobraCommand(cmd)
 	if err != nil {
 		t.Fatalf("Version with empty values: %v", err)
+	}
+}
+
+func TestVersion_PrintsAllThreeFields(t *testing.T) {
+	t.Parallel()
+
+	cmd := Version("1.2.3", "abc123", "2024-01-01")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{"1.2.3", "abc123", "2024-01-01"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("version output %q is missing field %q", out, want)
+		}
 	}
 }

--- a/pkg/dalgo2ingitdb/collection.go
+++ b/pkg/dalgo2ingitdb/collection.go
@@ -1,5 +1,7 @@
 package dalgo2ingitdb
 
+// specscore: feature/id-flag-format
+
 import (
 	"fmt"
 	"strings"
@@ -13,6 +15,18 @@ import (
 // "/" is reserved for separating collection ID from record key path segments.
 // The longest matching collection prefix wins.
 func CollectionForKey(def *ingitdb.Definition, id string) (*ingitdb.CollectionDef, string, error) {
+	// The collection ID is everything before the first "/", which separates it
+	// from the record key. Validate that segment up front so a malformed ID
+	// (missing separator or an invalid collection charset) yields a clear
+	// diagnostic instead of a generic "collection not found".
+	collectionSegment, _, found := strings.Cut(id, "/")
+	if !found {
+		return nil, "", fmt.Errorf("invalid ID %q: must be in the form <collection>/<key>", id)
+	}
+	if err := ingitdb.ValidateCollectionID(collectionSegment); err != nil {
+		return nil, "", fmt.Errorf("invalid collection in ID %q: %w", id, err)
+	}
+
 	var bestColDef *ingitdb.CollectionDef
 	var bestKey string
 	var bestLen int

--- a/pkg/dalgo2ingitdb/collection_test.go
+++ b/pkg/dalgo2ingitdb/collection_test.go
@@ -1,6 +1,7 @@
 package dalgo2ingitdb
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
@@ -118,5 +119,66 @@ func TestCollectionForKey_MissingRecordKey(t *testing.T) {
 	_, _, err := CollectionForKey(def, "countries/")
 	if err == nil {
 		t.Fatal("expected error when record key is empty")
+	}
+}
+
+func TestCollectionForKey_InvalidCharsetRejected(t *testing.T) {
+	t.Parallel()
+
+	def := collectionForKeyDef()
+	_, _, err := CollectionForKey(def, "bad!name/ie")
+	if err == nil {
+		t.Fatal("expected error for invalid collection charset")
+	}
+	if !strings.Contains(err.Error(), "invalid character") {
+		t.Errorf("error %q should diagnose the invalid collection character", err)
+	}
+}
+
+func TestCollectionForKey_MissingSeparatorRejected(t *testing.T) {
+	t.Parallel()
+
+	def := collectionForKeyDef()
+	_, _, err := CollectionForKey(def, "countries")
+	if err == nil {
+		t.Fatal("expected error when the collection/key separator is missing")
+	}
+	if !strings.Contains(err.Error(), "<collection>/<key>") {
+		t.Errorf("error %q should explain the required <collection>/<key> form", err)
+	}
+}
+
+func TestCollectionForKey_ValidButUndeclaredStillNotFound(t *testing.T) {
+	t.Parallel()
+
+	// A syntactically valid collection segment that is not declared must still
+	// report "collection not found", not a charset diagnostic.
+	def := collectionForKeyDef()
+	_, _, err := CollectionForKey(def, "missing/ie")
+	if err == nil {
+		t.Fatal("expected error for undeclared collection")
+	}
+	if !strings.Contains(err.Error(), "collection not found") {
+		t.Errorf("error %q should report collection not found", err)
+	}
+}
+
+func TestCollectionForKey_UnderscoreCollectionAllowed(t *testing.T) {
+	t.Parallel()
+
+	def := &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"exchange_rates": {ID: "exchange_rates"},
+		},
+	}
+	colDef, key, err := CollectionForKey(def, "exchange_rates/usd")
+	if err != nil {
+		t.Fatalf("unexpected error for underscore collection: %v", err)
+	}
+	if colDef.ID != "exchange_rates" {
+		t.Errorf("colDef.ID = %q, want %q", colDef.ID, "exchange_rates")
+	}
+	if key != "usd" {
+		t.Errorf("key = %q, want %q", key, "usd")
 	}
 }

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -33,7 +33,7 @@ This directory tracks the SpecScore feature specifications for the **ingitdb-cli
 | [cli/find](cli/find/README.md) | Withdrawn — moved to DataTug CLI | `ingitdb find` (not implemented). |
 | [cli/truncate](cli/truncate/README.md) | Withdrawn — use `delete --all` | `ingitdb truncate` (not implemented). |
 | [cli/migrate](cli/migrate/README.md) | Withdrawn (deferred) | `ingitdb migrate` (not implemented). |
-| [id-flag-format](id-flag-format/README.md) | Implementing | Cross-cutting `--id=<collection-id>/<record-key>` syntax. |
+| [id-flag-format](id-flag-format/README.md) | Stable | Cross-cutting `--id=<collection-id>/<record-key>` syntax. |
 | [output-formats](output-formats/README.md) | Stable | Cross-cutting `--format=yaml|json` flag and YAML default. |
 | [path-targeting](path-targeting/README.md) | Stable | Cross-cutting `--path` flag and its relation to `--remote`. |
 | [remote-repo-access](remote-repo-access/README.md) | Implementing | Cross-cutting `--remote=<URL>` flag, provider dispatch, and token resolution for remote Git hosting services. |

--- a/spec/features/cli/version/README.md
+++ b/spec/features/cli/version/README.md
@@ -1,7 +1,7 @@
 # Feature: Version Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/version?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/version?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/version?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/version?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/id-flag-format/README.md
+++ b/spec/features/id-flag-format/README.md
@@ -1,7 +1,7 @@
 # Feature: ID Flag Format
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/id-flag-format?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/id-flag-format?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/id-flag-format?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/id-flag-format?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 
 ## Summary
 
@@ -21,7 +21,7 @@ The `--id` value MUST be of the form `<collection-id>/<record-key>`, with a sing
 
 #### REQ: collection-id-charset
 
-A collection ID MUST contain only alphanumeric characters and the `.` character. It MUST start and end with an alphanumeric character. The `/` character MUST NOT appear inside a collection ID; its only role inside `--id` is to separate the collection from the key.
+A collection ID MUST contain only alphanumeric characters, the `.` character, and the `_` (underscore) character. It MUST start and end with an alphanumeric character. The `/` character MUST NOT appear inside a collection ID; its only role inside `--id` is to separate the collection from the key.
 
 #### REQ: longest-prefix-wins
 
@@ -45,6 +45,7 @@ Source files implementing this feature (annotated with
 `// specscore: feature/id-flag-format`):
 
 - [`pkg/ingitdb/collection_id.go`](../../pkg/ingitdb/collection_id.go)
+- [`pkg/dalgo2ingitdb/collection.go`](../../pkg/dalgo2ingitdb/collection.go)
 
 ## Acceptance Criteria
 

--- a/spec/ideas/seeds/assert-version-command-output-fields-in-tests.md
+++ b/spec/ideas/seeds/assert-version-command-output-fields-in-tests.md
@@ -5,7 +5,7 @@ captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
 captured_during: null
 trigger: explicit
-status: queued
+status: done
 synchestra_task: null
 ---
 # Add a test that captures `ingitdb version` stdout and asserts all three fields (version, commit, date) are present

--- a/spec/ideas/seeds/wire-collection-id-charset-validation-into-id-flag-parsing.md
+++ b/spec/ideas/seeds/wire-collection-id-charset-validation-into-id-flag-parsing.md
@@ -5,7 +5,7 @@ captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
 captured_during: null
 trigger: explicit
-status: queued
+status: done
 synchestra_task: null
 ---
 # Wire ValidateCollectionID into the --id resolution path so invalid collection segments yield a syntax diagnostic, and reconcile the underscore charset discrepancy


### PR DESCRIPTION
## Summary

Resolves the two quick-win gaps captured during the status reconciliation (their sidekick seeds are marked `done`). Both features are promoted `Implementing → Stable`.

### cli/version — `AC:version-prints-three-fields`
The command printed via `fmt.Printf` (raw `os.Stdout`), so no test could assert the output. Switched to `fmt.Fprintf(cmd.OutOrStdout(), …)` (matches the `output-formats` convention; stdout + exit-zero behavior preserved) and added `TestVersion_PrintsAllThreeFields` asserting version/commit/date all appear.

### id-flag-format — `AC:id-syntax-rejects-invalid`
`ValidateCollectionID` existed but was never called on the `--id` path, so a malformed collection segment produced a generic "collection not found". Added validation in `CollectionForKey` (the shared resolver behind `--id`, MCP tools, and the HTTP API):
- missing `/` separator → `invalid ID %q: must be in the form <collection>/<key>`
- invalid collection charset / bad start-end → clear diagnostic via `ValidateCollectionID`
- valid-but-undeclared collections still report "collection not found" (regression-guarded)

Also reconciled `REQ:collection-id-charset` to allow `_` (the validator and real collections like `exchange_rates` already use it), annotated `pkg/dalgo2ingitdb/collection.go` with the feature, and added it to the spec's Implementation list (traceability fix the verification flagged).

## Tests
New: `TestVersion_PrintsAllThreeFields`; `TestCollectionForKey_{InvalidCharsetRejected,MissingSeparatorRejected,ValidButUndeclaredStillNotFound,UnderscoreCollectionAllowed}`. Written test-first (confirmed red → green).

## Verification
- `go build ./...`: ok
- `go test ./...`: all packages green
- `golangci-lint run`: 0 issues
- `specscore spec lint`: 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)