### PR TITLE
docs(spec): normalize record-format status to Stable

### DIFF
--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -6,7 +6,7 @@ This directory tracks the SpecScore feature specifications for the **ingitdb-cli
 
 | Feature | Status | Description |
 |---|---|---|
-| [record-format](record-format/README.md) | Implemented | Umbrella for record-format extensions: CSV support, project-level `default_record_format` config, `--default-format` CLI flag on `ingitdb setup`. Additive on top of the existing six-format machinery (yaml/yml/json/markdown/toml/ingr). |
+| [record-format](record-format/README.md) | Stable | Umbrella for record-format extensions: CSV support, project-level `default_record_format` config, `--default-format` CLI flag on `ingitdb setup`. Additive on top of the existing six-format machinery (yaml/yml/json/markdown/toml/ingr). |
 | [cli/version](cli/version/README.md) | Implementing | `ingitdb version` — print build version, commit hash, and date. |
 | [cli/validate](cli/validate/README.md) | Implementing | `ingitdb validate` — check schema and records against `.ingitdb.yaml`. |
 | [cli/select](cli/select/README.md) | Implementing | `ingitdb select` — read a single record (`--id`) or query a set of records (`--from`/`--where`). |

--- a/spec/features/record-format/README.md
+++ b/spec/features/record-format/README.md
@@ -1,7 +1,7 @@
 # Feature: Record Format Extensions
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format?op=request-change) |
-**Status:** Implemented
+**Status:** Stable
 **Source Idea:** [`default-record-format`](../../ideas/default-record-format.md)
 
 ## Summary

--- a/spec/features/record-format/cli-default-format-flag/README.md
+++ b/spec/features/record-format/cli-default-format-flag/README.md
@@ -1,7 +1,7 @@
 # Feature: `ingitdb setup --default-format` Flag
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/cli-default-format-flag?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/cli-default-format-flag?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/cli-default-format-flag?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/cli-default-format-flag?op=request-change) |
-**Status:** Implemented
+**Status:** Stable
 **Source Idea:** [`default-record-format`](../../../ideas/default-record-format.md)
 **Parent Feature:** [`record-format`](../README.md)
 

--- a/spec/features/record-format/csv-support/README.md
+++ b/spec/features/record-format/csv-support/README.md
@@ -1,7 +1,7 @@
 # Feature: CSV Format Support
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/csv-support?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/csv-support?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/csv-support?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/csv-support?op=request-change) |
-**Status:** Implemented
+**Status:** Stable
 **Source Idea:** [`default-record-format`](../../../ideas/default-record-format.md)
 **Parent Feature:** [`record-format`](../README.md)
 

--- a/spec/features/record-format/project-default/README.md
+++ b/spec/features/record-format/project-default/README.md
@@ -1,7 +1,7 @@
 # Feature: Project-Level Default Record Format
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/project-default?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/project-default?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/project-default?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/project-default?op=request-change) |
-**Status:** Implemented
+**Status:** Stable
 **Source Idea:** [`default-record-format`](../../../ideas/default-record-format.md)
 **Parent Feature:** [`record-format`](../README.md)
 


### PR DESCRIPTION
## Summary

`record-format` and its children (`csv-support`, `project-default`, `cli-default-format-flag`) used a non-matrix `Implemented` status. That value isn't part of the SpecScore feature lifecycle (`Draft → Under Review → Approved → Implementing → Stable → Deprecated`) — `specscore feature change-status` rejects it as a dead-end ("has no legal targets"). This normalizes the four to `Stable`, consistent with every other implemented feature.

## Changes
- Set `**Status:** Stable` on the four `record-format*` feature READMEs.
- Features index (`spec/features/README.md`) synced via `specscore spec lint --fix`.

## Verification
- `specscore spec lint`: 0 violations
- No `Implemented` status remains anywhere under `spec/features/`

Spec-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)