### PR TITLE
feat(cli): wire up list-collections --in and --filter-name scoping

### DIFF
--- a/cmd/ingitdb/commands/coverage_additions_test.go
+++ b/cmd/ingitdb/commands/coverage_additions_test.go
@@ -219,7 +219,7 @@ func TestListCollectionsRemote_ReadFileError(t *testing.T) {
 	defer func() { gitHubFileReaderFactory = originalFactory }()
 
 	ctx := context.Background()
-	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "")
+	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "", "", "")
 	if err == nil {
 		t.Fatal("expected error when ReadFile returns an error")
 	}

--- a/cmd/ingitdb/commands/example_mock_usage_test.go
+++ b/cmd/ingitdb/commands/example_mock_usage_test.go
@@ -79,7 +79,7 @@ func TestListCollections_GitHubFileReaderError(t *testing.T) {
 	// Test the function that uses gitHubFileReaderFactory
 	ctx := context.Background()
 	spec := remoteSpec{Host: "github.com", Path: []string{"owner", "repo"}}
-	err := listCollectionsRemoteWithSpec(ctx, spec, "fake-token")
+	err := listCollectionsRemoteWithSpec(ctx, spec, "fake-token", "", "")
 
 	if err == nil {
 		t.Fatal("expected error when file reader creation fails")

--- a/cmd/ingitdb/commands/list.go
+++ b/cmd/ingitdb/commands/list.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"regexp"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -15,6 +16,51 @@ import (
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/config"
 )
+
+// collectionEntry pairs a collection's listed name (its ID) with its
+// starting-point path, so the --in and --filter-name scoping flags can be
+// applied uniformly to local and remote sources.
+type collectionEntry struct {
+	name string
+	path string
+}
+
+// filterCollectionIDs applies the --in (regular expression on the
+// starting-point path) and --filter-name (glob on the collection name) scoping
+// flags and returns the matching names sorted ascending. An empty inExpr or
+// nameGlob disables that filter; both filters are combined with AND.
+func filterCollectionIDs(entries []collectionEntry, inExpr, nameGlob string) ([]string, error) {
+	var inRE *regexp.Regexp
+	if inExpr != "" {
+		re, err := regexp.Compile(inExpr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --in regular expression %q: %w", inExpr, err)
+		}
+		inRE = re
+	}
+	if nameGlob != "" {
+		// path.Match only errors on a malformed pattern, independent of input,
+		// so validate it once up front and ignore the error at match time.
+		if _, err := path.Match(nameGlob, ""); err != nil {
+			return nil, fmt.Errorf("invalid --filter-name pattern %q: %w", nameGlob, err)
+		}
+	}
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if inRE != nil && !inRE.MatchString(e.path) {
+			continue
+		}
+		if nameGlob != "" {
+			matched, _ := path.Match(nameGlob, e.name)
+			if !matched {
+				continue
+			}
+		}
+		ids = append(ids, e.name)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
 
 // List returns the list command.
 func List(
@@ -68,13 +114,18 @@ func listCollectionsLocal(
 	if readErr != nil {
 		return fmt.Errorf("failed to read database definition: %w", readErr)
 	}
-	ids := make([]string, 0, len(def.Collections))
-	for id := range def.Collections {
-		ids = append(ids, id)
+	inExpr, _ := cmd.Flags().GetString("in")
+	nameGlob, _ := cmd.Flags().GetString("filter-name")
+	entries := make([]collectionEntry, 0, len(def.Collections))
+	for id, col := range def.Collections {
+		entries = append(entries, collectionEntry{name: id, path: col.DirPath})
 	}
-	sort.Strings(ids)
+	ids, filterErr := filterCollectionIDs(entries, inExpr, nameGlob)
+	if filterErr != nil {
+		return filterErr
+	}
 	for _, id := range ids {
-		_, _ = fmt.Fprintln(os.Stdout, id)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), id)
 	}
 	return nil
 }
@@ -86,13 +137,15 @@ func listCollectionsRemote(ctx context.Context, cmd *cobra.Command, remoteValue 
 	if err != nil {
 		return err
 	}
-	return listCollectionsRemoteWithSpec(ctx, spec, remoteToken(cmd, spec.Host))
+	inExpr, _ := cmd.Flags().GetString("in")
+	nameGlob, _ := cmd.Flags().GetString("filter-name")
+	return listCollectionsRemoteWithSpec(ctx, spec, remoteToken(cmd, spec.Host), inExpr, nameGlob)
 }
 
 // listCollectionsRemoteWithSpec is the testable inner form: it takes a
 // pre-parsed remoteSpec and an explicit token so unit tests can exercise
 // the remote code path without constructing a cobra.Command.
-func listCollectionsRemoteWithSpec(ctx context.Context, spec remoteSpec, token string) error {
+func listCollectionsRemoteWithSpec(ctx context.Context, spec remoteSpec, token, inExpr, nameGlob string) error {
 	cfg := newGitHubConfig(spec, token)
 	fileReader, newReaderErr := gitHubFileReaderFactory.NewGitHubFileReader(cfg)
 	if newReaderErr != nil {
@@ -116,11 +169,14 @@ func listCollectionsRemoteWithSpec(ctx context.Context, spec remoteSpec, token s
 	if validateErr != nil {
 		return fmt.Errorf("invalid %s: %w", rootCollectionsPath, validateErr)
 	}
-	ids := make([]string, 0)
-	for rootID := range rootConfig.RootCollections {
-		ids = append(ids, rootID)
+	entries := make([]collectionEntry, 0, len(rootConfig.RootCollections))
+	for rootID, rootPath := range rootConfig.RootCollections {
+		entries = append(entries, collectionEntry{name: rootID, path: rootPath})
 	}
-	sort.Strings(ids)
+	ids, filterErr := filterCollectionIDs(entries, inExpr, nameGlob)
+	if filterErr != nil {
+		return filterErr
+	}
 	for _, id := range ids {
 		_, _ = fmt.Fprintln(os.Stdout, id)
 	}

--- a/cmd/ingitdb/commands/list_test.go
+++ b/cmd/ingitdb/commands/list_test.go
@@ -1,9 +1,11 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -60,6 +62,92 @@ func TestListCollectionsLocal_Success(t *testing.T) {
 	err := runCobraCommand(cmd, "collections", "--path="+dir)
 	if err != nil {
 		t.Fatalf("ListCollections: %v", err)
+	}
+}
+
+func TestFilterCollectionIDs(t *testing.T) {
+	t.Parallel()
+
+	entries := []collectionEntry{
+		{name: "countries", path: "db/countries"},
+		{name: "geo.cities", path: "db/geo/cities"},
+		{name: "geo.regions", path: "db/geo/regions"},
+		{name: "todo.tasks", path: "db/todo/tasks"},
+	}
+
+	tests := []struct {
+		name     string
+		inExpr   string
+		nameGlob string
+		want     []string
+		wantErr  bool
+	}{
+		{name: "no filters returns all sorted", want: []string{"countries", "geo.cities", "geo.regions", "todo.tasks"}},
+		{name: "in regex on path", inExpr: "db/geo/", want: []string{"geo.cities", "geo.regions"}},
+		{name: "filter-name glob", nameGlob: "geo.*", want: []string{"geo.cities", "geo.regions"}},
+		{name: "in and filter-name combine with AND", inExpr: "db/geo/", nameGlob: "*cities", want: []string{"geo.cities"}},
+		{name: "no match yields empty", inExpr: "db/nope", want: []string{}},
+		{name: "invalid regex errors", inExpr: "[", wantErr: true},
+		{name: "invalid glob errors", nameGlob: "[", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := filterCollectionIDs(entries, tc.inExpr, tc.nameGlob)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for in=%q name=%q", tc.inExpr, tc.nameGlob)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got %v, want %v", got, tc.want)
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestListCollectionsLocal_ScopingFlags(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	def := &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"countries":   {ID: "countries", DirPath: dir + "/countries"},
+			"geo.cities":  {ID: "geo.cities", DirPath: dir + "/geo/cities"},
+			"geo.regions": {ID: "geo.regions", DirPath: dir + "/geo/regions"},
+		},
+	}
+
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return dir, nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
+		return def, nil
+	}
+
+	cmd := List(homeDir, getWd, readDef)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"collections", "--path=" + dir, "--in=/geo/", "--filter-name=*cities"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list collections: %v", err)
+	}
+
+	got := strings.Fields(buf.String())
+	want := []string{"geo.cities"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Errorf("scoped output = %v, want %v", got, want)
 	}
 }
 
@@ -164,7 +252,7 @@ func TestListCollectionsRemote_WithMock(t *testing.T) {
 	defer func() { gitHubFileReaderFactory = originalFactory }()
 
 	ctx := context.Background()
-	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "")
+	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "", "", "")
 	if err != nil {
 		t.Fatalf("listCollectionsRemoteWithSpec: %v", err)
 	}
@@ -182,7 +270,7 @@ func TestListCollectionsRemote_ReaderCreationError(t *testing.T) {
 	defer func() { gitHubFileReaderFactory = originalFactory }()
 
 	ctx := context.Background()
-	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "")
+	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "", "", "")
 	if err == nil {
 		t.Fatal("expected error when file reader creation fails")
 	}
@@ -201,7 +289,7 @@ func TestListCollectionsRemote_FileNotFound(t *testing.T) {
 	defer func() { gitHubFileReaderFactory = originalFactory }()
 
 	ctx := context.Background()
-	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "")
+	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "", "", "")
 	if err == nil {
 		t.Fatal("expected error when root config file not found")
 	}
@@ -224,7 +312,7 @@ func TestListCollectionsRemote_InvalidYAML(t *testing.T) {
 	defer func() { gitHubFileReaderFactory = originalFactory }()
 
 	ctx := context.Background()
-	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "")
+	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "", "", "")
 	if err == nil {
 		t.Fatal("expected error when root config has invalid YAML")
 	}
@@ -247,7 +335,7 @@ func TestListCollectionsRemote_InvalidConfig(t *testing.T) {
 	defer func() { gitHubFileReaderFactory = originalFactory }()
 
 	ctx := context.Background()
-	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "")
+	err := listCollectionsRemoteWithSpec(ctx, sampleRemoteSpec(), "", "", "")
 	if err == nil {
 		t.Fatal("expected error when root config validation fails")
 	}

--- a/spec/features/cli/list-collections/README.md
+++ b/spec/features/cli/list-collections/README.md
@@ -1,7 +1,7 @@
 # Feature: List Collections Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-collections?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-collections?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-collections?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-collections?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 
 ## Summary
 

--- a/spec/ideas/seeds/implement-or-remove-list-collections-scoping-flags.md
+++ b/spec/ideas/seeds/implement-or-remove-list-collections-scoping-flags.md
@@ -5,7 +5,7 @@ captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
 captured_during: null
 trigger: explicit
-status: queued
+status: done
 synchestra_task: null
 ---
 # Implement --in and --filter-name scoped filtering for `list collections` (or remove the dead flags from the command and spec)


### PR DESCRIPTION
## Summary

Closes gap #1 from the status reconciliation: the `--in` and `--filter-name` flags on `ingitdb list collections` were registered but never read, so `AC:scoped-listing` was unmet (the flags were silent no-ops). They now actually scope the listing.

## Changes
- New pure helper `filterCollectionIDs(entries, inExpr, nameGlob)`:
  - `--in` = regular expression matched against the collection's **starting-point path**
  - `--filter-name` = glob (`path.Match`) matched against the collection **name**
  - combined with **AND**; an empty flag disables that filter; results sorted
  - invalid regex / glob return a clear diagnostic instead of being ignored
- Applied on **both** sources: local (`CollectionDef.DirPath`) and remote (the `root-collections` name→path map), threading the flags through `listCollectionsRemoteWithSpec`.
- Local output now prints via `cmd.OutOrStdout()` so it is capturable/testable.

## Tests
- `TestFilterCollectionIDs` — table-driven: no-filter, in-only, name-only, AND, no-match, invalid-regex, invalid-glob
- `TestListCollectionsLocal_ScopingFlags` — end-to-end, asserts `--in=/geo/ --filter-name=*cities` narrows stdout to exactly `geo.cities`
- Existing `listCollectionsRemoteWithSpec` call sites updated for the new (no-filter) args

## Verification
- `go build ./...`, `go test ./...`: green
- `golangci-lint run`: 0 issues
- `specscore spec lint`: 0 violations

Feature promoted `Implementing → Stable`; the seed is marked `done`.

## Note
The spec's open question (JSON output via `--format=json`) is left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)