### PR TITLE
feat(cli): implement the diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ languages:
 | [`list collections`](docs/cli/commands/list.md)   | ✅ done    | List collection IDs (local or remote)                    |
 | `list views`                                      | 🟡 planned | List view definitions                                    |
 | [`materialize`](docs/cli/commands/materialize.md) | 🟡 planned | Build materialized views into `$views/`                  |
-| [`diff`](docs/cli/commands/diff.md)               | 🟡 planned | Show record-level changes between two git refs           |
+| [`diff`](docs/cli/commands/diff.md)               | ✅ done    | Show record-level changes between two git refs           |
 | [`pull`](docs/cli/commands/pull.md)               | ✅ done    | Pull remote changes, resolve conflicts, and rebuild views |
 | [`watch`](docs/cli/commands/watch.md)             | 🟡 planned | Stream record change events to stdout                    |
 | [`resolve`](docs/cli/commands/resolve.md)         | 🟡 planned | Interactive TUI for resolving data-file merge conflicts  |

--- a/cmd/ingitdb/commands/diff.go
+++ b/cmd/ingitdb/commands/diff.go
@@ -1,0 +1,422 @@
+package commands
+
+// specscore: feature/cli/diff
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v3"
+
+	toml "github.com/pelletier/go-toml/v2"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/dalgo2ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/datavalidator"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/gitdiff"
+)
+
+// --- model ---
+
+type diffKind string
+
+const (
+	diffAdded   diffKind = "added"
+	diffUpdated diffKind = "updated"
+	diffDeleted diffKind = "deleted"
+)
+
+type fieldChange struct {
+	Field  string `json:"field" yaml:"field" toml:"field"`
+	Before any    `json:"before,omitempty" yaml:"before,omitempty" toml:"before,omitempty"`
+	After  any    `json:"after,omitempty" yaml:"after,omitempty" toml:"after,omitempty"`
+}
+
+type recordChange struct {
+	Collection string        `json:"collection" yaml:"collection" toml:"collection"`
+	Key        string        `json:"key" yaml:"key" toml:"key"`
+	Kind       diffKind      `json:"kind" yaml:"kind" toml:"kind"`
+	Fields     []fieldChange `json:"fields,omitempty" yaml:"fields,omitempty" toml:"fields,omitempty"`
+}
+
+type collectionCount struct {
+	Collection string `json:"collection" yaml:"collection" toml:"collection"`
+	Added      int    `json:"added" yaml:"added" toml:"added"`
+	Updated    int    `json:"updated" yaml:"updated" toml:"updated"`
+	Deleted    int    `json:"deleted" yaml:"deleted" toml:"deleted"`
+}
+
+type diffReport struct {
+	From    string            `json:"from" yaml:"from" toml:"from"`
+	To      string            `json:"to" yaml:"to" toml:"to"`
+	Summary []collectionCount `json:"summary" yaml:"summary" toml:"summary"`
+	Records []recordChange    `json:"records,omitempty" yaml:"records,omitempty" toml:"records,omitempty"`
+}
+
+func (r *diffReport) changed() bool { return len(r.Records) > 0 }
+
+// --- ref parsing ---
+
+// parseDiffRefs maps the optional positional argument to (from, to) refs.
+// Empty arg → HEAD vs working tree (to==""); "<ref>" → ref vs HEAD;
+// "<a>..<b>" → a vs b.
+func parseDiffRefs(arg string) (from, to string) {
+	switch {
+	case arg == "":
+		return "HEAD", ""
+	case strings.Contains(arg, ".."):
+		parts := strings.SplitN(arg, "..", 2)
+		return parts[0], parts[1]
+	default:
+		return arg, "HEAD"
+	}
+}
+
+// --- engine ---
+
+// computeDiff compares two refs and returns the record-level changes, filtered
+// to a single collection and/or a record-path glob when requested.
+func computeDiff(ctx context.Context, dirPath string, def *ingitdb.Definition, from, to, collFilter, pathFilter string) (*diffReport, error) {
+	changed, err := gitdiff.NewGitDiffer().DiffFiles(ctx, dirPath, from, to)
+	if err != nil {
+		return nil, err
+	}
+	var records []recordChange
+	for _, cf := range changed {
+		if pathFilter != "" {
+			if matched, _ := filepath.Match(pathFilter, cf.Path); !matched && !strings.HasPrefix(cf.Path, pathFilter) {
+				continue
+			}
+		}
+		abs := filepath.Clean(filepath.Join(dirPath, cf.Path))
+		colID, colDef := datavalidator.CollectionForRecordFile(def, abs)
+		if colDef == nil {
+			continue // not a record file of any collection
+		}
+		if collFilter != "" && colID != collFilter {
+			continue
+		}
+		beforePath := cf.Path
+		if cf.Kind == ingitdb.ChangeKindRenamed && cf.OldPath != "" {
+			beforePath = cf.OldPath
+		}
+		before := parseKeyedRecords(gitShow(ctx, dirPath, from, beforePath), colDef, beforePath)
+		after := parseKeyedRecords(gitShow(ctx, dirPath, to, cf.Path), colDef, cf.Path)
+		records = append(records, diffRecordSets(colID, before, after)...)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].Collection != records[j].Collection {
+			return records[i].Collection < records[j].Collection
+		}
+		return records[i].Key < records[j].Key
+	})
+	return &diffReport{From: from, To: orWorkingTree(to), Summary: summarize(records), Records: records}, nil
+}
+
+func orWorkingTree(to string) string {
+	if to == "" {
+		return "(working tree)"
+	}
+	return to
+}
+
+// diffRecordSets compares two keyed record sets and returns one recordChange per
+// added/updated/deleted record.
+func diffRecordSets(colID string, before, after map[string]map[string]any) []recordChange {
+	var out []recordChange
+	for key, af := range after {
+		bf, existed := before[key]
+		if !existed {
+			out = append(out, recordChange{Collection: colID, Key: key, Kind: diffAdded})
+			continue
+		}
+		if fields := diffFields(bf, af); len(fields) > 0 {
+			out = append(out, recordChange{Collection: colID, Key: key, Kind: diffUpdated, Fields: fields})
+		}
+	}
+	for key := range before {
+		if _, ok := after[key]; !ok {
+			out = append(out, recordChange{Collection: colID, Key: key, Kind: diffDeleted})
+		}
+	}
+	return out
+}
+
+// diffFields returns the changed fields between two records, sorted by name.
+func diffFields(before, after map[string]any) []fieldChange {
+	names := map[string]struct{}{}
+	for k := range before {
+		names[k] = struct{}{}
+	}
+	for k := range after {
+		names[k] = struct{}{}
+	}
+	var changes []fieldChange
+	for name := range names {
+		b, a := before[name], after[name]
+		if !reflect.DeepEqual(b, a) {
+			changes = append(changes, fieldChange{Field: name, Before: b, After: a})
+		}
+	}
+	sort.Slice(changes, func(i, j int) bool { return changes[i].Field < changes[j].Field })
+	return changes
+}
+
+func summarize(records []recordChange) []collectionCount {
+	idx := map[string]*collectionCount{}
+	var order []string
+	for _, r := range records {
+		c := idx[r.Collection]
+		if c == nil {
+			c = &collectionCount{Collection: r.Collection}
+			idx[r.Collection] = c
+			order = append(order, r.Collection)
+		}
+		switch r.Kind {
+		case diffAdded:
+			c.Added++
+		case diffUpdated:
+			c.Updated++
+		case diffDeleted:
+			c.Deleted++
+		}
+	}
+	sort.Strings(order)
+	out := make([]collectionCount, 0, len(order))
+	for _, c := range order {
+		out = append(out, *idx[c])
+	}
+	return out
+}
+
+// parseKeyedRecords turns record-file content into a map keyed by record key.
+// Nil content (file absent at that ref) yields an empty map.
+func parseKeyedRecords(content []byte, colDef *ingitdb.CollectionDef, relPath string) map[string]map[string]any {
+	out := map[string]map[string]any{}
+	if content == nil || colDef.RecordFile == nil {
+		return out
+	}
+	switch colDef.RecordFile.RecordType {
+	case ingitdb.SingleRecord:
+		data, err := dalgo2ingitdb.ParseRecordContentForCollection(content, colDef)
+		if err != nil {
+			return out
+		}
+		out[recordKeyFromPath(relPath)] = data
+	case ingitdb.MapOfRecords:
+		m, err := dalgo2ingitdb.ParseMapOfRecordsContent(content, colDef.RecordFile.Format)
+		if err != nil {
+			return out
+		}
+		for k, v := range m {
+			out[k] = v
+		}
+	case ingitdb.ListOfRecords:
+		rows, err := dalgo2ingitdb.ParseListOfRecordsContent(content, colDef.RecordFile.Format)
+		if err != nil {
+			return out
+		}
+		for _, row := range rows {
+			if key, ok := dalgo2ingitdb.ResolveListRecordKey(row, colDef); ok {
+				out[key] = row
+			}
+		}
+	}
+	return out
+}
+
+func recordKeyFromPath(p string) string {
+	base := filepath.Base(p)
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+// gitShow returns the content of relPath at ref, or nil when it does not exist.
+// An empty ref reads the working-tree copy.
+func gitShow(ctx context.Context, dirPath, ref, relPath string) []byte {
+	if ref == "" {
+		content, err := os.ReadFile(filepath.Join(dirPath, relPath))
+		if err != nil {
+			return nil
+		}
+		return content
+	}
+	c := exec.CommandContext(ctx, "git", "show", ref+":"+relPath)
+	c.Dir = dirPath
+	out, err := c.Output()
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+// --- rendering ---
+
+func renderDiff(w io.Writer, report *diffReport, depth, format string) error {
+	switch format {
+	case "json":
+		return json.NewEncoder(w).Encode(diffView(report, depth))
+	case "yaml", "yml":
+		out, err := yaml.Marshal(diffView(report, depth))
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(out)
+		return err
+	case "toml":
+		out, err := toml.Marshal(diffView(report, depth))
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(out)
+		return err
+	default: // text
+		return renderDiffText(w, report, depth)
+	}
+}
+
+// diffView strips detail the chosen depth should not expose, so structured
+// output matches the text output for the same depth.
+func diffView(report *diffReport, depth string) *diffReport {
+	v := &diffReport{From: report.From, To: report.To, Summary: report.Summary}
+	if depth == "summary" {
+		return v
+	}
+	v.Records = make([]recordChange, len(report.Records))
+	for i, r := range report.Records {
+		rc := recordChange{Collection: r.Collection, Key: r.Key, Kind: r.Kind}
+		switch depth {
+		case "fields":
+			for _, f := range r.Fields {
+				rc.Fields = append(rc.Fields, fieldChange{Field: f.Field})
+			}
+		case "full":
+			rc.Fields = r.Fields
+		}
+		v.Records[i] = rc
+	}
+	return v
+}
+
+func renderDiffText(w io.Writer, report *diffReport, depth string) error {
+	p := func(format string, a ...any) { _, _ = fmt.Fprintf(w, format, a...) }
+	p("diff %s..%s\n", report.From, report.To)
+	if len(report.Summary) == 0 {
+		p("no record changes\n")
+		return nil
+	}
+	if depth == "summary" {
+		for _, c := range report.Summary {
+			p("%s: +%d ~%d -%d\n", c.Collection, c.Added, c.Updated, c.Deleted)
+		}
+		return nil
+	}
+	for _, r := range report.Records {
+		p("%-7s %s/%s\n", r.Kind, r.Collection, r.Key)
+		if depth == "fields" && len(r.Fields) > 0 {
+			names := make([]string, len(r.Fields))
+			for i, f := range r.Fields {
+				names[i] = f.Field
+			}
+			p("        fields: %s\n", strings.Join(names, ", "))
+		}
+		if depth == "full" {
+			for _, f := range r.Fields {
+				p("        %s: %v -> %v\n", f.Field, f.Before, f.After)
+			}
+		}
+	}
+	return nil
+}
+
+// --- command ---
+
+// Diff returns the diff command. exitCode is the process-exit seam (os.Exit in
+// production, captured in tests): the command exits 1 when changes are found,
+// 0 otherwise.
+func Diff(
+	homeDir func() (string, error),
+	getWd func() (string, error),
+	readDefinition func(string, ...ingitdb.ReadOption) (*ingitdb.Definition, error),
+	logf func(...any),
+	exitCode func(int),
+) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "diff [<ref> | <ref>..<ref>]",
+		Short: "Show record-level changes between two git refs",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = logf
+			ctx := cmd.Context()
+
+			depth, _ := cmd.Flags().GetString("depth")
+			switch depth {
+			case "", "summary":
+				depth = "summary"
+			case "record", "fields", "full":
+			default:
+				return fmt.Errorf("invalid --depth=%q (must be summary, record, fields, or full)", depth)
+			}
+			format, _ := cmd.Flags().GetString("format")
+			switch format {
+			case "", "text":
+				format = "text"
+			case "json", "yaml", "yml", "toml":
+			default:
+				return fmt.Errorf("invalid --format=%q (must be text, json, yaml, or toml)", format)
+			}
+			collFilter, _ := cmd.Flags().GetString("collection")
+			viewFilter, _ := cmd.Flags().GetString("view")
+			if viewFilter != "" {
+				return fmt.Errorf("--view diffing is not yet implemented")
+			}
+			if collFilter != "" && viewFilter != "" {
+				return fmt.Errorf("--collection and --view are mutually exclusive")
+			}
+			pathFilter, _ := cmd.Flags().GetString("path-filter")
+
+			arg := ""
+			if len(args) == 1 {
+				arg = args[0]
+			}
+			from, to := parseDiffRefs(arg)
+
+			dirPath, err := resolveDBPath(cmd, homeDir, getWd)
+			if err != nil {
+				return err
+			}
+			def, err := readDefinition(dirPath)
+			if err != nil {
+				return fmt.Errorf("failed to read database definition: %w", err)
+			}
+
+			report, err := computeDiff(ctx, dirPath, def, from, to, collFilter, pathFilter)
+			if err != nil {
+				return err
+			}
+			if err := renderDiff(cmd.OutOrStdout(), report, depth, format); err != nil {
+				return err
+			}
+			if report.changed() {
+				exitCode(1)
+			}
+			return nil
+		},
+	}
+	addPathFlag(cmd)
+	cmd.Flags().String("depth", "summary", "detail level: summary, record, fields, or full")
+	cmd.Flags().String("format", "text", "output format: text, json, yaml, or toml")
+	cmd.Flags().String("collection", "", "limit the diff to a single collection")
+	cmd.Flags().String("view", "", "limit the diff to a single view (not yet implemented)")
+	cmd.Flags().String("view-mode", "output", "with --view: diff 'output' or 'source' (not yet implemented)")
+	cmd.Flags().String("path-filter", "", "narrow by record path prefix or glob")
+	return cmd
+}

--- a/cmd/ingitdb/commands/diff_test.go
+++ b/cmd/ingitdb/commands/diff_test.go
@@ -1,0 +1,207 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+func TestParseDiffRefs(t *testing.T) {
+	t.Parallel()
+	tests := []struct{ arg, from, to string }{
+		{"", "HEAD", ""},
+		{"v1", "v1", "HEAD"},
+		{"a..b", "a", "b"},
+		{"main..feature", "main", "feature"},
+	}
+	for _, tc := range tests {
+		from, to := parseDiffRefs(tc.arg)
+		if from != tc.from || to != tc.to {
+			t.Errorf("parseDiffRefs(%q) = (%q,%q), want (%q,%q)", tc.arg, from, to, tc.from, tc.to)
+		}
+	}
+}
+
+func TestDiffFields(t *testing.T) {
+	t.Parallel()
+	before := map[string]any{"name": "Alice", "age": 30, "city": "NYC"}
+	after := map[string]any{"name": "Alice", "age": 31, "zip": "10001"}
+	got := diffFields(before, after)
+	// changed: age (30->31), city (removed), zip (added) — name unchanged.
+	gotNames := make([]string, len(got))
+	for i, f := range got {
+		gotNames[i] = f.Field
+	}
+	want := []string{"age", "city", "zip"} // sorted
+	if strings.Join(gotNames, ",") != strings.Join(want, ",") {
+		t.Errorf("changed fields = %v, want %v", gotNames, want)
+	}
+}
+
+func TestDiffRecordSets(t *testing.T) {
+	t.Parallel()
+	before := map[string]map[string]any{
+		"alice": {"age": 30},
+		"carol": {"age": 40},
+	}
+	after := map[string]map[string]any{
+		"alice": {"age": 31}, // updated
+		"bob":   {"age": 20}, // added
+		// carol deleted
+	}
+	got := diffRecordSets("people", before, after)
+	kinds := map[string]diffKind{}
+	for _, r := range got {
+		kinds[r.Key] = r.Kind
+	}
+	if kinds["alice"] != diffUpdated || kinds["bob"] != diffAdded || kinds["carol"] != diffDeleted {
+		t.Errorf("unexpected kinds: %+v", kinds)
+	}
+}
+
+// diffTestRepo builds a git repo with a single-record "people" collection,
+// two commits, and returns (dir, baseSha, readDef).
+func diffTestRepo(t *testing.T) (string, string, func(string, ...ingitdb.ReadOption) (*ingitdb.Definition, error)) {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	disableGitBackgroundMaintenance(t, dir)
+	runGit(t, dir, "config", "user.email", "t@example.com")
+	runGit(t, dir, "config", "user.name", "T")
+
+	write := func(key, content string) {
+		recDir := filepath.Join(dir, "people", "$records")
+		if err := os.MkdirAll(recDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(recDir, key+".yaml"), []byte(content), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	write("alice", "name: Alice\nage: 30\n")
+	write("carol", "name: Carol\nage: 40\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "base")
+	base := strings.TrimSpace(string(runGit(t, dir, "rev-parse", "HEAD")))
+
+	write("alice", "name: Alice\nage: 31\n") // updated
+	write("bob", "name: Bob\nage: 20\n")     // added
+	if err := os.Remove(filepath.Join(dir, "people", "$records", "carol.yaml")); err != nil {
+		t.Fatalf("remove carol: %v", err)
+	}
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-m", "second")
+
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
+		return &ingitdb.Definition{
+			Collections: map[string]*ingitdb.CollectionDef{
+				"people": {
+					ID:      "people",
+					DirPath: filepath.Join(dir, "people"),
+					RecordFile: &ingitdb.RecordFileDef{
+						Name: "{key}.yaml", Format: ingitdb.RecordFormatYAML, RecordType: ingitdb.SingleRecord,
+					},
+					Columns: map[string]*ingitdb.ColumnDef{
+						"name": {Type: ingitdb.ColumnTypeString},
+						"age":  {Type: ingitdb.ColumnTypeInt},
+					},
+				},
+			},
+		}, nil
+	}
+	return dir, base, readDef
+}
+
+func runDiff(t *testing.T, dir, readDefBase string, readDef func(string, ...ingitdb.ReadOption) (*ingitdb.Definition, error), args ...string) (string, int) {
+	t.Helper()
+	exitCode := 0
+	cmd := Diff(
+		func() (string, error) { return "/tmp/home", nil },
+		func() (string, error) { return dir, nil },
+		readDef, func(...any) {},
+		func(c int) { exitCode = c },
+	)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs(append([]string{readDefBase + "..HEAD", "--path=" + dir}, args...))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("diff %v: %v", args, err)
+	}
+	return buf.String(), exitCode
+}
+
+func TestDiff_EndToEnd(t *testing.T) {
+	dir, base, readDef := diffTestRepo(t)
+
+	// summary
+	out, code := runDiff(t, dir, base, readDef) // default depth=summary
+	if code != 1 {
+		t.Errorf("expected exit 1 (changes), got %d", code)
+	}
+	if !strings.Contains(out, "people: +1 ~1 -1") {
+		t.Errorf("summary mismatch: %s", out)
+	}
+
+	// record
+	out, _ = runDiff(t, dir, base, readDef, "--depth=record")
+	for _, want := range []string{"added   people/bob", "updated people/alice", "deleted people/carol"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("record output missing %q:\n%s", want, out)
+		}
+	}
+
+	// fields
+	out, _ = runDiff(t, dir, base, readDef, "--depth=fields")
+	if !strings.Contains(out, "fields: age") {
+		t.Errorf("fields output should list changed field 'age':\n%s", out)
+	}
+
+	// full
+	out, _ = runDiff(t, dir, base, readDef, "--depth=full")
+	if !strings.Contains(out, "age: 30 -> 31") {
+		t.Errorf("full output should show age before/after:\n%s", out)
+	}
+
+	// json
+	out, _ = runDiff(t, dir, base, readDef, "--depth=record", "--format=json")
+	var report diffReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("json output not valid: %v\n%s", err, out)
+	}
+	if len(report.Records) != 3 {
+		t.Errorf("expected 3 record changes in json, got %d", len(report.Records))
+	}
+}
+
+func TestDiff_NoChanges_Exit0(t *testing.T) {
+	dir, _, readDef := diffTestRepo(t)
+	// HEAD..HEAD → no changes.
+	out, code := runDiff(t, dir, "HEAD", readDef)
+	if code != 0 {
+		t.Errorf("expected exit 0 (no changes), got %d", code)
+	}
+	if !strings.Contains(out, "no record changes") {
+		t.Errorf("expected 'no record changes', got: %s", out)
+	}
+}
+
+func TestDiff_InvalidFlags(t *testing.T) {
+	dir, base, readDef := diffTestRepo(t)
+	for _, args := range [][]string{{"--depth=bogus"}, {"--format=xml"}, {"--view=v1"}} {
+		cmd := Diff(
+			func() (string, error) { return "/tmp/home", nil },
+			func() (string, error) { return dir, nil },
+			readDef, func(...any) {}, func(int) {},
+		)
+		cmd.SetArgs(append([]string{base + "..HEAD", "--path=" + dir}, args...))
+		if err := cmd.Execute(); err == nil {
+			t.Errorf("expected error for args %v", args)
+		}
+	}
+}

--- a/cmd/ingitdb/main.go
+++ b/cmd/ingitdb/main.go
@@ -90,6 +90,7 @@ func run(
 		// docs/adr/0001-remove-serve-command.md. Preserved in git history:
 		// last present at 184a40e; removed in 1bfecce.
 		// Recover with: git show 184a40e:cmd/ingitdb/commands/serve.go
+		commands.Diff(homeDir, getWd, readDefinition, logf, os.Exit),
 		commands.List(homeDir, getWd, readDefinition),
 		commands.Describe(homeDir, getWd, readDefinition),
 		commands.Select(homeDir, getWd, readDefinition, newDB, logf),

--- a/pkg/ingitdb/datavalidator/changeset_resolver.go
+++ b/pkg/ingitdb/datavalidator/changeset_resolver.go
@@ -29,7 +29,7 @@ func (changeSetResolver) Resolve(dbPath string, def *ingitdb.Definition, changed
 			continue
 		}
 		absPath := filepath.Clean(filepath.Join(dbPath, cf.Path))
-		colID, colDef := collectionForRecordFile(def, absPath)
+		colID, colDef := CollectionForRecordFile(def, absPath)
 		if colDef == nil {
 			continue
 		}
@@ -53,11 +53,12 @@ func (changeSetResolver) Resolve(dbPath string, def *ingitdb.Definition, changed
 	return affected, nil
 }
 
-// collectionForRecordFile returns the collection (and its ID) that owns absPath
+// CollectionForRecordFile returns the collection (and its ID) that owns absPath
 // as a record file, or ("", nil) when no collection's record-file layout
 // matches. It mirrors how the full validator enumerates record files, so the
-// incremental and full passes agree on which files are records.
-func collectionForRecordFile(def *ingitdb.Definition, absPath string) (string, *ingitdb.CollectionDef) {
+// incremental validator, change-set resolver, and `diff` all agree on which
+// files are records.
+func CollectionForRecordFile(def *ingitdb.Definition, absPath string) (string, *ingitdb.CollectionDef) {
 	for id, colDef := range def.Collections {
 		if shouldSkipRecordParsing(colDef) {
 			continue

--- a/spec/features/cli/diff/README.md
+++ b/spec/features/cli/diff/README.md
@@ -1,7 +1,7 @@
 # Feature: Diff Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/diff?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/diff?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/diff?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/diff?op=request-change) |
-**Status:** Draft
+**Status:** Implementing
 
 ## Summary
 
@@ -45,13 +45,65 @@ The command MUST exit `0` when no changes are found, `1` when changes are found,
 
 - path-targeting
 
+## Implementation
+
+Source files (annotated with `// specscore: feature/cli/diff`):
+
+- [`cmd/ingitdb/commands/diff.go`](../../../cmd/ingitdb/commands/diff.go)
+
+Reuses `pkg/ingitdb/gitdiff` (changed-file listing) and
+`pkg/ingitdb/datavalidator.CollectionForRecordFile` (file→collection mapping).
+
 ## Acceptance Criteria
 
-Not defined yet.
+### AC: refs-and-record-changes
+
+**Requirements:** cli/diff#req:subcommand-name, cli/diff#req:depth
+
+`ingitdb diff <a>..<b>` reports added/updated/deleted records grouped by
+collection. A bare `<ref>` compares that ref against HEAD; an omitted argument
+compares the working tree against HEAD. `--depth=summary` (default) prints
+per-collection counts; `record` lists one line per changed record; `fields`
+adds changed field names; `full` adds before/after values per field.
+
+### AC: format
+
+**Requirements:** cli/diff#req:format
+
+`--format=text|json|yaml|toml` (default `text`) renders the same depth-scoped
+result in the chosen format; the structured formats round-trip
+(e.g. JSON parses back into the record-change list).
+
+### AC: scoping
+
+**Requirements:** cli/diff#req:scoping-flags
+
+`--collection=KEY` limits the diff to one collection; `--path-filter=PATTERN`
+narrows by record-path prefix/glob.
+
+### AC: exit-codes
+
+**Requirements:** cli/diff#req:exit-codes
+
+The command exits `0` when no record changes are found and `1` when changes
+are found (suitable as a CI guard).
+
+## Scope (current implementation)
+
+Implemented: all three ref forms; `summary`/`record`/`fields`/`full` depth;
+`text`/`json`/`yaml`/`toml` format; `--collection` and `--path-filter`; exit
+`0`/`1`.
+
+Deferred / not yet implemented:
+- **`--view` / `--view-mode`** — diffing a view's generated output or source
+  records (`--view` currently returns a clear "not yet implemented" error).
+- **`record` depth commit metadata** — per-record commit count and short
+  hashes are not yet shown (only the change kind).
+- **Exit code `2`** — infrastructure errors currently exit `1` (non-zero), not
+  a distinct `2`; that granularity needs main-loop exit-code support.
 
 ## Open Questions
 
-- Acceptance criteria not yet defined for this feature.
 - Should `--depth=full` redact secrets the way some logging frameworks do?
 - Should the JSON output schema be versioned and documented as a stable contract?
 


### PR DESCRIPTION
## Summary

Implements `ingitdb diff` — record-level diff between two git refs, grouped by collection (the spec's motivation: `git diff` can't tell a meaningful field change from a YAML reformat). Built largely by **reuse**: the `gitdiff` change lister, the record-format parsers (`ParseMapOfRecordsContent` / `ParseListOfRecordsContent` / `ParseRecordContentForCollection`), and the file→collection matcher (exported as `datavalidator.CollectionForRecordFile`).

- **Refs:** omitted (working tree vs HEAD), `<ref>` (vs HEAD), `<a>..<b>`.
- **`--depth`:** `summary` (per-collection +/~/- counts) · `record` (one line per changed record) · `fields` (changed field names) · `full` (before/after per field).
- **`--format`:** `text` · `json` · `yaml` · `toml` (structured formats round-trip).
- **Scoping:** `--collection`, `--path-filter`.
- **Exit codes:** `0` no changes / `1` changes — via an injected exit seam, so it's a CI guard.

## Tests
- Unit: `parseDiffRefs`, `diffFields`, `diffRecordSets`.
- End-to-end git repo (add/update/delete records across two commits): asserts all four depths, JSON round-trip (3 record changes), `exit 1` on changes, `exit 0` + "no record changes" on `HEAD..HEAD`, and invalid `--depth`/`--format`/`--view` rejection.

## Deferred (documented in the spec)
- `--view` / `--view-mode` (view diffing) — `--view` returns a clear "not yet implemented".
- `record`-depth commit counts / short hashes (only the change kind is shown).
- Exit code `2` for infra errors (currently exit `1`/non-zero; same main-loop constraint as `pull`).

## Spec
ACs written (were "Not defined yet"); `cli/diff` **Draft → Implementing**; README status updated.

## Verification
`go build ./...`, `go test ./...`, `golangci-lint` (v2.12.2 — the CI version), `specscore spec lint` — all clean. (Bonus: exporting `CollectionForRecordFile` is a small DRY refactor shared with the validate change-set resolver.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)