### PR TITLE
feat(dalgo2ingitdb): report single-writer (SupportsConcurrentConnections=false)

### DIFF
--- a/pkg/dalgo2ingitdb/database.go
+++ b/pkg/dalgo2ingitdb/database.go
@@ -16,9 +16,8 @@ import (
 // Database is the dal.DB implementation for inGitDB projects on the local
 // filesystem. It implements the schema-management capability interfaces
 // (dbschema.SchemaReader, ddl.SchemaModifier, ddl.TransactionalDDL), the
-// dal.DB record-access methods, and reports dal.ConcurrencyAvailable via
-// the embedded helper struct — concurrent connections are safe because
-// every read and write path goes through gofrs/flock file locking.
+// dal.DB record-access methods, and reports dal.NoConcurrency — concurrent
+// connections are NOT advertised as safe (see the field comment for why).
 //
 // Record access loads the project Definition once per transaction via the
 // injected CollectionsReader; individual file operations take a shared
@@ -26,11 +25,23 @@ import (
 // ExecuteQueryToRecordsetReader is not yet implemented and returns
 // dal.ErrNotSupported.
 type Database struct {
-	// dal.ConcurrencyAvailable: gofrs/flock provides cross-platform file
-	// locking (syscall.Flock on Unix, LockFileEx on Windows), so two DB
-	// handles against the same project directory can operate concurrently
-	// without data races.
-	dal.ConcurrencyAvailable
+	// dal.NoConcurrency makes SupportsConcurrentConnections() report false.
+	//
+	// An inGitDB database is a git working tree. We do take gofrs/flock
+	// advisory locks per file (shared for reads, exclusive for writes) as
+	// defence-in-depth, but that is NOT a basis to advertise safe concurrent
+	// connections, because:
+	//   - flock is ADVISORY on Unix: it only binds processes that also call
+	//     flock. A plain `git`, an editor, or `rm` ignores it entirely — and
+	//     on Unix can even unlink a file out from under a held lock. It is
+	//     mandatory only on Windows (LockFileEx), so the protection is not
+	//     cross-platform.
+	//   - locks are PER FILE, so a change spanning multiple files (e.g. a
+	//     collection's definition.yaml plus root-collections.yaml, or a
+	//     subsequent git commit) is not atomic as a unit.
+	// The honest cross-platform contract is therefore single-writer: callers
+	// MUST NOT open concurrent writing connections against the same tree.
+	dal.NoConcurrency
 
 	projectPath string
 	reader      ingitdb.CollectionsReader

--- a/pkg/dalgo2ingitdb/database_test.go
+++ b/pkg/dalgo2ingitdb/database_test.go
@@ -77,8 +77,8 @@ func TestDatabase_SupportsConcurrentConnections(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDatabase: %v", err)
 	}
-	if !db.SupportsConcurrentConnections() {
-		t.Error("SupportsConcurrentConnections: want true (file locking is implemented)")
+	if db.SupportsConcurrentConnections() {
+		t.Error("SupportsConcurrentConnections: want false (single-writer git working tree; flock is advisory defence-in-depth, not a cross-platform concurrency guarantee)")
 	}
 }
 

--- a/pkg/dalgo2ingitdb/integration_test.go
+++ b/pkg/dalgo2ingitdb/integration_test.go
@@ -112,8 +112,11 @@ func TestIntegration_ConcurrentReads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDatabase: %v", err)
 	}
-	if !db.SupportsConcurrentConnections() {
-		t.Fatal("SupportsConcurrentConnections: want true")
+	// The driver advertises single-writer (false) as its cross-platform
+	// contract; the per-file shared locks below still permit concurrent
+	// in-process reads as defence-in-depth, which this test exercises.
+	if db.SupportsConcurrentConnections() {
+		t.Fatal("SupportsConcurrentConnections: want false")
 	}
 	reader := db.(dbschema.SchemaReader)
 	modifier := db.(ddl.SchemaModifier)

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -39,7 +39,7 @@ This directory tracks the SpecScore feature specifications for the **ingitdb-cli
 | [remote-repo-access](remote-repo-access/README.md) | Stable | Cross-cutting `--remote=<URL>` flag, provider dispatch, and token resolution for remote Git hosting services. |
 | [shared-cli-flags](shared-cli-flags/README.md) | Single source of truth for the CLI flag grammar shared across select, insert, update, delete, and drop verbs: --from, --into, --where, --set, --id, --all, --order-by, --fields. Defines parsing rules, operator semantics (==, ===, !=, !==, >=, <=, >, <), value-type model, and flag mutual-exclusion rules. |
 | [cli](cli/README.md) | Unknown | TODO: Add description. |
-| [dalgo2ingitdb-dbschema-ddl-coverage](dalgo2ingitdb-dbschema-ddl-coverage/README.md) | Implementing | TODO: Add description. |
+| [dalgo2ingitdb-dbschema-ddl-coverage](dalgo2ingitdb-dbschema-ddl-coverage/README.md) | Stable | TODO: Add description. |
 | [dalgo2ingitdb-referential-integrity](dalgo2ingitdb-referential-integrity/README.md) | Stable | DALgo write transactions enforce existing `foreign_key` metadata on Set, Insert, Update, and Delete. |
 | [record-key](record-key/README.md) | Draft | Umbrella for canonical record identity behavior across schema validation, storage paths, writes, and CLI key surfaces. |
 | [computed-columns](computed-columns/README.md) | Stable | TODO: Add description. |

--- a/spec/features/dalgo2ingitdb-dbschema-ddl-coverage/README.md
+++ b/spec/features/dalgo2ingitdb-dbschema-ddl-coverage/README.md
@@ -1,7 +1,7 @@
 # Feature: dbschema + ddl + ConcurrencyAware Coverage for inGitDB
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 **Source Idea:** —
 **Date:** 2026-05-13
 **Owner:** alex
@@ -72,7 +72,14 @@ The package MUST export `dalgo2ingitdb.NewDatabase(projectPath string, reader in
 
 #### REQ: concurrency-aware-false
 
-`Database.SupportsConcurrentConnections() bool` MUST return `false`. inGitDB writes to a git working tree. Concurrent writers against the same working-tree directory produce data races on both the record files and the `.collection/definition.yaml` metadata. The DALgo `ConcurrencyAware` contract collapses to a single boolean; the MVP returns `false` unconditionally.
+`Database.SupportsConcurrentConnections() bool` MUST return `false`, unconditionally and on every platform.
+
+Rationale: an inGitDB database is a git working tree, and the honest cross-platform contract for it is single-writer. The driver does take `gofrs/flock` advisory locks per file (shared for reads, exclusive for writes) as defence-in-depth, but that is deliberately NOT treated as a basis to advertise safe concurrent connections, because:
+
+- **flock is advisory on Unix.** It only constrains processes that also call `flock`. A plain `git`, an editor, or `rm` ignores it entirely — and on Unix can even `unlink` a file out from under a held lock (deletion removes the directory entry, not the locked inode). It is mandatory only on Windows (`LockFileEx`), so the protection is not cross-platform.
+- **Locks are per file.** A change spanning multiple files (a collection's `definition.yaml` plus `root-collections.yaml`, or a subsequent `git commit`) is not atomic as a unit.
+
+Returning `false` is the truthful signal to DALgo consumers across Linux/macOS/Windows; advertising `true` (even justified by flock) would overpromise on the platforms where the lock is advisory and for multi-file operations. A platform-conditional answer (true on Windows, false elsewhere) was considered and rejected: a capability that flips by OS is unsafe to consume — the same code would behave differently in dev/CI/prod. flock remains valuable as best-effort in-process protection, not as a concurrency guarantee.
 
 ### TransactionalDDL
 
@@ -103,7 +110,7 @@ If the collection directory does not exist or its `definition.yaml` is absent, `
 
 #### REQ: list-constraints
 
-`Database.ListConstraints(ctx context.Context, ref *dal.CollectionRef) ([]dbschema.ConstraintDef, error)` MUST return a one-element slice containing a synthesized primary-key constraint, and a nil error. The element MUST have `Type == dbschema.PrimaryKeyConstraint`. The richer PK column information lives on `DescribeCollection.PrimaryKey`; `dbschema.ConstraintDef` is intentionally minimal (Name + Type only). inGitDB has no other declared constraints (NOT NULL, CHECK, FK are not stored in `definition.yaml`).
+`Database.ListConstraints(ctx context.Context, ref *dal.CollectionRef) ([]dbschema.ConstraintDef, error)` MUST return a one-element slice containing a synthesized primary-key constraint, and a nil error. The element MUST have `Name == "$key-pk"` and `Type == "primary-key"` (the engine-neutral string `dbschema` documents; there is no `dbschema.PrimaryKeyConstraint` constant). The richer PK column information lives on `DescribeCollection.PrimaryKey`; `dbschema.ConstraintDef` is intentionally minimal (Name + Type only — it has no `Fields`). inGitDB has no other declared constraints (NOT NULL, CHECK, FK are not stored in `definition.yaml`).
 
 #### REQ: list-referrers
 
@@ -329,7 +336,7 @@ Source files implementing this feature (annotated with
 
 **Given** any existing collection
 **When** the caller invokes `reader.ListConstraints(ctx, ref)`
-**Then** the result is a one-element `[]dbschema.ConstraintDef` with `Type == PrimaryKeyConstraint` and `Fields == ["$key"]`, and a nil error.
+**Then** the result is a one-element `[]dbschema.ConstraintDef` with `Name == "$key-pk"` and `Type == "primary-key"`, and a nil error. (`dbschema.ConstraintDef` carries only `Name` and `Type`; there is no `Fields` field, so the synthetic PK is identified by its `Type` string.)
 
 ### AC: list-referrers-not-supported
 
@@ -505,7 +512,7 @@ Source files implementing this feature (annotated with
 - **Collection-not-found error type.** The `dbschema` package exports `*NotSupportedError` but not a `NotFoundError`. `DescribeCollection`'s contract is currently content-based (`err.Error()` contains `"not found"` + collection name). Plan-time options: (a) add `dbschema.NotFoundError` to `dal-go/dalgo` first; (b) define `dalgo2ingitdb.ErrCollectionNotFound` locally. The AC pins only the message-content contract so both options pass.
 - **`$key` as a synthetic PK field name.** Using the literal string `"$key"` as the synthesized primary-key field name may conflict if inGitDB ever declares a column literally named `$key`. For MVP this is acceptable. A follow-up could use a named constant exported from `ingitdb`.
 - **`AlterCollection` with record backfill and large collections.** The current design rewrites all record files in-memory per op. For collections with thousands of records this may be slow. A streaming rewrite is a follow-up optimization.
-- **`dbschema.ConstraintDef` type constant.** The spec assumes `dbschema.PrimaryKeyConstraint` exists as a named variant. Plan-time: verify against `dbschema/constraint.go`; if the constant name differs, update REQ:list-constraints and AC:list-constraints-returns-pk.
+- **`dbschema.ConstraintDef` type constant.** RESOLVED: `dbschema.ConstraintDef` exposes only `Name` and `Type` (a free-form engine-neutral string), with no `PrimaryKeyConstraint` constant and no `Fields`. The driver returns `{Name: "$key-pk", Type: "primary-key"}`; REQ:list-constraints and AC:list-constraints-returns-pk now reflect this.
 - **Default `RecordFile` value in `CreateCollection`.** The spec picks `{name: "{key}.yaml", format: yaml, type: "map[string]any"}` as the default. Plan-time: decide whether to expose a `WithRecordFileDef` option on `CreateCollection` so callers can specify a different format.
 
 ---

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -18,7 +18,7 @@ Use `specscore idea new <slug>` to scaffold a new idea.
 | [derived-record-keys](derived-record-keys.md) | Approved | 2026-05-30 | alexander.trakhimenok@gmail.com | — |
 | [list-of-records-files](list-of-records-files.md) | Approved | 2026-05-29 | alexander.trakhimenok@gmail.com | — |
 | [markdown-insert-ux](markdown-insert-ux.md) | Draft | 2026-05-12 | alexander.trakhimenok@gmail.com | — |
-| [scripted-formulas-and-views](scripted-formulas-and-views.md) | Specified | 2026-06-02 | alexander.trakhimenok@gmail.com | computed-columns |
+| [scripted-formulas-and-views](scripted-formulas-and-views.md) | Implemented | 2026-06-02 | alexander.trakhimenok@gmail.com | computed-columns |
 | [where-like-regex](where-like-regex.md) | Draft | 2026-05-12 | alexander.trakhimenok@gmail.com | — |
 
 ## Open Questions

--- a/spec/ideas/scripted-formulas-and-views.md
+++ b/spec/ideas/scripted-formulas-and-views.md
@@ -1,6 +1,6 @@
 # Idea: Scripted Computed Fields & Materialized Views (Starlark)
 
-**Status:** Specified
+**Status:** Implemented
 **Date:** 2026-06-02
 **Owner:** alexander.trakhimenok@gmail.com
 **Promotes To:** computed-columns

--- a/spec/ideas/seeds/reconcile-dbschema-concurrency-contract.md
+++ b/spec/ideas/seeds/reconcile-dbschema-concurrency-contract.md
@@ -5,7 +5,7 @@ captured_at: 2026-06-03T16:54:53Z
 captured_by: claude
 captured_during: null
 trigger: explicit
-status: queued
+status: done
 synchestra_task: null
 ---
 # Reconcile the dbschema-ddl concurrency contract: spec says single-writer (false), code returns true via flock


### PR DESCRIPTION
## Summary

Resolves the `dalgo2ingitdb-dbschema-ddl-coverage` concurrency gap by aligning the **code to the spec** (option (a)): the driver now embeds `dal.NoConcurrency` so `SupportsConcurrentConnections()` returns `false`. Previously it embedded `dal.ConcurrencyAvailable` (`true`), contradicting `REQ:concurrency-aware-false`.

## Why `false` (documented in code + spec)
An inGitDB database is a git working tree, so the honest **cross-platform** contract is single-writer. `gofrs/flock` locks are kept as defence-in-depth, but they don't justify advertising concurrency:
- **Advisory on Unix** — only binds processes that also call flock; a plain `git`, editor, or `rm` ignores it and can even `unlink` a locked file. Mandatory only on Windows (`LockFileEx`), so not cross-platform.
- **Per-file** — multi-file changes (`definition.yaml` + `root-collections.yaml`, or a `git commit`) aren't atomic.
A platform-conditional `true`/`false` (true on Windows) was considered and **rejected**: a capability that flips by OS is unsafe to consume (same code, different behavior in dev/CI/prod).

## Changes
- `database.go`: embed `dal.NoConcurrency`; expanded rationale comment.
- `database_test.go` / `integration_test.go`: assert `false`. The concurrent-reads behavior test is retained — per-file shared locks still permit in-process concurrent reads as defence-in-depth.
- Spec `REQ:concurrency-aware-false`: enriched with the advisory/mandatory + multi-file reasoning and the rejected platform-conditional option.
- Spec `REQ:list-constraints` + `AC:list-constraints-returns-pk` (the other minor gap): `dbschema.ConstraintDef` is `{Name, Type}` only — no `Fields`, no `PrimaryKeyConstraint` constant. Corrected to assert `Name == "$key-pk"` / `Type == "primary-key"`; resolved the related open question.

## Verification
- `go build ./...`, `go test ./...`: green
- `golangci-lint run`: 0 issues
- `specscore spec lint`: 0 violations

Completes the feature → promoted `Implementing → Stable`; concurrency seed marked `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)