### PR TITLE
docs(spec): reconcile draft statuses for has-code features

### DIFF
--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -39,7 +39,7 @@ This directory tracks the SpecScore feature specifications for the **ingitdb-cli
 | [remote-repo-access](remote-repo-access/README.md) | Stable | Cross-cutting `--remote=<URL>` flag, provider dispatch, and token resolution for remote Git hosting services. |
 | [shared-cli-flags](shared-cli-flags/README.md) | Single source of truth for the CLI flag grammar shared across select, insert, update, delete, and drop verbs: --from, --into, --where, --set, --id, --all, --order-by, --fields. Defines parsing rules, operator semantics (==, ===, !=, !==, >=, <=, >, <), value-type model, and flag mutual-exclusion rules. |
 | [cli](cli/README.md) | Unknown | TODO: Add description. |
-| [dalgo2ingitdb-dbschema-ddl-coverage](dalgo2ingitdb-dbschema-ddl-coverage/README.md) | Draft | TODO: Add description. |
+| [dalgo2ingitdb-dbschema-ddl-coverage](dalgo2ingitdb-dbschema-ddl-coverage/README.md) | Implementing | TODO: Add description. |
 | [dalgo2ingitdb-referential-integrity](dalgo2ingitdb-referential-integrity/README.md) | Stable | DALgo write transactions enforce existing `foreign_key` metadata on Set, Insert, Update, and Delete. |
 | [record-key](record-key/README.md) | Draft | Umbrella for canonical record identity behavior across schema validation, storage paths, writes, and CLI key surfaces. |
 | [computed-columns](computed-columns/README.md) | Stable | TODO: Add description. |

--- a/spec/features/cli/materialize/README.md
+++ b/spec/features/cli/materialize/README.md
@@ -1,7 +1,7 @@
 # Feature: Materialize Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=request-change) |
-**Status:** Draft
+**Status:** Implementing
 
 ## Summary
 

--- a/spec/features/cli/resolve/README.md
+++ b/spec/features/cli/resolve/README.md
@@ -1,7 +1,7 @@
 # Feature: Resolve Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve?op=request-change) |
-**Status:** Draft
+**Status:** Stable
 
 ## Summary
 

--- a/spec/features/cli/serve/README.md
+++ b/spec/features/cli/serve/README.md
@@ -1,7 +1,7 @@
 # Feature: Serve Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=request-change) |
-**Status:** Draft
+**Status:** Implementing
 
 ## Summary
 

--- a/spec/features/cli/setup/README.md
+++ b/spec/features/cli/setup/README.md
@@ -1,7 +1,7 @@
 # Feature: Setup Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/setup?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/setup?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/setup?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/setup?op=request-change) |
-**Status:** Draft
+**Status:** Implementing
 
 ## Summary
 

--- a/spec/features/dalgo2ingitdb-dbschema-ddl-coverage/README.md
+++ b/spec/features/dalgo2ingitdb-dbschema-ddl-coverage/README.md
@@ -1,7 +1,7 @@
 # Feature: dbschema + ddl + ConcurrencyAware Coverage for inGitDB
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=request-change) |
-**Status:** Draft
+**Status:** Implementing
 **Source Idea:** —
 **Date:** 2026-05-13
 **Owner:** alex

--- a/spec/ideas/seeds/materialize-subcommands-and-collection-targeting.md
+++ b/spec/ideas/seeds/materialize-subcommands-and-collection-targeting.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: materialize-subcommands-and-collection-targeting
+captured_at: 2026-06-03T16:54:53Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Implement materialize subcommands (collection/views) and the --collection / --views targeting, or reconcile the spec to the flat command
+
+Gap found verifying cli/materialize (1/3 REQs). The spec mandates `ingitdb materialize collection` and `ingitdb materialize views` subcommands; the code is a single flat `materialize` command (`materialize.go`) that only rebuilds views. The `--views=LIST` flag is registered (`flags.go`) but never read (dead no-op), there is no `--collection` flag, and there is no CLI path to regenerate a single collection's README (README rendering exists in `materializer/view_builder.go` but isn't wired to a `materialize collection` subcommand). Either implement the subcommands + flags (with tests) or update the spec to match the flat command. Spec Implementation list also omits `ci.go`/`flags.go`. Blocks cli/materialize → Stable.

--- a/spec/ideas/seeds/reconcile-dbschema-concurrency-contract.md
+++ b/spec/ideas/seeds/reconcile-dbschema-concurrency-contract.md
@@ -1,0 +1,15 @@
+---
+type: sidekick-seed
+slug: reconcile-dbschema-concurrency-contract
+captured_at: 2026-06-03T16:54:53Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Reconcile the dbschema-ddl concurrency contract: spec says single-writer (false), code returns true via flock
+
+Gap found verifying dalgo2ingitdb-dbschema-ddl-coverage (25/27 ACs — otherwise complete and well-tested). REQ:concurrency-aware-false / AC:supports-concurrent-connections-false mandate `SupportsConcurrentConnections() == false` (single-writer git working tree), but `database.go` embeds `dal.ConcurrencyAvailable` and returns `true`, and the tests (`TestDatabase_SupportsConcurrentConnections`, `TestIntegration_ConcurrentReads`) assert `true`, with code comments justifying it via gofrs/flock file locking. This is a deliberate design divergence, not a missing implementation.
+
+DECISION NEEDED: is flock-based concurrent access the intended contract? If yes, update the spec (Summary bullet, Out-of-Scope "Concurrent writes" line, REQ:concurrency-aware-false, AC) to reflect `true`. If single-writer is still required, change the code to return `false`. Once reconciled (plus the minor AC:list-constraints-returns-pk `Fields` wording, which contradicts its own REQ), the feature can move to Stable.

--- a/spec/ideas/seeds/serve-combinable-services-and-watcher-wiring.md
+++ b/spec/ideas/seeds/serve-combinable-services-and-watcher-wiring.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: serve-combinable-services-and-watcher-wiring
+captured_at: 2026-06-03T16:54:53Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Make `serve` run combinable services and wire --watcher
+
+Gap found verifying cli/serve (2/4 REQs). REQ:service-flags says multiple of `--mcp`/`--http`/`--watcher` MAY be combined and REQ:foreground-process says all requested services run in one process, but `serve.go` uses an if/else that runs only the first match (mcp > http): `--mcp --http` together runs only MCP. The `--watcher` flag is registered but never read (`GetBool("watcher")` absent), so `--watcher` alone falls through to the "no server mode" error; `pkg/watcher` exists but is unreferenced by serve. Run requested services concurrently in one process, wire the watcher, and add tests for combinations + watcher. Spec Implementation list omits `pkg/watcher`. Blocks cli/serve → Stable.

--- a/spec/ideas/seeds/setup-starter-config-and-overwrite-guard.md
+++ b/spec/ideas/seeds/setup-starter-config-and-overwrite-guard.md
@@ -1,0 +1,13 @@
+---
+type: sidekick-seed
+slug: setup-starter-config-and-overwrite-guard
+captured_at: 2026-06-03T16:54:53Z
+captured_by: claude
+captured_during: null
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# Make `setup` write a real starter config and refuse to overwrite an initialised db; reconcile the stale spec layout
+
+Gap found verifying cli/setup (2/4 REQs). REQ:writes-starter-config wants a seeded config (rootCollections + languages) but `runSetup` (`setup.go`) writes an empty `.ingitdb/settings.yaml` with no seed (a code comment defers this). REQ:idempotent-on-empty-target wants the command to refuse an already-initialised directory and exit non-zero, but it silently overwrites via `os.WriteFile` with no guard. Also the spec text is stale: it describes a single `.ingitdb.yaml` with rootCollections/languages, while the implemented model is `.ingitdb/settings.yaml` + `.ingitdb/root_collections.yaml`. Implement the seed + overwrite guard (with tests for the cwd default and the Setup() command wiring), and update the spec to the real `.ingitdb/` layout. Blocks cli/setup → Stable.


### PR DESCRIPTION
## Summary

Verification pass over the seven `Draft` features that appeared to have code, updating each to its true lifecycle status (parallel agents verified each against its spec ACs/REQs + code + tests).

| Feature | Verdict | New status |
|---|---|---|
| `cli/resolve` (parent) | COMPLETE 3/3 | **Draft → Stable** |
| `cli/materialize` | PARTIAL 1/3 | Draft → Implementing |
| `cli/serve` | PARTIAL 2/4 | Draft → Implementing |
| `cli/setup` | PARTIAL 2/4 | Draft → Implementing |
| `dalgo2ingitdb-dbschema-ddl-coverage` | PARTIAL 25/27 | Draft → Implementing |
| `cli/pull` | stub (0/4) | **stays Draft** |
| `cli/watch` | stub (0/4) | **stays Draft** |

`cli/resolve` is fully implemented + tested and (correctly) does not depend on the unbuilt interactive `manual-resolve` UI. `cli/pull` and `cli/watch` are stubs (`RunE` returns "not yet implemented"; their specs even lack ACs), so Draft is accurate.

## Gaps captured as seeds
For the four now-`Implementing` features, the remaining work before Stable is queued under `spec/ideas/seeds/`:
- **materialize**: missing `collection`/`views` subcommands + `--collection`; dead `--views` flag
- **serve**: services not combinable; `--watcher` never wired
- **setup**: no starter-config seed / no overwrite guard; spec stale on `.ingitdb/` layout
- **dbschema concurrency** — *decision needed*: code returns `SupportsConcurrentConnections()=true` (flock) but spec mandates `false`; reconcile spec-or-code

## Verification
- `specscore spec lint`: 0 violations
- Spec/status only — no source code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)