### PR TITLE
fix(resolve): escalate record merges that fail schema validation

### DIFF
--- a/cmd/ingitdb/commands/record_merge_resolver.go
+++ b/cmd/ingitdb/commands/record_merge_resolver.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/datavalidator"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/docsbuilder"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/recordmerge"
 )
@@ -71,6 +72,15 @@ func mergeAndSerialize(base, ours, theirs []byte, col *ingitdb.CollectionDef, op
 	outcome := recordmerge.MergeFiles(base, ours, theirs, col, opts)
 	if outcome.Escalate {
 		return nil, false
+	}
+	// Re-validate the merged records against the collection schema (DM-17 /
+	// AC:invalid-merge-escalates): a merge that is textually disjoint can still
+	// produce a record that violates the schema, in which case it must escalate
+	// to manual-resolve rather than be staged.
+	for _, r := range outcome.Merged {
+		if errs := datavalidator.ValidateRecordData(col, r.Key, r.Fields); len(errs) > 0 {
+			return nil, false
+		}
 	}
 	merged, err := serializeMergedRecords(outcome.Merged, col)
 	if err != nil {

--- a/cmd/ingitdb/commands/record_merge_resolver_test.go
+++ b/cmd/ingitdb/commands/record_merge_resolver_test.go
@@ -378,6 +378,37 @@ func TestMergeAndSerialize_SerializeFailureNotOK(t *testing.T) {
 	}
 }
 
+func TestMergeAndSerialize_InvalidSchemaEscalates(t *testing.T) {
+	t.Parallel()
+	// A map-of-records collection with a required "name" column. Each side adds
+	// a disjoint record (DM-1), so the merge does not textually escalate — but
+	// THEIRS' record omits the required "name", so the merged result fails
+	// schema validation and MUST escalate (AC:invalid-merge-escalates).
+	col := &ingitdb.CollectionDef{
+		ID:           "c",
+		ColumnsOrder: []string{"name", "note"},
+		RecordFile: &ingitdb.RecordFileDef{
+			Name: "data.yaml", Format: ingitdb.RecordFormatYAML, RecordType: ingitdb.MapOfRecords,
+		},
+		Columns: map[string]*ingitdb.ColumnDef{
+			"name": {Type: ingitdb.ColumnTypeString, Required: true},
+			"note": {Type: ingitdb.ColumnTypeString},
+		},
+	}
+	base := []byte("{}\n")
+	ours := []byte("a:\n  name: Alice\n")
+	theirsInvalid := []byte("b:\n  note: world\n") // missing required "name"
+	if _, ok := mergeAndSerialize(base, ours, theirsInvalid, col, recordmerge.Options{}); ok {
+		t.Fatal("expected escalation when the merged result fails schema validation")
+	}
+
+	// Control: a disjoint addition that satisfies the schema must still merge.
+	theirsValid := []byte("b:\n  name: Bob\n")
+	if _, ok := mergeAndSerialize(base, ours, theirsValid, col, recordmerge.Options{}); !ok {
+		t.Fatal("expected a schema-valid disjoint merge to succeed")
+	}
+}
+
 func TestSerializeMergedRecords(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ingitdb/datavalidator/validator.go
+++ b/pkg/ingitdb/datavalidator/validator.go
@@ -257,6 +257,16 @@ func parseListRows(content []byte, colDef *ingitdb.CollectionDef) ([]map[string]
 	}
 }
 
+// ValidateRecordData validates a single in-memory record's field values against
+// the collection's schema: declared column types, required fields, and the
+// rule that computed-column values must not be stored. It returns the schema
+// violations found (empty when the record is valid). Use it to check records
+// that are not yet persisted to a file, e.g. an auto-merge result before it is
+// staged.
+func ValidateRecordData(colDef *ingitdb.CollectionDef, recordKey string, data map[string]any) []ingitdb.ValidationError {
+	return validateRecordData(colDef.ID, "", recordKey, colDef, data)
+}
+
 func validateRecordData(
 	collectionKey string,
 	filePath string,

--- a/spec/features/cli/resolve/auto-resolve/record-merge/README.md
+++ b/spec/features/cli/resolve/auto-resolve/record-merge/README.md
@@ -1,7 +1,7 @@
 # Feature: Auto-Merge Logically Non-Conflicting Record Data
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve/record-merge?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve/record-merge?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve/record-merge?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve/record-merge?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 **Parent Feature:** [`cli/resolve/auto-resolve`](../README.md)
 
 ## Summary

--- a/spec/ideas/seeds/revalidate-auto-merged-records-against-schema.md
+++ b/spec/ideas/seeds/revalidate-auto-merged-records-against-schema.md
@@ -5,7 +5,7 @@ captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
 captured_during: null
 trigger: explicit
-status: queued
+status: done
 synchestra_task: null
 ---
 # Re-validate auto-merged records against the collection schema and escalate invalid merges instead of staging them


### PR DESCRIPTION
## Summary

Closes gap #3 (`cli/resolve/auto-resolve/record-merge` — `AC:invalid-merge-escalates` / DM-17). The spec's Concept and `REQ:real-conflicts-escalate` require that a merge whose result fails schema validation is **not** auto-staged but handed to `manual-resolve`. Previously `mergeAndSerialize` only checked for merge escalation and serialization failure — it never re-validated the merged records against the collection schema, so a textually-disjoint merge could stage a schema-invalid record.

## Changes
- Export `datavalidator.ValidateRecordData(colDef, recordKey, data)` — validates an in-memory record against the schema (column types, required fields, reject-stored-computed-column) without needing a file on disk. Thin wrapper over the existing internal `validateRecordData`.
- In `mergeAndSerialize`, after the three-way merge, validate every merged record; escalate (`ok=false`) if any violates the schema.

## Tests
- `TestMergeAndSerialize_InvalidSchemaEscalates`: a disjoint addition (DM-1) whose THEIRS record omits a required field escalates; a schema-valid disjoint merge still succeeds (control). Written test-first (confirmed red → green).

## Verification
- `go build ./...`, `go test ./...`: green
- `golangci-lint run`: 0 issues
- `specscore spec lint`: 0 violations

Feature promoted `Implementing → Stable`; seed marked `done`.

## Scope note
"Schema validation" here is type/required/computed-column validation. Referential-integrity (foreign-key) checks during merge are a separate concern (tracked by the existing `wire-write-time-validations…` seed) and out of scope for this AC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)