### PR TITLE
feat(cli): implement incremental (commit-range) validation

### DIFF
--- a/cmd/ingitdb/main.go
+++ b/cmd/ingitdb/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2fsingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/datavalidator"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/gitdiff"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/materializer"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/validator"
 )
@@ -74,7 +75,8 @@ func run(
 
 	rootCmd.AddCommand(
 		commands.Version(version, commit, date),
-		commands.Validate(homeDir, getWd, readDefinition, datavalidator.NewValidator(), nil, logf),
+		commands.Validate(homeDir, getWd, readDefinition, datavalidator.NewValidator(),
+			datavalidator.NewIncrementalValidator(gitdiff.NewGitDiffer(), datavalidator.NewChangeSetResolver(), datavalidator.NewValidator()), logf),
 		commands.Materialize(homeDir, getWd, readDefinition, vb, logf),
 		commands.CI(homeDir, getWd, readDefinition, vb, logf),
 		commands.Pull(),

--- a/pkg/ingitdb/datavalidator/changeset_resolver.go
+++ b/pkg/ingitdb/datavalidator/changeset_resolver.go
@@ -1,0 +1,82 @@
+package datavalidator
+
+// specscore: feature/cli/validate
+
+import (
+	"path/filepath"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// NewChangeSetResolver returns the default ChangeSetResolver, which maps changed
+// files to the collection records they belong to. It assumes the database
+// directory is the git repository root (changed-file paths are joined onto it).
+func NewChangeSetResolver() ChangeSetResolver {
+	return changeSetResolver{}
+}
+
+type changeSetResolver struct{}
+
+// Resolve maps each changed file to the collection record it affects. Deleted
+// files are skipped (there is nothing to open; orphaned-reference checks are
+// out of scope). For single-record layouts the affected record key is derived
+// from the file name; for map/list layouts the whole shared file is marked
+// affected (RecordKey == "").
+func (changeSetResolver) Resolve(dbPath string, def *ingitdb.Definition, changedFiles []ingitdb.ChangedFile) ([]AffectedRecord, error) {
+	var affected []AffectedRecord
+	for _, cf := range changedFiles {
+		if cf.Kind == ingitdb.ChangeKindDeleted {
+			continue
+		}
+		absPath := filepath.Clean(filepath.Join(dbPath, cf.Path))
+		colID, colDef := collectionForRecordFile(def, absPath)
+		if colDef == nil {
+			continue
+		}
+		switch colDef.RecordFile.RecordType {
+		case ingitdb.SingleRecord:
+			affected = append(affected, AffectedRecord{
+				CollectionID: colID,
+				FilePath:     absPath,
+				RecordKey:    recordKeyFromFilePath(absPath),
+				ChangeKind:   cf.Kind,
+			})
+		case ingitdb.MapOfRecords, ingitdb.ListOfRecords:
+			affected = append(affected, AffectedRecord{
+				CollectionID: colID,
+				FilePath:     absPath,
+				RecordKey:    "",
+				ChangeKind:   cf.Kind,
+			})
+		}
+	}
+	return affected, nil
+}
+
+// collectionForRecordFile returns the collection (and its ID) that owns absPath
+// as a record file, or ("", nil) when no collection's record-file layout
+// matches. It mirrors how the full validator enumerates record files, so the
+// incremental and full passes agree on which files are records.
+func collectionForRecordFile(def *ingitdb.Definition, absPath string) (string, *ingitdb.CollectionDef) {
+	for id, colDef := range def.Collections {
+		if shouldSkipRecordParsing(colDef) {
+			continue
+		}
+		switch colDef.RecordFile.RecordType {
+		case ingitdb.SingleRecord:
+			pattern, err := singleRecordGlobPattern(colDef)
+			if err != nil {
+				continue
+			}
+			matched, matchErr := filepath.Match(filepath.Clean(pattern), absPath)
+			if matchErr == nil && matched && !skipRecordPath(absPath, colDef.RecordFile) {
+				return id, colDef
+			}
+		case ingitdb.MapOfRecords, ingitdb.ListOfRecords:
+			if filepath.Clean(collectionRecordFilePath(colDef)) == absPath {
+				return id, colDef
+			}
+		}
+	}
+	return "", nil
+}

--- a/pkg/ingitdb/datavalidator/changeset_resolver_test.go
+++ b/pkg/ingitdb/datavalidator/changeset_resolver_test.go
@@ -1,0 +1,76 @@
+package datavalidator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+func resolverTestDef(dbPath string) *ingitdb.Definition {
+	return &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"people": {
+				ID:      "people",
+				DirPath: filepath.Join(dbPath, "people"),
+				RecordFile: &ingitdb.RecordFileDef{
+					Name: "{key}.yaml", Format: ingitdb.RecordFormatYAML, RecordType: ingitdb.SingleRecord,
+				},
+				Columns: map[string]*ingitdb.ColumnDef{"name": {Type: ingitdb.ColumnTypeString}},
+			},
+			"tags": {
+				ID:      "tags",
+				DirPath: filepath.Join(dbPath, "tags"),
+				RecordFile: &ingitdb.RecordFileDef{
+					Name: "tags.yaml", Format: ingitdb.RecordFormatYAML, RecordType: ingitdb.MapOfRecords,
+				},
+				Columns: map[string]*ingitdb.ColumnDef{"label": {Type: ingitdb.ColumnTypeString}},
+			},
+		},
+	}
+}
+
+func TestChangeSetResolver_Resolve(t *testing.T) {
+	t.Parallel()
+
+	dbPath := "/db"
+	def := resolverTestDef(dbPath)
+	// Single-record collections with a templated {key} name store records under
+	// a "$records" subdirectory (see RecordFileDef.RecordsBasePath).
+	changed := []ingitdb.ChangedFile{
+		{Kind: ingitdb.ChangeKindModified, Path: "people/$records/alice.yaml"},
+		{Kind: ingitdb.ChangeKindAdded, Path: "people/$records/bob.yaml"},
+		{Kind: ingitdb.ChangeKindModified, Path: "tags/tags.yaml"},
+		{Kind: ingitdb.ChangeKindDeleted, Path: "people/$records/carol.yaml"}, // skipped: deletion
+		{Kind: ingitdb.ChangeKindModified, Path: "README.md"},                 // skipped: not a record file
+	}
+
+	got, err := NewChangeSetResolver().Resolve(dbPath, def, changed)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// Index by file path for assertions.
+	byPath := map[string]AffectedRecord{}
+	for _, ar := range got {
+		byPath[ar.FilePath] = ar
+	}
+	if len(byPath) != 3 {
+		t.Fatalf("expected 3 affected records, got %d: %+v", len(byPath), got)
+	}
+
+	alice := byPath[filepath.Join(dbPath, "people/$records/alice.yaml")]
+	if alice.CollectionID != "people" || alice.RecordKey != "alice" {
+		t.Errorf("alice affected = %+v, want collection people key alice", alice)
+	}
+	tags := byPath[filepath.Join(dbPath, "tags/tags.yaml")]
+	if tags.CollectionID != "tags" || tags.RecordKey != "" {
+		t.Errorf("tags affected = %+v, want collection tags whole-file key \"\"", tags)
+	}
+	if _, ok := byPath[filepath.Join(dbPath, "people/$records/carol.yaml")]; ok {
+		t.Error("deleted file must not be reported as affected")
+	}
+	if _, ok := byPath[filepath.Join(dbPath, "README.md")]; ok {
+		t.Error("non-record file must not be reported as affected")
+	}
+}

--- a/pkg/ingitdb/datavalidator/incremental_validator.go
+++ b/pkg/ingitdb/datavalidator/incremental_validator.go
@@ -1,0 +1,124 @@
+package datavalidator
+
+// specscore: feature/cli/validate
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/config"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/gitdiff"
+)
+
+// NewIncrementalValidator returns an IncrementalValidator that validates only
+// the records whose files changed between two git refs. differ lists changed
+// files, resolver maps them to collection records, and full is used as a
+// fall-back when a definition file changed (the schema itself moved).
+func NewIncrementalValidator(differ gitdiff.GitDiffer, resolver ChangeSetResolver, full DataValidator) IncrementalValidator {
+	return &incrementalValidator{differ: differ, resolver: resolver, full: full}
+}
+
+type incrementalValidator struct {
+	differ   gitdiff.GitDiffer
+	resolver ChangeSetResolver
+	full     DataValidator
+}
+
+func (iv *incrementalValidator) ValidateChanges(
+	ctx context.Context,
+	dbPath string,
+	def *ingitdb.Definition,
+	fromCommit, toCommit string,
+) (*ingitdb.ValidationResult, error) {
+	changed, err := iv.differ.DiffFiles(ctx, dbPath, fromCommit, toCommit)
+	if err != nil {
+		return nil, err
+	}
+	// If a definition file changed, the schema itself moved — a record-scoped
+	// pass could miss records that became invalid under the new schema. Fall
+	// back to a full validation pass.
+	if changedDefinitionFile(changed) {
+		return iv.full.Validate(ctx, dbPath, def)
+	}
+
+	affected, err := iv.resolver.Resolve(dbPath, def, changed)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ingitdb.ValidationResult{}
+	type counts struct{ passed, total int }
+	perCollection := map[string]*counts{}
+	wholeFileDone := map[string]bool{} // collectionID → its shared file already validated
+
+	for _, ar := range affected {
+		colDef := def.Collections[ar.CollectionID]
+		if colDef == nil {
+			continue
+		}
+		c := perCollection[ar.CollectionID]
+		if c == nil {
+			c = &counts{}
+			perCollection[ar.CollectionID] = c
+		}
+		switch colDef.RecordFile.RecordType {
+		case ingitdb.SingleRecord:
+			passed, total, errs := validateSingleRecordFile(ar.CollectionID, colDef, ar.FilePath)
+			c.passed += passed
+			c.total += total
+			appendErrors(result, errs)
+		case ingitdb.MapOfRecords, ingitdb.ListOfRecords:
+			if wholeFileDone[ar.CollectionID] {
+				continue
+			}
+			wholeFileDone[ar.CollectionID] = true
+			passed, total, errs := validateWholeRecordFile(ar.CollectionID, colDef)
+			c.passed += passed
+			c.total += total
+			appendErrors(result, errs)
+		}
+	}
+
+	for collectionID, c := range perCollection {
+		result.SetRecordCounts(collectionID, c.passed, c.total)
+		result.SetRecordCount(collectionID, c.total)
+	}
+	return result, nil
+}
+
+// validateWholeRecordFile validates every record in a collection's shared
+// map/list record file.
+func validateWholeRecordFile(collectionKey string, colDef *ingitdb.CollectionDef) (int, int, []ingitdb.ValidationError) {
+	switch colDef.RecordFile.RecordType {
+	case ingitdb.MapOfRecords:
+		return validateMapOfRecordsFile(collectionKey, colDef)
+	case ingitdb.ListOfRecords:
+		return validateListOfRecordsFile(collectionKey, colDef)
+	default:
+		return 0, 0, nil
+	}
+}
+
+func appendErrors(result *ingitdb.ValidationResult, errs []ingitdb.ValidationError) {
+	for _, e := range errs {
+		result.Append(e)
+	}
+}
+
+// changedDefinitionFile reports whether any changed file is a schema/definition
+// file (database config, collection definition, or root-collections), in which
+// case incremental validation falls back to a full pass.
+func changedDefinitionFile(changed []ingitdb.ChangedFile) bool {
+	for _, cf := range changed {
+		base := filepath.Base(cf.Path)
+		if base == ingitdb.CollectionDefFileName || base == config.RootCollectionsFileName || base == ".ingitdb.yaml" {
+			return true
+		}
+		if strings.HasPrefix(cf.Path, config.IngitDBDirName+"/") || strings.Contains(cf.Path, "/"+config.IngitDBDirName+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ingitdb/datavalidator/incremental_validator_test.go
+++ b/pkg/ingitdb/datavalidator/incremental_validator_test.go
@@ -1,0 +1,167 @@
+package datavalidator
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/gitdiff"
+)
+
+type fakeDiffer struct {
+	files []ingitdb.ChangedFile
+	err   error
+}
+
+func (f fakeDiffer) DiffFiles(_ context.Context, _, _, _ string) ([]ingitdb.ChangedFile, error) {
+	return f.files, f.err
+}
+
+type fakeFullValidator struct {
+	called bool
+	result *ingitdb.ValidationResult
+}
+
+func (f *fakeFullValidator) Validate(_ context.Context, _ string, _ *ingitdb.Definition) (*ingitdb.ValidationResult, error) {
+	f.called = true
+	return f.result, nil
+}
+
+func TestChangedDefinitionFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"root config", ".ingitdb.yaml", true},
+		{"collection definition", "people/.collection/definition.yaml", true},
+		{"root-collections", ".ingitdb/root-collections.yaml", true},
+		{"plain record", "people/alice.yaml", false},
+		{"readme", "people/README.md", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := changedDefinitionFile([]ingitdb.ChangedFile{{Kind: ingitdb.ChangeKindModified, Path: tc.path}})
+			if got != tc.want {
+				t.Errorf("changedDefinitionFile(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIncrementalValidator_FallsBackOnDefinitionChange(t *testing.T) {
+	t.Parallel()
+
+	sentinel := &ingitdb.ValidationResult{}
+	full := &fakeFullValidator{result: sentinel}
+	differ := fakeDiffer{files: []ingitdb.ChangedFile{{Kind: ingitdb.ChangeKindModified, Path: ".ingitdb.yaml"}}}
+	iv := NewIncrementalValidator(differ, NewChangeSetResolver(), full)
+
+	got, err := iv.ValidateChanges(context.Background(), "/db", &ingitdb.Definition{}, "A", "B")
+	if err != nil {
+		t.Fatalf("ValidateChanges: %v", err)
+	}
+	if !full.called {
+		t.Error("expected fall-back to full validation when a definition file changed")
+	}
+	if got != sentinel {
+		t.Error("expected the full validator's result to be returned")
+	}
+}
+
+// TestIncrementalValidator_ScopedToChangedRecords is the AC:scoped-validation
+// end-to-end: only records whose files changed in the range are validated;
+// records outside the range are not opened.
+func TestIncrementalValidator_ScopedToChangedRecords(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	git := func(args ...string) {
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(rel, content string) {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	git("init")
+	git("config", "user.email", "t@example.com")
+	git("config", "user.name", "T")
+	// Single-record collection with a templated {key} name stores records under
+	// "$records". Base: an already-invalid record (missing required name) that we
+	// will NOT touch, plus a valid record.
+	write("people/$records/keep_bad.yaml", "{}\n")
+	write("people/$records/alice.yaml", "name: Alice\n")
+	git("add", ".")
+	git("commit", "-m", "base")
+	base := strings.TrimSpace(gitOut(t, dir, "rev-parse", "HEAD"))
+
+	// Second commit: modify alice (still valid) and add an invalid charlie.
+	write("people/$records/alice.yaml", "name: Alice2\n")
+	write("people/$records/charlie.yaml", "{}\n")
+	git("add", ".")
+	git("commit", "-m", "second")
+
+	def := &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"people": {
+				ID:      "people",
+				DirPath: filepath.Join(dir, "people"),
+				RecordFile: &ingitdb.RecordFileDef{
+					Name: "{key}.yaml", Format: ingitdb.RecordFormatYAML, RecordType: ingitdb.SingleRecord,
+				},
+				Columns: map[string]*ingitdb.ColumnDef{"name": {Type: ingitdb.ColumnTypeString, Required: true}},
+			},
+		},
+	}
+
+	iv := NewIncrementalValidator(gitdiff.NewGitDiffer(), NewChangeSetResolver(), NewValidator())
+	result, err := iv.ValidateChanges(context.Background(), dir, def, base, "HEAD")
+	if err != nil {
+		t.Fatalf("ValidateChanges: %v", err)
+	}
+	if !result.HasErrors() {
+		t.Fatal("expected the changed invalid record (charlie) to fail validation")
+	}
+	joined := strings.Join(errorStrings(result), " | ")
+	if !strings.Contains(joined, "charlie") {
+		t.Errorf("expected error to reference changed record charlie, got: %s", joined)
+	}
+	if strings.Contains(joined, "keep_bad") {
+		t.Errorf("unchanged invalid record keep_bad must not be opened/validated, got: %s", joined)
+	}
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	out, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+func errorStrings(result *ingitdb.ValidationResult) []string {
+	var out []string
+	for _, e := range result.Errors() {
+		out = append(out, e.FilePath+":"+e.Error())
+	}
+	return out
+}

--- a/pkg/ingitdb/datavalidator/validator.go
+++ b/pkg/ingitdb/datavalidator/validator.go
@@ -85,41 +85,45 @@ func validateSingleRecordFiles(collectionKey string, colDef *ingitdb.CollectionD
 	total := 0
 	var errors []ingitdb.ValidationError
 	for _, filePath := range matches {
-		if skipRecordPath(filePath, colDef.RecordFile) {
-			continue
-		}
-		info, statErr := os.Stat(filePath)
-		if statErr != nil {
-			total++
-			validationErr := newValidationError(collectionKey, filePath, "", "", "failed to stat record file", statErr)
-			errors = append(errors, validationErr)
-			continue
-		}
-		if info.IsDir() {
-			continue
-		}
-		total++
-		content, readErr := os.ReadFile(filePath)
-		if readErr != nil {
-			validationErr := newValidationError(collectionKey, filePath, "", "", "failed to read record file", readErr)
-			errors = append(errors, validationErr)
-			continue
-		}
-		data, parseErr := dalgo2ingitdb.ParseRecordContentForCollection(content, colDef)
-		if parseErr != nil {
-			validationErr := newValidationError(collectionKey, filePath, "", "", "failed to parse record file", parseErr)
-			errors = append(errors, validationErr)
-			continue
-		}
-		recordKey := recordKeyFromFilePath(filePath)
-		recordErrors := validateRecordData(collectionKey, filePath, recordKey, colDef, data)
-		if len(recordErrors) > 0 {
-			errors = append(errors, recordErrors...)
-			continue
-		}
-		passed++
+		filePassed, fileTotal, fileErrors := validateSingleRecordFile(collectionKey, colDef, filePath)
+		passed += filePassed
+		total += fileTotal
+		errors = append(errors, fileErrors...)
 	}
 	return passed, total, errors
+}
+
+// validateSingleRecordFile validates one single-record file: it stats, reads,
+// parses, and schema-validates the record. It returns the per-file passed/total
+// counts (a skipped or directory path counts as 0/0) and any errors found.
+func validateSingleRecordFile(collectionKey string, colDef *ingitdb.CollectionDef, filePath string) (int, int, []ingitdb.ValidationError) {
+	if skipRecordPath(filePath, colDef.RecordFile) {
+		return 0, 0, nil
+	}
+	info, statErr := os.Stat(filePath)
+	if statErr != nil {
+		validationErr := newValidationError(collectionKey, filePath, "", "", "failed to stat record file", statErr)
+		return 0, 1, []ingitdb.ValidationError{validationErr}
+	}
+	if info.IsDir() {
+		return 0, 0, nil
+	}
+	content, readErr := os.ReadFile(filePath)
+	if readErr != nil {
+		validationErr := newValidationError(collectionKey, filePath, "", "", "failed to read record file", readErr)
+		return 0, 1, []ingitdb.ValidationError{validationErr}
+	}
+	data, parseErr := dalgo2ingitdb.ParseRecordContentForCollection(content, colDef)
+	if parseErr != nil {
+		validationErr := newValidationError(collectionKey, filePath, "", "", "failed to parse record file", parseErr)
+		return 0, 1, []ingitdb.ValidationError{validationErr}
+	}
+	recordKey := recordKeyFromFilePath(filePath)
+	recordErrors := validateRecordData(collectionKey, filePath, recordKey, colDef, data)
+	if len(recordErrors) > 0 {
+		return 0, 1, recordErrors
+	}
+	return 1, 1, nil
 }
 
 func singleRecordGlobPattern(colDef *ingitdb.CollectionDef) (string, error) {

--- a/pkg/ingitdb/gitdiff/gitdiff.go
+++ b/pkg/ingitdb/gitdiff/gitdiff.go
@@ -1,7 +1,12 @@
 package gitdiff
 
+// specscore: feature/cli/validate
+
 import (
 	"context"
+	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
@@ -10,4 +15,62 @@ import (
 // The default implementation shells out to `git diff --name-status fromRef toRef`.
 type GitDiffer interface {
 	DiffFiles(ctx context.Context, repoPath, fromRef, toRef string) ([]ingitdb.ChangedFile, error)
+}
+
+// NewGitDiffer returns the default GitDiffer, which shells out to git.
+func NewGitDiffer() GitDiffer {
+	return cmdGitDiffer{}
+}
+
+type cmdGitDiffer struct{}
+
+// DiffFiles runs `git diff --name-status <fromRef> [<toRef>]` in repoPath and
+// parses the result. An empty toRef diffs fromRef against the working tree.
+func (cmdGitDiffer) DiffFiles(ctx context.Context, repoPath, fromRef, toRef string) ([]ingitdb.ChangedFile, error) {
+	if fromRef == "" {
+		return nil, fmt.Errorf("from ref is required")
+	}
+	args := []string{"diff", "--name-status", fromRef}
+	if toRef != "" {
+		args = append(args, toRef)
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = repoPath
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff failed: %w", err)
+	}
+	return parseNameStatus(string(out)), nil
+}
+
+// parseNameStatus parses `git diff --name-status` output into ChangedFile
+// entries. Each line is a tab-separated status and path(s); rename/copy lines
+// carry the score-suffixed status, an old path, and a new path.
+func parseNameStatus(out string) []ingitdb.ChangedFile {
+	var changed []ingitdb.ChangedFile
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 {
+			continue
+		}
+		status := fields[0]
+		switch status[0] {
+		case 'A':
+			changed = append(changed, ingitdb.ChangedFile{Kind: ingitdb.ChangeKindAdded, Path: fields[1]})
+		case 'D':
+			changed = append(changed, ingitdb.ChangedFile{Kind: ingitdb.ChangeKindDeleted, Path: fields[1]})
+		case 'R', 'C':
+			if len(fields) < 3 {
+				continue
+			}
+			changed = append(changed, ingitdb.ChangedFile{Kind: ingitdb.ChangeKindRenamed, OldPath: fields[1], Path: fields[2]})
+		default: // M, T (type change) and anything else → treat as modified
+			changed = append(changed, ingitdb.ChangedFile{Kind: ingitdb.ChangeKindModified, Path: fields[1]})
+		}
+	}
+	return changed
 }

--- a/pkg/ingitdb/gitdiff/gitdiff_cmd_test.go
+++ b/pkg/ingitdb/gitdiff/gitdiff_cmd_test.go
@@ -1,0 +1,97 @@
+package gitdiff
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+func TestParseNameStatus(t *testing.T) {
+	t.Parallel()
+
+	out := "M\tcountries/ie.yaml\n" +
+		"A\tcountries/gb.yaml\n" +
+		"D\tcountries/fr.yaml\n" +
+		"R100\tcountries/de.yaml\tcountries/germany.yaml\n" +
+		"\n"
+	got := parseNameStatus(out)
+
+	want := []ingitdb.ChangedFile{
+		{Kind: ingitdb.ChangeKindModified, Path: "countries/ie.yaml"},
+		{Kind: ingitdb.ChangeKindAdded, Path: "countries/gb.yaml"},
+		{Kind: ingitdb.ChangeKindDeleted, Path: "countries/fr.yaml"},
+		{Kind: ingitdb.ChangeKindRenamed, OldPath: "countries/de.yaml", Path: "countries/germany.yaml"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parseNameStatus returned %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestCmdGitDiffer_RequiresFromRef(t *testing.T) {
+	t.Parallel()
+	if _, err := NewGitDiffer().DiffFiles(context.Background(), t.TempDir(), "", "HEAD"); err == nil {
+		t.Fatal("expected error when from ref is empty")
+	}
+}
+
+func TestCmdGitDiffer_DiffFiles_RealRepo(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	git := func(args ...string) {
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	git("init")
+	git("config", "user.email", "t@example.com")
+	git("config", "user.name", "T")
+	write("a.yaml", "v: 1\n")
+	git("add", ".")
+	git("commit", "-m", "base")
+	revParse := exec.Command("git", "rev-parse", "HEAD")
+	revParse.Dir = dir
+	baseOut, err := revParse.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse: %v\n%s", err, baseOut)
+	}
+	base := strings.TrimSpace(string(baseOut))
+
+	write("a.yaml", "v: 2\n") // modified
+	write("b.yaml", "v: 3\n") // added
+	git("add", ".")
+	git("commit", "-m", "second")
+
+	got, err := NewGitDiffer().DiffFiles(context.Background(), dir, base, "HEAD")
+	if err != nil {
+		t.Fatalf("DiffFiles: %v", err)
+	}
+	kinds := map[string]ingitdb.ChangeKind{}
+	for _, c := range got {
+		kinds[c.Path] = c.Kind
+	}
+	if kinds["a.yaml"] != ingitdb.ChangeKindModified {
+		t.Errorf("a.yaml kind = %q, want modified", kinds["a.yaml"])
+	}
+	if kinds["b.yaml"] != ingitdb.ChangeKindAdded {
+		t.Errorf("b.yaml kind = %q, want added", kinds["b.yaml"])
+	}
+}

--- a/spec/features/cli/validate/README.md
+++ b/spec/features/cli/validate/README.md
@@ -1,7 +1,7 @@
 # Feature: Validate Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/validate?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/validate?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/validate?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/validate?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 
 ## Summary
 
@@ -31,7 +31,7 @@ The `--only=VALUE` flag MUST accept the values `definition` and `records`. When 
 
 #### REQ: commit-range
 
-The `--from-commit=SHA` and `--to-commit=SHA` flags MUST scope record validation to files changed between the two commits. They MAY be combined with `--only=records`. When neither flag is provided, all record files in the working tree are checked.
+The `--from-commit=SHA` and `--to-commit=SHA` flags MUST scope record validation to files changed between the two commits. They MAY be combined with `--only=records`. When neither flag is provided, all record files in the working tree are checked. When `--to-commit` is omitted, the range ends at the working tree (uncommitted changes are included). Because the change set is computed at file granularity, records whose files did not change in the range are not opened. If a definition file (`.ingitdb.yaml`, a collection `definition.yaml`, or `.ingitdb/`) changed within the range, the schema itself may have moved, so the command MUST fall back to a full validation pass.
 
 ### Output and exit code
 
@@ -59,6 +59,9 @@ Source files implementing this feature (annotated with
 - [`cmd/ingitdb/commands/validate.go`](../../../cmd/ingitdb/commands/validate.go)
 - [`pkg/ingitdb/validator/def_validator.go`](../../../pkg/ingitdb/validator/def_validator.go)
 - [`pkg/ingitdb/validator/subscribers_validator.go`](../../../pkg/ingitdb/validator/subscribers_validator.go)
+- [`pkg/ingitdb/datavalidator/incremental_validator.go`](../../../pkg/ingitdb/datavalidator/incremental_validator.go) — incremental (commit-range) validation
+- [`pkg/ingitdb/datavalidator/changeset_resolver.go`](../../../pkg/ingitdb/datavalidator/changeset_resolver.go) — maps changed files to affected collection records
+- [`pkg/ingitdb/gitdiff/gitdiff.go`](../../../pkg/ingitdb/gitdiff/gitdiff.go) — `git diff --name-status` change lister
 
 ## Acceptance Criteria
 

--- a/spec/ideas/seeds/implement-incremental-validation-commit-range.md
+++ b/spec/ideas/seeds/implement-incremental-validation-commit-range.md
@@ -5,7 +5,7 @@ captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
 captured_during: null
 trigger: explicit
-status: queued
+status: done
 synchestra_task: null
 ---
 # Implement IncrementalValidator so `validate --from-commit/--to-commit` scopes validation to changed records instead of returning not-implemented


### PR DESCRIPTION
## Summary

Closes gap #4 (`cli/validate` — `AC:scoped-validation` / `REQ:commit-range`). `ingitdb validate --from-commit/--to-commit` previously returned *"incremental validation is not yet implemented"* because `IncrementalValidator` was wired as `nil`. The interfaces and command-side plumbing already existed; this fills in the production implementations behind those stable contracts.

## Changes
- **`gitdiff`**: concrete `GitDiffer` (`NewGitDiffer`) shelling out to `git diff --name-status`, with a pure, unit-tested `parseNameStatus`. An empty `to` ref diffs against the working tree.
- **`datavalidator.ChangeSetResolver`**: maps changed files → affected collection records — single-record → per-file (key from filename); map/list → the whole shared file (`RecordKey == ""`); deletions skipped. Reuses the validator's own record-file matchers (`singleRecordGlobPattern`, `collectionRecordFilePath`) so the incremental and full passes agree on what counts as a record.
- **`datavalidator.IncrementalValidator`**: orchestrates diff → resolve → validate only the changed files, accumulating a `ValidationResult`. Falls back to a full pass if a definition file changed in the range.
- Extracted `validateSingleRecordFile` so full and incremental validation share one record-validation code path.
- Wired the concrete validator in `main.go` (replacing `nil`).

## Design decisions (per agreed defaults)
- Empty `--to-commit` ⇒ working tree (uncommitted changes included).
- A definition-file change in range ⇒ full validation fallback (schema may have moved).
- Referential-integrity / FK checks remain out of scope (consistent with the record-merge decision).

These are now documented in `REQ:commit-range`.

## Tests
- `parseNameStatus` + a real-repo `GitDiffer` integration test
- `ChangeSetResolver` mapping (single/map, deletion + non-record skipped)
- `changedDefinitionFile` predicate
- definition-change → full fallback (fakes)
- **end-to-end scoped validation**: an *unchanged* invalid record is **not opened**, while a *changed* invalid record fails — directly exercising `AC:scoped-validation`

All written test-first (confirmed red where applicable).

## Verification
- `go build ./...`, `go test ./...`: green
- `golangci-lint run`: 0 issues
- `specscore spec lint`: 0 violations

Feature promoted `Implementing → Stable`; seed marked `done`.

## Scope note
Assumes the database directory is the git repo root (changed-file paths are joined onto `dbPath`). A db nested in a subdirectory of a larger repo is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)