### PR TITLE
feat(cli): require a token for remote writes

### DIFF
--- a/cmd/ingitdb/commands/cobra_helpers.go
+++ b/cmd/ingitdb/commands/cobra_helpers.go
@@ -98,6 +98,29 @@ func remoteToken(cmd *cobra.Command, host string) string {
 	return resolveRemoteToken(host, tokenFlag, os.Getenv)
 }
 
+// requireRemoteWriteToken enforces REQ:token-required-for-writes: a write
+// command using --remote MUST have a resolvable token (from --token or a
+// host-derived *_TOKEN env var), even against a public repository. It is a
+// no-op for local (non-remote) operations and runs before any network I/O.
+func requireRemoteWriteToken(cmd *cobra.Command) error {
+	remoteValue, _ := cmd.Flags().GetString("remote")
+	if remoteValue == "" {
+		return nil
+	}
+	spec, err := resolveRemoteFromFlags(cmd, remoteValue)
+	if err != nil {
+		return err
+	}
+	if remoteToken(cmd, spec.Host) != "" {
+		return nil
+	}
+	envHint := hostTokenEnvName(spec.Host, true)
+	if envHint == "" {
+		envHint = hostTokenEnvName(spec.Host, false)
+	}
+	return fmt.Errorf("a token is required for remote writes (even for public repositories): provide --token or set %s", envHint)
+}
+
 // resolveRemoteFromFlags parses --remote and validates the provider override,
 // returning a canonical remoteSpec ready for the github (or future) adapter.
 // Errors from invalid grammar or unsupported provider fire before any I/O.

--- a/cmd/ingitdb/commands/coverage_final_test.go
+++ b/cmd/ingitdb/commands/coverage_final_test.go
@@ -1306,7 +1306,7 @@ func TestDropViewRemote_ScopeColNotFound_Final(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "my-view", "--in=ghosts", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "my-view", "--in=ghosts", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for unknown scopeCol")
@@ -1329,7 +1329,7 @@ func TestDropCollectionRemote_RootNotFound(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"collection", "items", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"collection", "items", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when root-collections.yaml not found")
@@ -1550,7 +1550,7 @@ func TestDropViewRemote_FileReaderFactoryError(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "my-view", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "my-view", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when file reader errors")
@@ -1574,7 +1574,7 @@ func TestDropViewRemote_NotFound_IfExists(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "nonexistent", "--remote=github.com/owner/repo", "--if-exists"})
+	cmd.SetArgs([]string{"view", "nonexistent", "--remote=github.com/owner/repo", "--token=test-token", "--if-exists"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("expected no error with --if-exists for missing view, got: %v", err)
 	}

--- a/cmd/ingitdb/commands/coverage_remote_test.go
+++ b/cmd/ingitdb/commands/coverage_remote_test.go
@@ -1027,7 +1027,7 @@ func TestDropCollectionRemote_ListFilesError(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when ListFilesUnder fails")
@@ -1056,7 +1056,7 @@ func TestDropCollectionRemote_CommitError(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when CommitChanges fails")
@@ -1090,7 +1090,7 @@ func TestDropViewRemote_ScopedToCollection(t *testing.T) {
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
 	// --in=cities restricts the search to that collection
-	cmd.SetArgs([]string{"view", "by_country", "--remote=github.com/owner/repo", "--in=cities"})
+	cmd.SetArgs([]string{"view", "by_country", "--remote=github.com/owner/repo", "--token=test-token", "--in=cities"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -1113,7 +1113,7 @@ func TestDropViewRemote_ScopedCollectionNotFound(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "some_view", "--remote=github.com/owner/repo", "--in=nonexistent"})
+	cmd.SetArgs([]string{"view", "some_view", "--remote=github.com/owner/repo", "--token=test-token", "--in=nonexistent"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when scoped collection not found")
@@ -1140,7 +1140,7 @@ func TestDropViewRemote_AmbiguousView(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "common", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "common", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for ambiguous view name")
@@ -1165,7 +1165,7 @@ func TestDropViewRemote_NotFound_NoScopeCol(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "missing_view", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "missing_view", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when view not found")
@@ -1190,7 +1190,7 @@ func TestDropViewRemote_NotFound_WithScopeCol(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "missing_view", "--remote=github.com/owner/repo", "--in=cities"})
+	cmd.SetArgs([]string{"view", "missing_view", "--remote=github.com/owner/repo", "--token=test-token", "--in=cities"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when view not found in scoped collection")
@@ -1220,7 +1220,7 @@ func TestDropViewRemote_IfExists_NotFound(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "nonexistent", "--remote=github.com/owner/repo", "--if-exists"})
+	cmd.SetArgs([]string{"view", "nonexistent", "--remote=github.com/owner/repo", "--token=test-token", "--if-exists"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("expected no error with --if-exists for missing view, got: %v", err)
 	}
@@ -1247,7 +1247,7 @@ func TestDropViewRemote_ReadFileError(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "some_view", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "some_view", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when ReadFile fails")
@@ -1279,7 +1279,7 @@ func TestDropViewRemote_CommitError(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "by_country", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "by_country", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when CommitChanges fails")
@@ -1312,7 +1312,7 @@ func TestDropViewRemote_ViewWithNoOutputFile(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "by_country", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "by_country", "--remote=github.com/owner/repo", "--token=test-token"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -1349,7 +1349,7 @@ func TestDropViewRemote_TreeWriterError(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "by_country", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "by_country", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when tree writer factory fails")
@@ -1690,7 +1690,7 @@ func TestDropCollectionRemote_ReadRootCollectionsError(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when readRemoteRootCollections fails")
@@ -1709,7 +1709,7 @@ func TestDropCollectionRemote_RootCollectionsNotFound(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when root-collections.yaml not found")
@@ -1739,7 +1739,7 @@ func TestDropCollectionRemote_TreeWriterError2(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when tree writer fails")
@@ -1779,7 +1779,7 @@ func TestDropViewRemote_ReadRootCollectionsError(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "some_view", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "some_view", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when readRemoteRootCollections fails")
@@ -1797,7 +1797,7 @@ func TestDropViewRemote_RootCollectionsNotFound(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "some_view", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "some_view", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when root-collections.yaml not found")
@@ -1840,7 +1840,7 @@ func TestDropViewRemote_FileReaderCreationError(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "some_view", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "some_view", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when second file reader creation fails")

--- a/cmd/ingitdb/commands/delete.go
+++ b/cmd/ingitdb/commands/delete.go
@@ -43,6 +43,10 @@ func Delete(
 				}
 			}
 
+			if err := requireRemoteWriteToken(cmd); err != nil {
+				return err
+			}
+
 			id, _ := cmd.Flags().GetString("id")
 			from, _ := cmd.Flags().GetString("from")
 			mode, err := sqlflags.ResolveMode(id, from)

--- a/cmd/ingitdb/commands/drop.go
+++ b/cmd/ingitdb/commands/drop.go
@@ -75,6 +75,9 @@ func dropCollection(
 			if remoteVal != "" && pathVal != "" {
 				return fmt.Errorf("--path and --remote are mutually exclusive")
 			}
+			if err := requireRemoteWriteToken(cmd); err != nil {
+				return err
+			}
 			if remoteVal != "" {
 				return dropCollectionRemote(cmd.Context(), cmd, name, ifExists)
 			}
@@ -134,6 +137,9 @@ func dropView(
 			pathVal, _ := cmd.Flags().GetString("path")
 			if remoteVal != "" && pathVal != "" {
 				return fmt.Errorf("--path and --remote are mutually exclusive")
+			}
+			if err := requireRemoteWriteToken(cmd); err != nil {
+				return err
 			}
 			if remoteVal != "" {
 				return dropViewRemote(cmd.Context(), cmd, name, scopeCol, ifExists)

--- a/cmd/ingitdb/commands/drop_remote_test.go
+++ b/cmd/ingitdb/commands/drop_remote_test.go
@@ -129,7 +129,7 @@ func TestDropCollection_Remote_HappyPath(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo", "--token=test-token"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestDropCollection_Remote_IfExistsMissing(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"collection", "missing", "--remote=github.com/owner/repo", "--if-exists"})
+	cmd.SetArgs([]string{"collection", "missing", "--remote=github.com/owner/repo", "--token=test-token", "--if-exists"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestDropCollection_Remote_MissingErrors(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"collection", "missing", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"collection", "missing", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for missing collection without --if-exists")
@@ -223,7 +223,7 @@ func TestDrop_Remote_PathMutex(t *testing.T) {
 	t.Parallel()
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"collection", "x", "--path=.", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"collection", "x", "--path=.", "--remote=github.com/owner/repo", "--token=test-token"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for --path with --remote")
@@ -276,7 +276,7 @@ func TestDropView_Remote_HappyPath(t *testing.T) {
 
 	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
 	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
-	cmd.SetArgs([]string{"view", "by_country", "--remote=github.com/owner/repo"})
+	cmd.SetArgs([]string{"view", "by_country", "--remote=github.com/owner/repo", "--token=test-token"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}

--- a/cmd/ingitdb/commands/insert.go
+++ b/cmd/ingitdb/commands/insert.go
@@ -50,6 +50,10 @@ func Insert(
 			_ = logf
 			ctx := cmd.Context()
 
+			if err := requireRemoteWriteToken(cmd); err != nil {
+				return err
+			}
+
 			// Batch mode validation: --format must be one of the four supported
 			// stream formats. Empty means single-record mode.
 			format, _ := cmd.Flags().GetString("format")

--- a/cmd/ingitdb/commands/remote_write_token_test.go
+++ b/cmd/ingitdb/commands/remote_write_token_test.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// parseRemoteFlags builds a command with the shared remote flags and parses args.
+func parseRemoteFlags(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "x"}
+	addRemoteFlags(cmd)
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags(%v): %v", args, err)
+	}
+	return cmd
+}
+
+func TestRequireRemoteWriteToken(t *testing.T) {
+	// Ensure no ambient token leaks in from the environment (e.g. CI).
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_COM_TOKEN", "")
+
+	t.Run("no remote is a no-op", func(t *testing.T) {
+		cmd := parseRemoteFlags(t)
+		if err := requireRemoteWriteToken(cmd); err != nil {
+			t.Errorf("local write must not require a token, got: %v", err)
+		}
+	})
+
+	t.Run("remote without token errors", func(t *testing.T) {
+		cmd := parseRemoteFlags(t, "--remote=github.com/owner/repo")
+		err := requireRemoteWriteToken(cmd)
+		if err == nil || !strings.Contains(err.Error(), "token") {
+			t.Errorf("expected a token-required error, got: %v", err)
+		}
+	})
+
+	t.Run("remote with --token is allowed", func(t *testing.T) {
+		cmd := parseRemoteFlags(t, "--remote=github.com/owner/repo", "--token=abc")
+		if err := requireRemoteWriteToken(cmd); err != nil {
+			t.Errorf("a supplied --token must satisfy the requirement, got: %v", err)
+		}
+	})
+
+	t.Run("remote with host env token is allowed", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "from-env")
+		cmd := parseRemoteFlags(t, "--remote=github.com/owner/repo")
+		if err := requireRemoteWriteToken(cmd); err != nil {
+			t.Errorf("a host-derived env token must satisfy the requirement, got: %v", err)
+		}
+	})
+}
+
+// TestDropRemote_RequiresToken is the command-level check: a remote write
+// (drop) with no token fails fast with a clear token error, before any I/O.
+func TestDropRemote_RequiresToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_COM_TOKEN", "")
+
+	homeDir, getWd, readDef, newDB, logf := emptyDropDeps(t)
+	cmd := Drop(homeDir, getWd, readDef, newDB, logf)
+	cmd.SetArgs([]string{"collection", "cities", "--remote=github.com/owner/repo"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "token") {
+		t.Fatalf("expected a token-required error for a remote drop with no token, got: %v", err)
+	}
+}

--- a/cmd/ingitdb/commands/update_new.go
+++ b/cmd/ingitdb/commands/update_new.go
@@ -46,6 +46,10 @@ func Update(
 				}
 			}
 
+			if err := requireRemoteWriteToken(cmd); err != nil {
+				return err
+			}
+
 			id, _ := cmd.Flags().GetString("id")
 			from, _ := cmd.Flags().GetString("from")
 			mode, err := sqlflags.ResolveMode(id, from)

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -36,7 +36,7 @@ This directory tracks the SpecScore feature specifications for the **ingitdb-cli
 | [id-flag-format](id-flag-format/README.md) | Stable | Cross-cutting `--id=<collection-id>/<record-key>` syntax. |
 | [output-formats](output-formats/README.md) | Stable | Cross-cutting `--format=yaml|json` flag and YAML default. |
 | [path-targeting](path-targeting/README.md) | Stable | Cross-cutting `--path` flag and its relation to `--remote`. |
-| [remote-repo-access](remote-repo-access/README.md) | Implementing | Cross-cutting `--remote=<URL>` flag, provider dispatch, and token resolution for remote Git hosting services. |
+| [remote-repo-access](remote-repo-access/README.md) | Stable | Cross-cutting `--remote=<URL>` flag, provider dispatch, and token resolution for remote Git hosting services. |
 | [shared-cli-flags](shared-cli-flags/README.md) | Single source of truth for the CLI flag grammar shared across select, insert, update, delete, and drop verbs: --from, --into, --where, --set, --id, --all, --order-by, --fields. Defines parsing rules, operator semantics (==, ===, !=, !==, >=, <=, >, <), value-type model, and flag mutual-exclusion rules. |
 | [cli](cli/README.md) | Unknown | TODO: Add description. |
 | [dalgo2ingitdb-dbschema-ddl-coverage](dalgo2ingitdb-dbschema-ddl-coverage/README.md) | Draft | TODO: Add description. |

--- a/spec/features/remote-repo-access/README.md
+++ b/spec/features/remote-repo-access/README.md
@@ -1,7 +1,7 @@
 # Feature: Remote Repository Access
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/remote-repo-access?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/remote-repo-access?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/remote-repo-access?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/remote-repo-access?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 
 ## Summary
 

--- a/spec/ideas/seeds/enforce-token-for-remote-writes-and-github-enterprise-provider.md
+++ b/spec/ideas/seeds/enforce-token-for-remote-writes-and-github-enterprise-provider.md
@@ -5,7 +5,7 @@ captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
 captured_during: null
 trigger: explicit
-status: queued
+status: done
 synchestra_task: null
 ---
 # Enforce a local token-required pre-flight for remote writes


### PR DESCRIPTION
## Summary

Closes the final piece of the `remote-repo-access` gap (`REQ:token-required-for-writes`). Writes (`insert`/`update`/`delete`/`drop`) against `--remote` now require a token even for public repos, while reads stay token-free. Previously a tokenless write resolved to an empty token and failed late at the host API with a 401 instead of a clear local error.

## Changes
- Add `requireRemoteWriteToken` pre-flight: when `--remote` is set, resolve the token (from `--token` or a host-derived `*_TOKEN` env var) and fail fast with a clear diagnostic naming the expected env var, **before any network I/O**. No-op for local operations.
- Wire it into the `insert`/`update`/`delete`/`drop` command `RunE` paths — placed after existing flag/mutex validation so those errors keep precedence, and `resolveRemoteFromFlags` still surfaces grammar/unimplemented-provider errors first. The shared read path used by `select --id` is untouched.

## Tests
- `TestRequireRemoteWriteToken` — no-remote (no-op), remote-without-token (error), remote-with-`--token` (ok), remote-with-host-env-token (ok)
- `TestDropRemote_RequiresToken` — command-level: a remote drop with no token fails fast with a token error
- Existing remote-drop happy-path/behavior tests updated to pass `--token` (they exercise a real write, which now needs one); read tests left token-free

## Verification
- `go build ./...`, `go test ./...`: green
- `golangci-lint run`: 0 issues
- `specscore spec lint`: 0 violations

Completes `remote-repo-access`; promoted `Implementing → Stable`; seed marked `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)