### PR TITLE
ci: stop inGitDB workflow running twice on same-repo PRs

### DIFF
--- a/.github/workflows/ingitdb.yml
+++ b/.github/workflows/ingitdb.yml
@@ -8,9 +8,21 @@ on:
     branches:
       - '**'
 
+# Avoid running the same job twice for same-repo branches, which trigger both
+# `push` and `pull_request`. The `push` run is the one that materializes views
+# and pushes them back, so we keep it and skip the duplicate `pull_request` run
+# for same-repo PRs. Fork PRs (whose pushes don't reach this repo) still run via
+# `pull_request`. A concurrency group also cancels superseded in-flight runs.
+concurrency:
+  group: ingitdb-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   Validator:
+    # Run on push (covers same-repo branches + main) and on pull_request only
+    # when it comes from a fork; this de-duplicates same-repo push+PR runs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
## Problem

The **inGitDB** workflow (`ingitdb.yml`) triggers on **both** `push` (any non-renovate branch) and `pull_request` (all branches). For a same-repo PR branch, a push fires *both* events → the `Validator` job runs **twice**. (`golangci.yml` is unaffected — its `push` is already scoped to `main`.)

## Why not just scope `push` to `main`

The `push` run isn't pure CI — it **materializes views, commits, and pushes them back** (the `Push materialized views` step is gated on `github.event_name == 'push'`). Scoping push to `main` would kill per-branch view auto-materialization. So instead we de-duplicate while keeping that behavior.

## Fix

- **Job-level guard** on `Validator`:
  ```yaml
  if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
  ```
  - same-repo branch push → `push` run executes (full CI + materialize + push); the `pull_request` run is **skipped** (no duplicate).
  - **fork** PR → `push` doesn't reach this repo, so the `pull_request` run executes (forks still get CI).
  - merge to `main` → `push` run.
- **Concurrency group** keyed by PR number / ref with `cancel-in-progress: true`, to cancel superseded in-flight runs on rapid pushes.

Net: **one** `Validator` run per same-repo PR push, one per fork PR, one on merge to main — and view auto-materialization on branch pushes is preserved.

## Notes
- Skipped `pull_request` jobs report as "skipped" (treated as success), and branch-protection required checks are satisfied by the `push` run's identical `inGitDB / Validator` context on the same commit SHA — so merge gating still works.
- Validated with `actionlint` (only a pre-existing `SC2086` info on an untouched step remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)