### PR TITLE
fix(cli): abort rebase on conflicts outside --resolve scope

### DIFF
--- a/cmd/ingitdb/commands/rebase.go
+++ b/cmd/ingitdb/commands/rebase.go
@@ -73,8 +73,13 @@ func Rebase(
 					return fmt.Errorf("failed to resolve docs:\n%w", resolveErr)
 				}
 				if len(unresolved) > 0 {
-					return fmt.Errorf("rebase failed with unresolved conflicts in files other than README.md:\n%s\nOutput:\n%s",
-						strings.Join(unresolved, "\n"), rebaseOut)
+					unresolvedList := strings.Join(unresolved, "\n")
+					if abortErr := gitRebaseAbort(ctx, wd); abortErr != nil {
+						return fmt.Errorf("rebase has conflicts in files outside the --resolve scope, and 'git rebase --abort' also failed:\n%s\nunresolved:\n%s",
+							abortErr, unresolvedList)
+					}
+					return fmt.Errorf("rebase aborted: conflicts in files outside the --resolve scope must be resolved manually:\n%s",
+						unresolvedList)
 				}
 				if len(result.Errors) > 0 {
 					return fmt.Errorf("failed to resolve docs:\n%v", result.Errors[0])
@@ -122,6 +127,18 @@ func gitCommitNoVerify(ctx context.Context, wd, message string) error {
 	out, err := cCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to commit resolved files:\n%s\n%v", out, err)
+	}
+	return nil
+}
+
+// gitRebaseAbort runs git rebase --abort to return the working tree to its
+// pre-rebase state when conflicts fall outside the --resolve scope.
+func gitRebaseAbort(ctx context.Context, wd string) error {
+	abortCmd := exec.CommandContext(ctx, "git", "rebase", "--abort")
+	abortCmd.Dir = wd
+	out, err := abortCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to abort rebase:\n%s", out)
 	}
 	return nil
 }

--- a/cmd/ingitdb/commands/rebase_test.go
+++ b/cmd/ingitdb/commands/rebase_test.go
@@ -273,6 +273,71 @@ func TestRebase_ContinueFails(t *testing.T) {
 	}
 }
 
+// setupRebaseSourceConflict creates a git repo where rebasing main onto base
+// conflicts on a plain source file (data.yaml) that is NOT a generated
+// collection README, so it falls outside any --resolve category.
+func setupRebaseSourceConflict(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "init")
+	disableGitBackgroundMaintenance(t, dir)
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test User")
+
+	src := filepath.Join(dir, "data.yaml")
+	writeRebaseFile(t, src, "value: initial\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "initial")
+	runGit(t, dir, "branch", "-m", "main")
+	runGit(t, dir, "branch", "base")
+
+	writeRebaseFile(t, src, "value: main\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "main change")
+
+	runGit(t, dir, "checkout", "base")
+	writeRebaseFile(t, src, "value: base\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "base change")
+	runGit(t, dir, "checkout", "main")
+}
+
+// rebaseInProgress reports whether a git rebase is still halted in dir.
+func rebaseInProgress(dir string) bool {
+	for _, d := range []string{"rebase-merge", "rebase-apply"} {
+		if _, err := os.Stat(filepath.Join(dir, ".git", d)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRebase_AbortsOnSourceConflict covers AC:aborts-on-source-conflict: a
+// conflict outside the --resolve scope must abort the rebase (not leave it
+// halted) and report the unresolved path.
+func TestRebase_AbortsOnSourceConflict(t *testing.T) {
+	dir := t.TempDir()
+	setupRebaseSourceConflict(t, dir)
+
+	getWd := func() (string, error) { return dir, nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
+		return &ingitdb.Definition{Collections: map[string]*ingitdb.CollectionDef{}}, nil
+	}
+
+	cmd := Rebase(getWd, readDef, func(...any) {})
+	err := runCobraCommand(cmd, "--base_ref=base", "--resolve=readme")
+	if err == nil {
+		_ = runGitNoFail(dir, "rebase", "--abort")
+		t.Skip("git produced no conflict in this environment")
+	}
+	if !strings.Contains(err.Error(), "data.yaml") {
+		t.Errorf("expected error to list the unresolved path data.yaml, got: %v", err)
+	}
+	if rebaseInProgress(dir) {
+		_ = runGitNoFail(dir, "rebase", "--abort")
+		t.Errorf("expected rebase to be aborted, but a rebase is still in progress")
+	}
+}
+
 // runGitNoFailOut runs git, ignoring errors, returning combined output.
 func runGitNoFailOut(dir string, args ...string) string {
 	c := exec.Command("git", args...)

--- a/spec/features/cli/rebase/README.md
+++ b/spec/features/cli/rebase/README.md
@@ -1,7 +1,7 @@
 # Feature: Rebase Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/rebase?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/rebase?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/rebase?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/rebase?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 
 ## Summary
 

--- a/spec/ideas/seeds/rebase-abort-on-unresolvable-source-conflicts.md
+++ b/spec/ideas/seeds/rebase-abort-on-unresolvable-source-conflicts.md
@@ -5,7 +5,7 @@ captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
 captured_during: null
 trigger: explicit
-status: queued
+status: done
 synchestra_task: null
 ---
 # Make `ingitdb rebase` run `git rebase --abort` and report unresolved paths on conflicts outside the --resolve scope, with a test


### PR DESCRIPTION
## Summary

Closes gap #2 from the status reconciliation (`cli/rebase` — `AC:aborts-on-source-conflict`). `REQ:aborts-on-unresolvable` requires that when a conflicting file falls outside the `--resolve` categories, the command **aborts the rebase** and reports the unresolved paths. Previously it returned an error listing the paths but left the rebase **halted in progress** — the working tree was stuck mid-rebase.

## Changes
- Add `gitRebaseAbort` helper; call `git rebase --abort` before returning when unresolved conflicts remain. If the abort itself fails, surface that as a secondary error.
- Reword the diagnostic to be category-generic (it was hardcoded to "files other than README.md", which was misleading once `--resolve` became a general category list).

## Tests
- `TestRebase_AbortsOnSourceConflict`: builds a repo whose `main`/`base` conflict on a plain source file (`data.yaml`), runs `rebase --resolve=readme`, and asserts (a) the error lists the unresolved path and (b) **no rebase is in progress** afterward (`.git/rebase-merge` / `rebase-apply` both gone). Written test-first (confirmed red → green).
- Existing README-auto-resolve and failure-branch tests still pass.

## Verification
- `go build ./...`, `go test ./...`: green
- `golangci-lint run`: 0 issues
- `specscore spec lint`: 0 violations

Feature promoted `Implementing → Stable`; seed marked `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)