### PR TITLE
docs(spec): use registered github provider for self-hosted host AC

### DIFF
--- a/spec/features/remote-repo-access/README.md
+++ b/spec/features/remote-repo-access/README.md
@@ -188,14 +188,14 @@ With only `GITHUB_TOKEN` set, `ingitdb update --remote=github.com/owner/repo --i
 
 **Requirements:** remote-repo-access#req:token-resolution, remote-repo-access#req:provider-override
 
-With `GIT_CORP_EXAMPLE_TOKEN` set and `--provider=github-enterprise`, `ingitdb select --remote=git.corp.example.com/owner/repo --id=x/y` MUST authenticate using that token without requiring `--token` on the command line.
+With `GIT_CORP_EXAMPLE_TOKEN` set and `--provider=github` (a self-hosted GitHub Enterprise instance reuses the registered `github` adapter against its own host), `ingitdb select --remote=git.corp.example.com/owner/repo --id=x/y` MUST authenticate using that token without requiring `--token` on the command line. The `--provider` value MUST be a registered provider id (`github`, `gitlab`, or `bitbucket`); there is no separate `github-enterprise` id.
 
 ## Open Questions
 
 - How should the command behave when the provider rate-limits the caller mid-operation? (carried over from `github-direct-access`)
 - Should the commit message format be configurable per command or fixed by convention? (carried over)
 - Is `--provider` a global flag or per-command? Proposed: global, registered alongside `--remote` and `--token` by `addRemoteFlags`.
-- Should `--provider` accept a versioned id (e.g. `github-enterprise@v3`) for hosts that expose multiple incompatible API generations, or is one id per provider sufficient?
+- Should `--provider` accept a versioned id (e.g. `github@v3`) for hosts that expose multiple incompatible API generations, or is one id per provider sufficient?
 
 ---
 *This document follows the https://specscore.md/feature-specification*

--- a/spec/ideas/seeds/enforce-token-for-remote-writes-and-github-enterprise-provider.md
+++ b/spec/ideas/seeds/enforce-token-for-remote-writes-and-github-enterprise-provider.md
@@ -8,6 +8,8 @@ trigger: explicit
 status: queued
 synchestra_task: null
 ---
-# Enforce a local token-required pre-flight for remote writes, and add the github-enterprise provider to the registry
+# Enforce a local token-required pre-flight for remote writes
 
-Two gaps found while reconciling remote-repo-access (7/9 ACs). (1) REQ:token-required-for-writes is unenforced: no CLI/library pre-flight rejects a write when no token resolves (flag and all *_TOKEN env vars empty). `remoteToken` may return "" and writes proceed unauthenticated, failing only at the GitHub API (401) instead of with the spec-mandated local "token required" error; no test covers "write without token must fail". (2) `AC:self-hosted-host-token` is written against `--provider=github-enterprise`, but that id is not in `registeredProviders` (only github/gitlab/bitbucket), so the AC's literal invocation fails with "unknown --provider" before token resolution runs. Token resolution for self-hosted hosts (`TestResolveRemoteToken`, `TestHostTokenEnvName`) is otherwise implemented. Either register a `github-enterprise` provider/adapter or fix the spec to use a registered provider, then add the end-to-end test.
+REQ:token-required-for-writes is unenforced: no CLI/library pre-flight rejects a write when no token resolves (flag and all *_TOKEN env vars empty). `remoteToken` may return "" and writes proceed unauthenticated, failing only at the GitHub API (401) instead of with the spec-mandated local "token required" error; no test covers "write without token must fail".
+
+RESOLVED (separate change): the `--provider=github-enterprise` sub-gap on `AC:self-hosted-host-token` was fixed by correcting the spec to use the registered `github` provider (a self-hosted GitHub Enterprise host reuses the `github` adapter); there is no separate `github-enterprise` id. Only the token-required-for-writes enforcement above remains before remote-repo-access can move to Stable.


### PR DESCRIPTION
## Summary

Resolves the `github-enterprise` half of the `remote-repo-access` gap by **correcting the spec** (your call) rather than adding a new provider.

`AC:self-hosted-host-token` was written against `--provider=github-enterprise`, but that id is **not** registered (`registeredProviders` = github/gitlab/bitbucket). The AC's literal invocation would fail with "unknown --provider" before token resolution ever ran — i.e. the AC could never pass as written.

A self-hosted GitHub Enterprise instance reuses the **`github`** adapter against its own host (the implemented, tested path), so the AC now uses `--provider=github` and states explicitly that there is no separate `github-enterprise` id. The versioned-id open question is reworded (`github@v3`) to match.

## Changes
- `spec/features/remote-repo-access/README.md`: corrected `AC:self-hosted-host-token` + open question.
- Updated the `remote-repo-access` seed: github-enterprise sub-gap resolved; **token-required-for-writes enforcement remains** the only blocker before the feature can go `Stable`.

## Verification
- `specscore spec lint`: 0 violations

Spec-only change — no code touched. Feature stays `Implementing` (token-enforcement gap outstanding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)