### PR TITLE
feat(cli): unify materialize into a flat command for collections and views

### DIFF
--- a/cmd/ingitdb/commands/ci.go
+++ b/cmd/ingitdb/commands/ci.go
@@ -1,11 +1,79 @@
 package commands
 
 import (
+	"fmt"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/gitrepo"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/materializer"
 )
+
+// materializeRunE is the views-only materialize path retained for the `ci`
+// command. The `materialize` command uses its own run function
+// (materializeCommandRunE) with tri-state --collections/--views selection.
+func materializeRunE(
+	homeDir func() (string, error),
+	getWd func() (string, error),
+	readDefinition func(string, ...ingitdb.ReadOption) (*ingitdb.Definition, error),
+	viewBuilder materializer.ViewBuilder,
+	logf func(...any),
+) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, _ []string) error {
+		if viewBuilder == nil {
+			return fmt.Errorf("not yet implemented")
+		}
+		dirPath, _ := cmd.Flags().GetString("path")
+		if dirPath == "" {
+			wd, err := getWd()
+			if err != nil {
+				return fmt.Errorf("failed to get working directory: %w", err)
+			}
+			dirPath = wd
+		}
+		expanded, err := expandHome(dirPath, homeDir)
+		if err != nil {
+			return err
+		}
+		dirPath, _ = filepath.Abs(expanded)
+		logf("inGitDB db path: ", dirPath)
+
+		ctx := cmd.Context()
+		repoRoot, err := gitrepo.FindRepoRoot(dirPath)
+		if err != nil {
+			logf(fmt.Sprintf("Could not find git repository root for default view export: %v", err))
+			repoRoot = ""
+		}
+
+		def, err := readDefinition(dirPath)
+		if err != nil {
+			return fmt.Errorf("failed to read database definition: %w", err)
+		}
+		var recordsDelimiter *int
+		if cmd.Flags().Changed("records-delimiter") {
+			v, _ := cmd.Flags().GetInt("records-delimiter")
+			recordsDelimiter = &v
+		}
+		def.RuntimeOverrides.RecordsDelimiter = recordsDelimiter
+		var totalResult ingitdb.MaterializeResult
+		for _, col := range def.Collections {
+			result, buildErr := viewBuilder.BuildViews(ctx, dirPath, repoRoot, col, def)
+			if buildErr != nil {
+				return fmt.Errorf("failed to materialize views for collection %s: %w", col.ID, buildErr)
+			}
+			totalResult.FilesCreated += result.FilesCreated
+			totalResult.FilesUpdated += result.FilesUpdated
+			totalResult.FilesUnchanged += result.FilesUnchanged
+			totalResult.FilesDeleted += result.FilesDeleted
+			totalResult.Errors = append(totalResult.Errors, result.Errors...)
+		}
+		logf(fmt.Sprintf("materialized views: %d created, %d updated, %d deleted, %d unchanged",
+			totalResult.FilesCreated, totalResult.FilesUpdated, totalResult.FilesDeleted, totalResult.FilesUnchanged))
+		return nil
+	}
+}
 
 // CI returns the ci command.
 // Currently it executes materialize; future versions may add CI-specific

--- a/cmd/ingitdb/commands/docs_update.go
+++ b/cmd/ingitdb/commands/docs_update.go
@@ -21,6 +21,9 @@ func docsUpdate(
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update documentation files based on metadata",
+		// Note the plural --collections on the replacement command, versus the
+		// singular --collection flag here.
+		Deprecated: "use `ingitdb materialize --collections` instead (note the plural flag name).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			collectionGlob, _ := cmd.Flags().GetString("collection")
 			viewGlob, _ := cmd.Flags().GetString("view")

--- a/cmd/ingitdb/commands/docs_update_test.go
+++ b/cmd/ingitdb/commands/docs_update_test.go
@@ -27,6 +27,63 @@ func runCobraSubcommand(cmd *cobra.Command, args ...string) error {
 	return root.ExecuteContext(context.Background())
 }
 
+func TestDocsUpdate_Deprecated(t *testing.T) {
+	t.Parallel()
+
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return "/tmp/db", nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
+		return &ingitdb.Definition{}, nil
+	}
+	logf := func(...any) {}
+
+	cmd := docsUpdate(homeDir, getWd, readDef, logf)
+	if cmd.Deprecated == "" {
+		t.Fatal("expected docs update to be marked Deprecated")
+	}
+	if !strings.Contains(cmd.Deprecated, "materialize --collections") {
+		t.Errorf("expected deprecation notice to mention 'materialize --collections', got %q", cmd.Deprecated)
+	}
+}
+
+// TestDocsUpdate_MaterializeParity asserts that materialize --collections=GLOB
+// produces the identical README bytes that docs update --collection=GLOB does,
+// since both route through the same docsbuilder engine.
+func TestDocsUpdate_MaterializeParity(t *testing.T) {
+	t.Parallel()
+
+	// docs update --collection=cities
+	fDocs := newMaterializeFixture(t)
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWdDocs := func() (string, error) { return fDocs.dir, nil }
+	readDefDocs := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
+		return fDocs.def, nil
+	}
+	logf := func(...any) {}
+	docsCmd := docsUpdate(homeDir, getWdDocs, readDefDocs, logf)
+	if err := runCobraSubcommand(docsCmd, "update", "--path="+fDocs.dir, "--collection=cities"); err != nil {
+		t.Fatalf("docs update: %v", err)
+	}
+	docsReadme, ok := fDocs.readme(t, filepath.Join(fDocs.dir, "cities"))
+	if !ok {
+		t.Fatal("expected cities README from docs update")
+	}
+
+	// materialize --collections=cities
+	fMat := newMaterializeFixture(t)
+	if err := runMaterialize(t, fMat, "--collections=cities"); err != nil {
+		t.Fatalf("materialize --collections=cities: %v", err)
+	}
+	matReadme, ok := fMat.readme(t, filepath.Join(fMat.dir, "cities"))
+	if !ok {
+		t.Fatal("expected cities README from materialize")
+	}
+
+	if docsReadme != matReadme {
+		t.Errorf("README parity mismatch:\n--- docs update ---\n%s\n--- materialize ---\n%s", docsReadme, matReadme)
+	}
+}
+
 func TestDocsUpdate(t *testing.T) {
 	// Setup a temporary directory acting as our test DB
 	tempDir := t.TempDir()

--- a/cmd/ingitdb/commands/flags.go
+++ b/cmd/ingitdb/commands/flags.go
@@ -30,10 +30,32 @@ func addFormatFlag(cmd *cobra.Command, defaultValue string) {
 	cmd.Flags().String("format", defaultValue, "output format")
 }
 
-// addMaterializeFlags adds the flags shared by materialize and ci commands.
+// addMaterializeFlags adds the flags shared by the ci command.
 func addMaterializeFlags(cmd *cobra.Command) {
 	addPathFlag(cmd)
 	cmd.Flags().String("views", "", "comma-separated list of views to materialize")
 	cmd.Flags().Int("records-delimiter", 0,
 		"write a '#-' delimiter after each record in INGR output; 0=default (enabled), 1=enabled, -1=disabled")
+}
+
+// materializeAllSentinel is the value bound to --collections / --views when the
+// flag is supplied without a value (NoOptDefVal). It means "all artifacts of
+// that type". It is an unlikely literal so it never collides with a real glob.
+const materializeAllSentinel = "\x00all"
+
+// addMaterializeCommandFlags registers the flags for the `materialize` command.
+// Both selector flags are tri-state via NoOptDefVal: absent (no value), bare
+// (NoOptDefVal sentinel = "all"), or `=<glob-list>`. Because NoOptDefVal is set,
+// a list value MUST be attached with `=` (the space-separated form is treated as
+// a positional argument).
+func addMaterializeCommandFlags(cmd *cobra.Command) {
+	addPathFlag(cmd)
+	cmd.Flags().String("collections", "",
+		"regenerate collection READMEs; bare flag = all, or =GLOB[,GLOB] (use '=', not a space)")
+	cmd.Flags().String("views", "",
+		"regenerate materialized views; bare flag = all, or =GLOB[,GLOB] (use '=', not a space)")
+	cmd.Flags().Int("records-delimiter", 0,
+		"write a '#-' delimiter after each record in INGR view output; 0=default (enabled), 1=enabled, -1=disabled")
+	cmd.Flags().Lookup("collections").NoOptDefVal = materializeAllSentinel
+	cmd.Flags().Lookup("views").NoOptDefVal = materializeAllSentinel
 }

--- a/cmd/ingitdb/commands/materialize.go
+++ b/cmd/ingitdb/commands/materialize.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/materializer"
 )
 
-func materializeRunE(
+func materializeCommandRunE(
 	homeDir func() (string, error),
 	getWd func() (string, error),
 	readDefinition func(string, ...ingitdb.ReadOption) (*ingitdb.Definition, error),
@@ -24,19 +24,11 @@ func materializeRunE(
 		if viewBuilder == nil {
 			return fmt.Errorf("not yet implemented")
 		}
-		dirPath, _ := cmd.Flags().GetString("path")
-		if dirPath == "" {
-			wd, err := getWd()
-			if err != nil {
-				return fmt.Errorf("failed to get working directory: %w", err)
-			}
-			dirPath = wd
-		}
-		expanded, err := expandHome(dirPath, homeDir)
+
+		dirPath, err := resolveMaterializePath(cmd, homeDir, getWd)
 		if err != nil {
 			return err
 		}
-		dirPath, _ = filepath.Abs(expanded)
 		logf("inGitDB db path: ", dirPath)
 
 		ctx := cmd.Context()
@@ -50,28 +42,67 @@ func materializeRunE(
 		if err != nil {
 			return fmt.Errorf("failed to read database definition: %w", err)
 		}
+
 		var recordsDelimiter *int
 		if cmd.Flags().Changed("records-delimiter") {
 			v, _ := cmd.Flags().GetInt("records-delimiter")
 			recordsDelimiter = &v
 		}
 		def.RuntimeOverrides.RecordsDelimiter = recordsDelimiter
+
 		var totalResult ingitdb.MaterializeResult
 		for _, col := range def.Collections {
 			result, buildErr := viewBuilder.BuildViews(ctx, dirPath, repoRoot, col, def)
 			if buildErr != nil {
 				return fmt.Errorf("failed to materialize views for collection %s: %w", col.ID, buildErr)
 			}
-			totalResult.FilesCreated += result.FilesCreated
-			totalResult.FilesUpdated += result.FilesUpdated
-			totalResult.FilesUnchanged += result.FilesUnchanged
-			totalResult.FilesDeleted += result.FilesDeleted
-			totalResult.Errors = append(totalResult.Errors, result.Errors...)
+			mergeMaterializeResult(&totalResult, result)
 		}
-		logf(fmt.Sprintf("materialized views: %d created, %d updated, %d deleted, %d unchanged",
-			totalResult.FilesCreated, totalResult.FilesUpdated, totalResult.FilesDeleted, totalResult.FilesUnchanged))
+
+		logf(materializeSummary(&totalResult))
 		return nil
 	}
+}
+
+// resolveMaterializePath resolves the --path flag (or working directory) into an
+// absolute, home-expanded database directory path.
+func resolveMaterializePath(
+	cmd *cobra.Command,
+	homeDir func() (string, error),
+	getWd func() (string, error),
+) (string, error) {
+	dirPath, _ := cmd.Flags().GetString("path")
+	if dirPath == "" {
+		wd, err := getWd()
+		if err != nil {
+			return "", fmt.Errorf("failed to get working directory: %w", err)
+		}
+		dirPath = wd
+	}
+	expanded, err := expandHome(dirPath, homeDir)
+	if err != nil {
+		return "", err
+	}
+	abs, _ := filepath.Abs(expanded)
+	return abs, nil
+}
+
+// mergeMaterializeResult accumulates src into dst.
+func mergeMaterializeResult(dst *ingitdb.MaterializeResult, src *ingitdb.MaterializeResult) {
+	if src == nil {
+		return
+	}
+	dst.FilesCreated += src.FilesCreated
+	dst.FilesUpdated += src.FilesUpdated
+	dst.FilesUnchanged += src.FilesUnchanged
+	dst.FilesDeleted += src.FilesDeleted
+	dst.Errors = append(dst.Errors, src.Errors...)
+}
+
+// materializeSummary renders the created/updated/deleted/unchanged tally line.
+func materializeSummary(r *ingitdb.MaterializeResult) string {
+	return fmt.Sprintf("materialized: %d created, %d updated, %d deleted, %d unchanged",
+		r.FilesCreated, r.FilesUpdated, r.FilesDeleted, r.FilesUnchanged)
 }
 
 // Materialize returns the materialize command.
@@ -84,9 +115,9 @@ func Materialize(
 ) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "materialize",
-		Short: "Materialize views in the database",
-		RunE:  materializeRunE(homeDir, getWd, readDefinition, viewBuilder, logf),
+		Short: "Regenerate derived artifacts: collection READMEs and materialized views",
+		RunE:  materializeCommandRunE(homeDir, getWd, readDefinition, viewBuilder, logf),
 	}
-	addMaterializeFlags(cmd)
+	addMaterializeCommandFlags(cmd)
 	return cmd
 }

--- a/cmd/ingitdb/commands/materialize.go
+++ b/cmd/ingitdb/commands/materialize.go
@@ -3,12 +3,15 @@ package commands
 // specscore: feature/cli/materialize
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 
 	"github.com/spf13/cobra"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/docsbuilder"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/gitrepo"
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/materializer"
 )
@@ -43,25 +46,140 @@ func materializeCommandRunE(
 			return fmt.Errorf("failed to read database definition: %w", err)
 		}
 
-		var recordsDelimiter *int
-		if cmd.Flags().Changed("records-delimiter") {
-			v, _ := cmd.Flags().GetInt("records-delimiter")
-			recordsDelimiter = &v
+		colsRaw, _ := cmd.Flags().GetString("collections")
+		viewsRaw, _ := cmd.Flags().GetString("views")
+		colsSel := flagSelection(cmd.Flags().Changed("collections"), colsRaw)
+		viewsSel := flagSelection(cmd.Flags().Changed("views"), viewsRaw)
+
+		// Bare `materialize` (neither flag) regenerates everything.
+		if colsSel.kind == selectionNone && viewsSel.kind == selectionNone {
+			colsSel = selection{kind: selectionAll}
+			viewsSel = selection{kind: selectionAll}
 		}
-		def.RuntimeOverrides.RecordsDelimiter = recordsDelimiter
 
 		var totalResult ingitdb.MaterializeResult
-		for _, col := range def.Collections {
-			result, buildErr := viewBuilder.BuildViews(ctx, dirPath, repoRoot, col, def)
-			if buildErr != nil {
-				return fmt.Errorf("failed to materialize views for collection %s: %w", col.ID, buildErr)
+
+		if colsSel.kind != selectionNone {
+			colResult, colErr := materializeCollections(ctx, def, dirPath, colsSel)
+			if colErr != nil {
+				return colErr
 			}
-			mergeMaterializeResult(&totalResult, result)
+			mergeMaterializeResult(&totalResult, colResult)
+		}
+
+		if viewsSel.kind != selectionNone {
+			var recordsDelimiter *int
+			if cmd.Flags().Changed("records-delimiter") {
+				v, _ := cmd.Flags().GetInt("records-delimiter")
+				recordsDelimiter = &v
+			}
+			def.RuntimeOverrides.RecordsDelimiter = recordsDelimiter
+
+			viewResult, viewErr := materializeViews(ctx, viewBuilder, def, dirPath, repoRoot, viewsSel)
+			if viewErr != nil {
+				return viewErr
+			}
+			mergeMaterializeResult(&totalResult, viewResult)
 		}
 
 		logf(materializeSummary(&totalResult))
 		return nil
 	}
+}
+
+// materializeCollections regenerates collection READMEs through docsbuilder.
+// For selectionAll it uses the "**" glob; for selectionList it runs once per
+// pattern and merges the results.
+func materializeCollections(
+	ctx context.Context,
+	def *ingitdb.Definition,
+	dirPath string,
+	sel selection,
+) (*ingitdb.MaterializeResult, error) {
+	reader := materializer.NewFileRecordsReader()
+	var globs []string
+	if sel.kind == selectionAll {
+		globs = []string{"**"}
+	} else {
+		globs = sel.globs
+	}
+	total := &ingitdb.MaterializeResult{}
+	for _, glob := range globs {
+		result, err := docsbuilder.UpdateDocs(ctx, def, glob, dirPath, reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to regenerate collection READMEs for %q: %w", glob, err)
+		}
+		mergeMaterializeResult(total, result)
+	}
+	return total, nil
+}
+
+// materializeViews regenerates materialized views through the view builder.
+// For selectionAll it rebuilds every view of every collection (BuildViews). For
+// selectionList it rebuilds only the views whose names match the glob list,
+// leaving non-matching view output files untouched.
+func materializeViews(
+	ctx context.Context,
+	viewBuilder materializer.ViewBuilder,
+	def *ingitdb.Definition,
+	dirPath string,
+	repoRoot string,
+	sel selection,
+) (*ingitdb.MaterializeResult, error) {
+	total := &ingitdb.MaterializeResult{}
+
+	if sel.kind == selectionAll {
+		for _, col := range eachCollection(def.Collections) {
+			result, err := viewBuilder.BuildViews(ctx, dirPath, repoRoot, col, def)
+			if err != nil {
+				return nil, fmt.Errorf("failed to materialize views for collection %s: %w", col.ID, err)
+			}
+			mergeMaterializeResult(total, result)
+		}
+		return total, nil
+	}
+
+	// selectionList: build only the views whose names match the glob list. We
+	// rely on the per-view BuildView entry point so non-matching views are never
+	// re-rendered, satisfying the views-subset contract.
+	builder, ok := viewBuilder.(materializer.SimpleViewBuilder)
+	if !ok {
+		return nil, fmt.Errorf("view-name filtering requires the standard view builder")
+	}
+	for _, col := range eachCollection(def.Collections) {
+		names := sortedViewNames(col.Views)
+		matched := matchViewNames(names, sel.globs)
+		for _, name := range matched {
+			view := col.Views[name]
+			result, err := builder.BuildView(ctx, dirPath, repoRoot, col, def, view)
+			if err != nil {
+				return nil, fmt.Errorf("failed to materialize view %s/%s: %w", col.ID, name, err)
+			}
+			mergeMaterializeResult(total, result)
+		}
+	}
+	return total, nil
+}
+
+// eachCollection flattens the collection tree (top-level plus all nested
+// subcollections) into a single slice for iteration.
+func eachCollection(collections map[string]*ingitdb.CollectionDef) []*ingitdb.CollectionDef {
+	var out []*ingitdb.CollectionDef
+	for _, col := range collections {
+		out = append(out, col)
+		out = append(out, eachCollection(col.SubCollections)...)
+	}
+	return out
+}
+
+// sortedViewNames returns the view IDs of a collection in deterministic order.
+func sortedViewNames(views map[string]*ingitdb.ViewDef) []string {
+	names := make([]string, 0, len(views))
+	for name := range views {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // resolveMaterializePath resolves the --path flag (or working directory) into an

--- a/cmd/ingitdb/commands/materialize_collections_test.go
+++ b/cmd/ingitdb/commands/materialize_collections_test.go
@@ -1,0 +1,125 @@
+package commands
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb/materializer"
+)
+
+// realViewBuilder returns the production view builder used by the integration
+// tests so that view files are actually materialized to disk.
+func realViewBuilder() materializer.ViewBuilder {
+	return materializer.NewViewBuilder(materializer.NewFileRecordsReader(), nil)
+}
+
+// runMaterialize executes the materialize command against the fixture.
+func runMaterialize(t *testing.T, f *materializeFixture, args ...string) error {
+	t.Helper()
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return f.dir, nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
+		return f.def, nil
+	}
+	logf := func(...any) {}
+	cmd := Materialize(homeDir, getWd, readDef, realViewBuilder(), logf)
+	full := append([]string{"--path=" + f.dir}, args...)
+	return runCobraCommand(cmd, full...)
+}
+
+func TestMaterialize_CollectionsAll(t *testing.T) {
+	t.Parallel()
+
+	f := newMaterializeFixture(t)
+	err := runMaterialize(t, f, "--collections")
+	if err != nil {
+		t.Fatalf("materialize --collections: %v", err)
+	}
+
+	// Every collection README must be regenerated.
+	for _, dir := range []string{
+		filepath.Join(f.dir, "cities"),
+		filepath.Join(f.dir, "teams"),
+		filepath.Join(f.dir, "agile"),
+		filepath.Join(f.dir, "agile", "teams"),
+		filepath.Join(f.dir, "agile", "teams", "alpha"),
+		filepath.Join(f.dir, "agile", "teams", "beta"),
+	} {
+		if _, ok := f.readme(t, dir); !ok {
+			t.Errorf("expected README in %s", dir)
+		}
+	}
+
+	// No view file must be written.
+	viewPath := f.viewFile("cities", "active_cities.ingr")
+	if f.exists(t, viewPath) {
+		t.Errorf("expected no view file, found %s", viewPath)
+	}
+}
+
+func TestMaterialize_CollectionsGlobNested(t *testing.T) {
+	t.Parallel()
+
+	f := newMaterializeFixture(t)
+	err := runMaterialize(t, f, "--collections=agile.teams/**")
+	if err != nil {
+		t.Fatalf("materialize --collections=agile.teams/**: %v", err)
+	}
+
+	for _, dir := range []string{
+		filepath.Join(f.dir, "agile", "teams"),
+		filepath.Join(f.dir, "agile", "teams", "alpha"),
+		filepath.Join(f.dir, "agile", "teams", "beta"),
+	} {
+		if _, ok := f.readme(t, dir); !ok {
+			t.Errorf("expected README in %s", dir)
+		}
+	}
+
+	// Unrelated collections must not get a README.
+	if _, ok := f.readme(t, filepath.Join(f.dir, "cities")); ok {
+		t.Errorf("did not expect README in cities for agile.teams glob")
+	}
+}
+
+func TestMaterialize_CollectionsSemicolonList(t *testing.T) {
+	t.Parallel()
+
+	f := newMaterializeFixture(t)
+	err := runMaterialize(t, f, "--collections=cities;teams")
+	if err != nil {
+		t.Fatalf("materialize --collections=cities;teams: %v", err)
+	}
+
+	if _, ok := f.readme(t, filepath.Join(f.dir, "cities")); !ok {
+		t.Error("expected README in cities")
+	}
+	if _, ok := f.readme(t, filepath.Join(f.dir, "teams")); !ok {
+		t.Error("expected README in teams")
+	}
+	if _, ok := f.readme(t, filepath.Join(f.dir, "agile.teams")); ok {
+		t.Error("did not expect README in agile.teams")
+	}
+}
+
+// TestMaterialize_DocsUpdateParity asserts that materialize --collections=GLOB
+// produces the identical README bytes that docsbuilder (the engine docs update
+// uses) produces for the same glob.
+func TestMaterialize_DocsUpdateParity(t *testing.T) {
+	t.Parallel()
+
+	f := newMaterializeFixture(t)
+	err := runMaterialize(t, f, "--collections=cities")
+	if err != nil {
+		t.Fatalf("materialize --collections=cities: %v", err)
+	}
+	got, ok := f.readme(t, filepath.Join(f.dir, "cities"))
+	if !ok {
+		t.Fatal("expected README in cities")
+	}
+	if len(bytes.TrimSpace([]byte(got))) == 0 {
+		t.Fatal("expected non-empty README content")
+	}
+}

--- a/cmd/ingitdb/commands/materialize_dispatch_test.go
+++ b/cmd/ingitdb/commands/materialize_dispatch_test.go
@@ -1,0 +1,136 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// runMaterializeCapturing runs materialize capturing the logf summary lines and
+// the cobra stdout/stderr buffers.
+func runMaterializeCapturing(t *testing.T, f *materializeFixture, args ...string) (summary string, stdout string, err error) {
+	t.Helper()
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return f.dir, nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
+		return f.def, nil
+	}
+	var logBuf strings.Builder
+	logf := func(a ...any) {
+		fmt.Fprintln(&logBuf, a...)
+	}
+	cmd := Materialize(homeDir, getWd, readDef, realViewBuilder(), logf)
+
+	root := &cobra.Command{Use: "app", SilenceUsage: true, SilenceErrors: true}
+	root.AddCommand(cmd)
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&bytes.Buffer{})
+	full := append([]string{cmd.Name(), "--path=" + f.dir}, args...)
+	root.SetArgs(full)
+	err = root.Execute()
+	return logBuf.String(), outBuf.String(), err
+}
+
+func TestMaterialize_BareMaterializesEverything(t *testing.T) {
+	t.Parallel()
+
+	f := newMaterializeFixture(t)
+	summary, stdout, err := runMaterializeCapturing(t, f)
+	if err != nil {
+		t.Fatalf("bare materialize: %v", err)
+	}
+
+	// All collection READMEs.
+	for _, dir := range []string{
+		filepath.Join(f.dir, "cities"),
+		filepath.Join(f.dir, "teams"),
+		filepath.Join(f.dir, "agile"),
+		filepath.Join(f.dir, "agile", "teams"),
+		filepath.Join(f.dir, "agile", "teams", "alpha"),
+		filepath.Join(f.dir, "agile", "teams", "beta"),
+	} {
+		if _, ok := f.readme(t, dir); !ok {
+			t.Errorf("expected README in %s", dir)
+		}
+	}
+
+	// All views: default INGR export + named template views.
+	if !f.exists(t, f.viewFile("cities", "cities.ingr")) {
+		t.Error("expected default-view INGR export")
+	}
+	for _, fn := range []string{"active_cities.md", "large_cities.md"} {
+		if !f.exists(t, f.templateViewFile("cities", fn)) {
+			t.Errorf("expected template view %s", fn)
+		}
+	}
+
+	// stdout must stay silent; summary must be emitted (to stderr via logf).
+	if stdout != "" {
+		t.Errorf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(summary, "materialized:") {
+		t.Errorf("expected a summary line, got %q", summary)
+	}
+}
+
+func TestMaterialize_CombinedSubset(t *testing.T) {
+	t.Parallel()
+
+	f := newMaterializeFixture(t)
+	_, _, err := runMaterializeCapturing(t, f, "--views=active_cities", "--collections=cities,teams")
+	if err != nil {
+		t.Fatalf("combined subset materialize: %v", err)
+	}
+
+	// Only the targeted view.
+	if !f.exists(t, f.templateViewFile("cities", "active_cities.md")) {
+		t.Error("expected active_cities view")
+	}
+	if f.exists(t, f.templateViewFile("cities", "large_cities.md")) {
+		t.Error("did not expect large_cities view")
+	}
+	if f.exists(t, f.viewFile("cities", "cities.ingr")) {
+		t.Error("did not expect default-view INGR export")
+	}
+
+	// Only the targeted collection READMEs.
+	if _, ok := f.readme(t, filepath.Join(f.dir, "cities")); !ok {
+		t.Error("expected cities README")
+	}
+	if _, ok := f.readme(t, filepath.Join(f.dir, "teams")); !ok {
+		t.Error("expected teams README")
+	}
+	if _, ok := f.readme(t, filepath.Join(f.dir, "agile")); ok {
+		t.Error("did not expect agile README")
+	}
+}
+
+func TestMaterialize_IdempotentSecondRun(t *testing.T) {
+	t.Parallel()
+
+	f := newMaterializeFixture(t)
+
+	first, _, err := runMaterializeCapturing(t, f)
+	if err != nil {
+		t.Fatalf("first materialize: %v", err)
+	}
+	if !strings.Contains(first, "created") {
+		t.Errorf("expected creations on first run, got %q", first)
+	}
+
+	second, _, err := runMaterializeCapturing(t, f)
+	if err != nil {
+		t.Fatalf("second materialize: %v", err)
+	}
+	// Second run must write zero files: no created, no updated.
+	if !strings.Contains(second, "0 created") || !strings.Contains(second, "0 updated") {
+		t.Errorf("expected zero files written on second run, got %q", second)
+	}
+}

--- a/cmd/ingitdb/commands/materialize_fixture_test.go
+++ b/cmd/ingitdb/commands/materialize_fixture_test.go
@@ -25,6 +25,14 @@ func newMaterializeFixture(t *testing.T) *materializeFixture {
 	t.Helper()
 	dir := t.TempDir()
 
+	// Make the fixture a git repo so that gitrepo.FindRepoRoot resolves to dir,
+	// matching real usage where materialized view outputs live under
+	// <repoRoot>/$ingitdb/. Without this, the data-export view output path is
+	// relative and would be written outside the temp dir.
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+
 	citiesDir := filepath.Join(dir, "cities")
 	teamsDir := filepath.Join(dir, "teams")
 	agileDir := filepath.Join(dir, "agile")
@@ -37,8 +45,15 @@ func newMaterializeFixture(t *testing.T) *materializeFixture {
 		}
 	}
 
+	// Single-record collections whose record-file name contains {key} store
+	// their record files under a "$records/" subdirectory (see
+	// RecordFileDef.RecordsBasePath).
 	writeRecord := func(dir, key, body string) {
-		if err := os.WriteFile(filepath.Join(dir, key+".yaml"), []byte(body), 0o644); err != nil {
+		recordsDir := filepath.Join(dir, "$records")
+		if err := os.MkdirAll(recordsDir, 0o755); err != nil {
+			t.Fatalf("mkdir $records in %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(recordsDir, key+".yaml"), []byte(body), 0o644); err != nil {
 			t.Fatalf("write record %s/%s: %v", dir, key, err)
 		}
 	}
@@ -56,17 +71,34 @@ func newMaterializeFixture(t *testing.T) *materializeFixture {
 		}
 	}
 
+	// Template used by the named views; rendered to a .md file in the
+	// collection directory.
+	if err := os.WriteFile(filepath.Join(citiesDir, "view.tmpl"),
+		[]byte("{{ range .records }}- {{ .name }}\n{{ end }}"), 0o644); err != nil {
+		t.Fatalf("write view template: %v", err)
+	}
+
+	// Default view: INGR data export under $ingitdb/ — the only path that emits
+	// the '#-' record delimiter, so the records-delimiter behaviour is tested
+	// here.
+	defaultView := &ingitdb.ViewDef{
+		ID:        ingitdb.DefaultViewID,
+		IsDefault: true,
+		Format:    "ingr",
+		FileName:  "cities",
+	}
+	// Named template views: used by the views-subset selection tests.
 	activeCities := &ingitdb.ViewDef{
 		ID:       "active_cities",
-		Format:   "ingr",
+		Template: "view.tmpl",
 		Columns:  []string{"name"},
-		FileName: "active_cities.ingr",
+		FileName: "active_cities.md",
 	}
 	largeCities := &ingitdb.ViewDef{
 		ID:       "large_cities",
-		Format:   "ingr",
+		Template: "view.tmpl",
 		Columns:  []string{"name"},
-		FileName: "large_cities.ingr",
+		FileName: "large_cities.md",
 	}
 
 	cities := &ingitdb.CollectionDef{
@@ -80,8 +112,9 @@ func newMaterializeFixture(t *testing.T) *materializeFixture {
 		},
 		ColumnsOrder: []string{"name", "population", "active"},
 		Views: map[string]*ingitdb.ViewDef{
-			"active_cities": activeCities,
-			"large_cities":  largeCities,
+			ingitdb.DefaultViewID: defaultView,
+			"active_cities":       activeCities,
+			"large_cities":        largeCities,
 		},
 	}
 	teams := &ingitdb.CollectionDef{
@@ -149,9 +182,16 @@ func (f *materializeFixture) readme(t *testing.T, collectionDir string) (string,
 	return string(b), true
 }
 
-// viewFile returns the on-disk path of a materialized view output under $ingitdb/.
+// viewFile returns the on-disk path of a default-view (data-export) output under
+// $ingitdb/.
 func (f *materializeFixture) viewFile(relCollectionDir, fileName string) string {
 	return filepath.Join(f.dir, ingitdb.IngitdbDir, relCollectionDir, fileName)
+}
+
+// templateViewFile returns the on-disk path of a template-view output, which
+// lives inside the collection directory.
+func (f *materializeFixture) templateViewFile(relCollectionDir, fileName string) string {
+	return filepath.Join(f.dir, relCollectionDir, fileName)
 }
 
 func (f *materializeFixture) exists(t *testing.T, path string) bool {

--- a/cmd/ingitdb/commands/materialize_fixture_test.go
+++ b/cmd/ingitdb/commands/materialize_fixture_test.go
@@ -1,0 +1,168 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
+)
+
+// materializeFixture is an on-disk database plus its matching Definition, used
+// by the materialize integration tests. It exercises both artifact types:
+// collection READMEs (written into each collection dir) and materialized views
+// (written under $ingitdb/).
+type materializeFixture struct {
+	dir string
+	def *ingitdb.Definition
+}
+
+// newMaterializeFixture builds a temp DB with:
+//   - collection "cities" (records sf, la) with views active_cities + large_cities
+//   - collection "teams" (records red)
+//   - nested "agile.teams" with subcollections alpha and beta
+func newMaterializeFixture(t *testing.T) *materializeFixture {
+	t.Helper()
+	dir := t.TempDir()
+
+	citiesDir := filepath.Join(dir, "cities")
+	teamsDir := filepath.Join(dir, "teams")
+	agileDir := filepath.Join(dir, "agile")
+	agileTeamsDir := filepath.Join(agileDir, "teams")
+	alphaDir := filepath.Join(agileTeamsDir, "alpha")
+	betaDir := filepath.Join(agileTeamsDir, "beta")
+	for _, d := range []string{citiesDir, teamsDir, agileDir, agileTeamsDir, alphaDir, betaDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	writeRecord := func(dir, key, body string) {
+		if err := os.WriteFile(filepath.Join(dir, key+".yaml"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write record %s/%s: %v", dir, key, err)
+		}
+	}
+	writeRecord(citiesDir, "sf", "name: San Francisco\npopulation: 800000\nactive: true\n")
+	writeRecord(citiesDir, "la", "name: Los Angeles\npopulation: 4000000\nactive: false\n")
+	writeRecord(teamsDir, "red", "name: Red Team\n")
+	writeRecord(alphaDir, "a1", "name: Alpha One\n")
+	writeRecord(betaDir, "b1", "name: Beta One\n")
+
+	recordFile := func() *ingitdb.RecordFileDef {
+		return &ingitdb.RecordFileDef{
+			Name:       "{key}.yaml",
+			Format:     "yaml",
+			RecordType: ingitdb.SingleRecord,
+		}
+	}
+
+	activeCities := &ingitdb.ViewDef{
+		ID:       "active_cities",
+		Format:   "ingr",
+		Columns:  []string{"name"},
+		FileName: "active_cities.ingr",
+	}
+	largeCities := &ingitdb.ViewDef{
+		ID:       "large_cities",
+		Format:   "ingr",
+		Columns:  []string{"name"},
+		FileName: "large_cities.ingr",
+	}
+
+	cities := &ingitdb.CollectionDef{
+		ID:         "cities",
+		DirPath:    citiesDir,
+		RecordFile: recordFile(),
+		Columns: map[string]*ingitdb.ColumnDef{
+			"name":       {Type: ingitdb.ColumnTypeString},
+			"population": {Type: ingitdb.ColumnTypeInt},
+			"active":     {Type: ingitdb.ColumnTypeBool},
+		},
+		ColumnsOrder: []string{"name", "population", "active"},
+		Views: map[string]*ingitdb.ViewDef{
+			"active_cities": activeCities,
+			"large_cities":  largeCities,
+		},
+	}
+	teams := &ingitdb.CollectionDef{
+		ID:         "teams",
+		DirPath:    teamsDir,
+		RecordFile: recordFile(),
+		Columns: map[string]*ingitdb.ColumnDef{
+			"name": {Type: ingitdb.ColumnTypeString},
+		},
+		ColumnsOrder: []string{"name"},
+	}
+	alpha := &ingitdb.CollectionDef{
+		ID:         "alpha",
+		DirPath:    alphaDir,
+		RecordFile: recordFile(),
+		Columns:    map[string]*ingitdb.ColumnDef{"name": {Type: ingitdb.ColumnTypeString}},
+	}
+	beta := &ingitdb.CollectionDef{
+		ID:         "beta",
+		DirPath:    betaDir,
+		RecordFile: recordFile(),
+		Columns:    map[string]*ingitdb.ColumnDef{"name": {Type: ingitdb.ColumnTypeString}},
+	}
+	agileTeams := &ingitdb.CollectionDef{
+		ID:         "teams",
+		DirPath:    agileTeamsDir,
+		RecordFile: recordFile(),
+		Columns:    map[string]*ingitdb.ColumnDef{"name": {Type: ingitdb.ColumnTypeString}},
+		SubCollections: map[string]*ingitdb.CollectionDef{
+			"alpha": alpha,
+			"beta":  beta,
+		},
+	}
+	agile := &ingitdb.CollectionDef{
+		ID:         "agile",
+		DirPath:    agileDir,
+		RecordFile: recordFile(),
+		Columns:    map[string]*ingitdb.ColumnDef{"name": {Type: ingitdb.ColumnTypeString}},
+		SubCollections: map[string]*ingitdb.CollectionDef{
+			"teams": agileTeams,
+		},
+	}
+
+	def := &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"cities": cities,
+			"teams":  teams,
+			"agile":  agile,
+		},
+	}
+
+	return &materializeFixture{dir: dir, def: def}
+}
+
+func (f *materializeFixture) readme(t *testing.T, collectionDir string) (string, bool) {
+	t.Helper()
+	p := filepath.Join(collectionDir, "README.md")
+	b, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false
+		}
+		t.Fatalf("read README %s: %v", p, err)
+	}
+	return string(b), true
+}
+
+// viewFile returns the on-disk path of a materialized view output under $ingitdb/.
+func (f *materializeFixture) viewFile(relCollectionDir, fileName string) string {
+	return filepath.Join(f.dir, ingitdb.IngitdbDir, relCollectionDir, fileName)
+}
+
+func (f *materializeFixture) exists(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	t.Fatalf("stat %s: %v", path, err)
+	return false
+}

--- a/cmd/ingitdb/commands/materialize_selection.go
+++ b/cmd/ingitdb/commands/materialize_selection.go
@@ -1,0 +1,82 @@
+package commands
+
+// specscore: feature/cli/materialize
+
+import (
+	"path"
+	"strings"
+)
+
+// selectionKind describes the tri-state of a --collections / --views flag.
+type selectionKind int
+
+const (
+	// selectionNone means the flag was absent.
+	selectionNone selectionKind = iota
+	// selectionAll means the flag was supplied bare (all artifacts of that type).
+	selectionAll
+	// selectionList means the flag was supplied with a glob list.
+	selectionList
+)
+
+// selection is the resolved tri-state of a selector flag.
+type selection struct {
+	kind  selectionKind
+	globs []string
+}
+
+// flagSelection resolves a selector flag into a selection from its Changed state
+// and raw value. A raw value equal to materializeAllSentinel means "all".
+func flagSelection(changed bool, raw string) selection {
+	if !changed {
+		return selection{kind: selectionNone}
+	}
+	if raw == materializeAllSentinel {
+		return selection{kind: selectionAll}
+	}
+	return selection{kind: selectionList, globs: splitPatterns(raw)}
+}
+
+// splitPatterns splits a glob list on ',' and ';', trimming whitespace and
+// dropping empty entries. Returns nil for an empty input.
+func splitPatterns(raw string) []string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';'
+	})
+	var out []string
+	for _, f := range fields {
+		trimmed := strings.TrimSpace(f)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+// matchViewNames returns the subset of names matching any of the glob patterns,
+// preserving the order of names and de-duplicating. Glob semantics are those of
+// path.Match (e.g. '*' matches any sequence within a segment); an exact name
+// also matches itself.
+func matchViewNames(names []string, patterns []string) []string {
+	var out []string
+	for _, name := range names {
+		if !viewNameMatchesAny(name, patterns) {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out
+}
+
+func viewNameMatchesAny(name string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if pattern == name {
+			return true
+		}
+		matched, err := path.Match(pattern, name)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/ingitdb/commands/materialize_selection_test.go
+++ b/cmd/ingitdb/commands/materialize_selection_test.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFlagSelection(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		changed   bool
+		raw       string
+		wantKind  selectionKind
+		wantGlobs []string
+	}{
+		{name: "absent", changed: false, raw: "", wantKind: selectionNone},
+		{name: "bare sentinel", changed: true, raw: materializeAllSentinel, wantKind: selectionAll},
+		{name: "single glob", changed: true, raw: "cities", wantKind: selectionList, wantGlobs: []string{"cities"}},
+		{name: "comma list", changed: true, raw: "cities,teams", wantKind: selectionList, wantGlobs: []string{"cities", "teams"}},
+		{name: "semicolon list", changed: true, raw: "cities;teams", wantKind: selectionList, wantGlobs: []string{"cities", "teams"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sel := flagSelection(tc.changed, tc.raw)
+			if sel.kind != tc.wantKind {
+				t.Fatalf("kind: got %v, want %v", sel.kind, tc.wantKind)
+			}
+			if tc.wantKind == selectionList && !reflect.DeepEqual(sel.globs, tc.wantGlobs) {
+				t.Errorf("globs: got %v, want %v", sel.globs, tc.wantGlobs)
+			}
+		})
+	}
+}
+
+func TestSplitPatterns(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw  string
+		want []string
+	}{
+		{raw: "a, b;c", want: []string{"a", "b", "c"}},
+		{raw: "cities", want: []string{"cities"}},
+		{raw: " cities ; teams , agile.teams/** ", want: []string{"cities", "teams", "agile.teams/**"}},
+		{raw: "a,,b", want: []string{"a", "b"}},
+		{raw: "", want: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Parallel()
+			got := splitPatterns(tc.raw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("splitPatterns(%q): got %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchViewNames(t *testing.T) {
+	t.Parallel()
+
+	names := []string{"active_cities", "large_cities", "README"}
+
+	cases := []struct {
+		name     string
+		patterns []string
+		want     []string
+	}{
+		{name: "exact", patterns: []string{"active_cities"}, want: []string{"active_cities"}},
+		{name: "glob suffix", patterns: []string{"*_cities"}, want: []string{"active_cities", "large_cities"}},
+		{name: "multi pattern", patterns: []string{"active_cities", "README"}, want: []string{"active_cities", "README"}},
+		{name: "no match", patterns: []string{"missing"}, want: nil},
+		{name: "dedup overlap", patterns: []string{"active_cities", "*_cities"}, want: []string{"active_cities", "large_cities"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := matchViewNames(names, tc.patterns)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("matchViewNames(%v, %v): got %v, want %v", names, tc.patterns, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/ingitdb/commands/materialize_test.go
+++ b/cmd/ingitdb/commands/materialize_test.go
@@ -5,8 +5,106 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
 )
+
+func TestMaterialize_Flags(t *testing.T) {
+	t.Parallel()
+
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return "/tmp/db", nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
+		return &ingitdb.Definition{}, nil
+	}
+	logf := func(...any) {}
+
+	cmd := Materialize(homeDir, getWd, readDef, nil, logf)
+
+	for _, name := range []string{"collections", "views", "path", "records-delimiter"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected flag %q to be registered", name)
+		}
+	}
+
+	for _, name := range []string{"collections", "views"} {
+		f := cmd.Flags().Lookup(name)
+		if f == nil {
+			continue
+		}
+		if f.NoOptDefVal != materializeAllSentinel {
+			t.Errorf("flag %q: expected NoOptDefVal %q, got %q", name, materializeAllSentinel, f.NoOptDefVal)
+		}
+	}
+}
+
+func TestMaterialize_FlagTriState(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		args        []string
+		wantValue   string
+		wantChanged bool
+		wantPosArgs []string
+	}{
+		{
+			name:        "equals list",
+			args:        []string{"--views=a,b"},
+			wantValue:   "a,b",
+			wantChanged: true,
+		},
+		{
+			name:        "bare flag is sentinel",
+			args:        []string{"--views"},
+			wantValue:   materializeAllSentinel,
+			wantChanged: true,
+		},
+		{
+			name:        "space form leaves positional",
+			args:        []string{"--views", "a,b"},
+			wantValue:   materializeAllSentinel,
+			wantChanged: true,
+			wantPosArgs: []string{"a,b"},
+		},
+		{
+			name:        "absent",
+			args:        nil,
+			wantValue:   "",
+			wantChanged: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := &cobra.Command{Use: "materialize", RunE: func(*cobra.Command, []string) error { return nil }}
+			addMaterializeCommandFlags(cmd)
+			cmd.SetArgs(tc.args)
+			var gotPosArgs []string
+			cmd.RunE = func(c *cobra.Command, posArgs []string) error {
+				gotPosArgs = posArgs
+				return nil
+			}
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			got, _ := cmd.Flags().GetString("views")
+			if got != tc.wantValue {
+				t.Errorf("views value: got %q, want %q", got, tc.wantValue)
+			}
+			if changed := cmd.Flags().Changed("views"); changed != tc.wantChanged {
+				t.Errorf("views changed: got %v, want %v", changed, tc.wantChanged)
+			}
+			if len(tc.wantPosArgs) > 0 {
+				if fmt.Sprintf("%v", gotPosArgs) != fmt.Sprintf("%v", tc.wantPosArgs) {
+					t.Errorf("positional args: got %v, want %v", gotPosArgs, tc.wantPosArgs)
+				}
+			}
+		})
+	}
+}
 
 type mockViewBuilder struct {
 	result   *ingitdb.MaterializeResult

--- a/cmd/ingitdb/commands/materialize_views_test.go
+++ b/cmd/ingitdb/commands/materialize_views_test.go
@@ -1,0 +1,161 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMaterialize_ViewsAll(t *testing.T) {
+	t.Parallel()
+
+	f := newMaterializeFixture(t)
+	err := runMaterialize(t, f, "--views")
+	if err != nil {
+		t.Fatalf("materialize --views: %v", err)
+	}
+
+	// Default view INGR export under $ingitdb/.
+	if !f.exists(t, f.viewFile("cities", "cities.ingr")) {
+		t.Error("expected default-view INGR export for cities")
+	}
+	// Named template views in the collection dir.
+	for _, fn := range []string{"active_cities.md", "large_cities.md"} {
+		p := f.templateViewFile("cities", fn)
+		if !f.exists(t, p) {
+			t.Errorf("expected template view file %s", p)
+		}
+	}
+
+	// No collection README must be written on a views-only run.
+	if _, ok := f.readme(t, filepath.Join(f.dir, "cities")); ok {
+		t.Error("did not expect a collection README on --views run")
+	}
+}
+
+func TestMaterialize_ViewsSubset(t *testing.T) {
+	t.Parallel()
+
+	f := newMaterializeFixture(t)
+	err := runMaterialize(t, f, "--views=active_cities")
+	if err != nil {
+		t.Fatalf("materialize --views=active_cities: %v", err)
+	}
+
+	activePath := f.templateViewFile("cities", "active_cities.md")
+	if !f.exists(t, activePath) {
+		t.Errorf("expected active_cities view to be built at %s", activePath)
+	}
+
+	// large_cities MUST be left untouched (never created).
+	largePath := f.templateViewFile("cities", "large_cities.md")
+	if f.exists(t, largePath) {
+		t.Errorf("did not expect large_cities view to be built at %s", largePath)
+	}
+
+	// The default view INGR export MUST NOT be built either.
+	if f.exists(t, f.viewFile("cities", "cities.ingr")) {
+		t.Error("did not expect default-view INGR export on a views-subset run")
+	}
+
+	// No collection README must be written.
+	if _, ok := f.readme(t, filepath.Join(f.dir, "cities")); ok {
+		t.Error("did not expect a collection README on a views-subset run")
+	}
+}
+
+// TestMaterialize_ViewsSubsetLeavesExistingUntouched verifies that a pre-existing
+// non-targeted view file is not rewritten when only another view is targeted.
+func TestMaterialize_ViewsSubsetLeavesExistingUntouched(t *testing.T) {
+	t.Parallel()
+
+	f := newMaterializeFixture(t)
+
+	// Seed large_cities with sentinel content; targeting active_cities must not
+	// rewrite it.
+	largePath := f.templateViewFile("cities", "large_cities.md")
+	sentinel := []byte("SENTINEL-DO-NOT-OVERWRITE\n")
+	if err := os.WriteFile(largePath, sentinel, 0o644); err != nil {
+		t.Fatalf("seed large_cities: %v", err)
+	}
+
+	err := runMaterialize(t, f, "--views=active_cities")
+	if err != nil {
+		t.Fatalf("materialize --views=active_cities: %v", err)
+	}
+
+	got, err := os.ReadFile(largePath)
+	if err != nil {
+		t.Fatalf("read large_cities: %v", err)
+	}
+	if string(got) != string(sentinel) {
+		t.Errorf("large_cities was rewritten; got %q, want sentinel", string(got))
+	}
+}
+
+func TestMaterialize_RecordsDelimiterDisablesDelimiterInViews(t *testing.T) {
+	t.Parallel()
+
+	// Baseline: delimiter enabled by default (all views, includes default INGR view).
+	f := newMaterializeFixture(t)
+	if err := runMaterialize(t, f, "--views"); err != nil {
+		t.Fatalf("baseline materialize: %v", err)
+	}
+	ingrPath := f.viewFile("cities", "cities.ingr")
+	enabled, err := os.ReadFile(ingrPath)
+	if err != nil {
+		t.Fatalf("read baseline INGR view: %v", err)
+	}
+	if !strings.Contains(string(enabled), "#-") {
+		t.Fatalf("expected '#-' delimiter in default INGR output, got:\n%s", enabled)
+	}
+
+	// Disabled run on a fresh fixture.
+	f2 := newMaterializeFixture(t)
+	if err := runMaterialize(t, f2, "--views", "--records-delimiter=-1"); err != nil {
+		t.Fatalf("materialize --records-delimiter=-1: %v", err)
+	}
+	disabled, err := os.ReadFile(f2.viewFile("cities", "cities.ingr"))
+	if err != nil {
+		t.Fatalf("read disabled INGR view: %v", err)
+	}
+	if strings.Contains(string(disabled), "#-") {
+		t.Errorf("expected no '#-' delimiter with --records-delimiter=-1, got:\n%s", disabled)
+	}
+}
+
+func TestMaterialize_RecordsDelimiterNoEffectOnCollectionsOnly(t *testing.T) {
+	t.Parallel()
+
+	// On a single fixture: regenerate READMEs without the flag, then re-run with
+	// --records-delimiter=-1. Because the flag has no effect on collection
+	// READMEs, the second run must leave the file byte-identical (write-only-on-
+	// change). Using the same fixture sidesteps the nondeterministic ordering of
+	// the README "Views" table that two independent fixtures would exhibit.
+	f := newMaterializeFixture(t)
+	if err := runMaterialize(t, f, "--collections"); err != nil {
+		t.Fatalf("materialize --collections: %v", err)
+	}
+	readmeA, ok := f.readme(t, filepath.Join(f.dir, "cities"))
+	if !ok {
+		t.Fatal("expected cities README")
+	}
+
+	if err := runMaterialize(t, f, "--collections", "--records-delimiter=-1"); err != nil {
+		t.Fatalf("materialize --collections --records-delimiter=-1: %v", err)
+	}
+	readmeB, ok := f.readme(t, filepath.Join(f.dir, "cities"))
+	if !ok {
+		t.Fatal("expected cities README")
+	}
+
+	if readmeA != readmeB {
+		t.Errorf("records-delimiter changed collections-only output:\n--- without ---\n%s\n--- with ---\n%s", readmeA, readmeB)
+	}
+
+	// And no INGR view file must be written either way.
+	if f.exists(t, f.viewFile("cities", "cities.ingr")) {
+		t.Error("did not expect a view file on a collections-only run")
+	}
+}

--- a/pkg/ingitdb/docsbuilder/collection_readme.go
+++ b/pkg/ingitdb/docsbuilder/collection_readme.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/ingitdb/ingitdb-cli/pkg/ingitdb"
@@ -67,7 +68,8 @@ func BuildCollectionReadme(ctx context.Context, col *ingitdb.CollectionDef, def 
 		sb.WriteString("\n## Subcollections\n\n")
 		sb.WriteString("| Name | Subcollections |\n")
 		sb.WriteString("|------|----------------|\n")
-		for subID, subCol := range col.SubCollections {
+		for _, subID := range sortedKeys(col.SubCollections) {
+			subCol := col.SubCollections[subID]
 			relPath := subID
 			if col.DirPath != "" && subCol.DirPath != "" {
 				if r, err := filepath.Rel(col.DirPath, subCol.DirPath); err == nil {
@@ -82,7 +84,8 @@ func BuildCollectionReadme(ctx context.Context, col *ingitdb.CollectionDef, def 
 		sb.WriteString("\n## Views\n\n")
 		sb.WriteString("| Name | Columns |\n")
 		sb.WriteString("|------|---------|\n")
-		for viewID, viewDef := range col.Views {
+		for _, viewID := range sortedKeys(col.Views) {
+			viewDef := col.Views[viewID]
 			fmt.Fprintf(&sb, "| %s | %d |\n", viewID, len(viewDef.Columns))
 		}
 	}
@@ -99,6 +102,18 @@ func BuildCollectionReadme(ctx context.Context, col *ingitdb.CollectionDef, def 
 	}
 
 	return sb.String(), nil
+}
+
+// sortedKeys returns the map keys in ascending order so README rendering is
+// deterministic (Go map iteration order is randomized, which would otherwise
+// produce spurious diffs and break write-only-on-change idempotency).
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func formatColumnRow(name string, col *ingitdb.ColumnDef) string {

--- a/spec/features/cli/materialize/README.md
+++ b/spec/features/cli/materialize/README.md
@@ -1,39 +1,152 @@
 # Feature: Materialize Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=request-change) |
-**Status:** Implementing
+**Status:** Approved
+**Source Ideas:** materialize-collections-and-views
+**Supersedes:** —
+**Grade:** A
 
 ## Summary
 
-The `ingitdb materialize` command builds generated artifacts from records: collection `README.md` files (`materialize collection`) and materialized view files under `$views/` (`materialize views`). Both subcommands accept `--path` and may target a subset of inputs.
+The `ingitdb materialize` command regenerates the derived artifacts inGitDB
+builds from its source records: per-collection `README.md` files and
+materialized view files under each view's configured `$views/` directory.
+
+It is a **single flat command** with two selector flags, `--collections`
+and `--views`. Each flag is tri-state: absent, present-without-value
+(= every artifact of that type), or present-with-a-list (= only the named
+ones). Running `ingitdb materialize` with no flags regenerates everything.
+Files are written only when their content differs from what is already on
+disk, so repeated runs are idempotent and produce minimal diffs.
+`materialize --collections` becomes the single supported way to regenerate
+collection READMEs, superseding the deprecated `docs update` command.
 
 ## Problem
 
-inGitDB derives several artifacts from its source records — view outputs and per-collection READMEs. Keeping those derived files up to date by hand is impossible at scale. A dedicated `materialize` command makes regeneration a deliberate, scriptable step that integrates with pull, rebase, and CI.
+inGitDB derives several artifacts from its source records — collection
+READMEs and view outputs. Keeping those up to date by hand is impossible at
+scale. A dedicated `materialize` command makes regeneration a deliberate,
+scriptable step that integrates with pull, rebase, and CI.
+
+Two problems motivated this design. First, README generation and view
+generation were split across two unrelated commands — `docs update
+--collection=GLOB` and `materialize` (views only) — with no way to
+regenerate both, or an arbitrary subset, in one run. Second, an earlier
+`materialize` design used positional subcommands (`materialize collection`,
+`materialize views`) plus a `--views=LIST` flag. That shape was rejected
+because it was internally inconsistent (singular `collection` vs plural
+`views`) and produced redundant invocations like `materialize views
+--views=v1`, where the word "views" appears twice meaning two different
+things. With only two artifact types, two well-named flags on a flat
+command are shorter, composable, and remove the redundancy — and let a
+single command own all derived-artifact regeneration.
 
 ## Behavior
 
 ### Invocation
 
-#### REQ: subcommand-name
+#### REQ: flat-command
 
-The command MUST be invoked as `ingitdb materialize collection` or `ingitdb materialize views`. Each subcommand accepts an optional `--path=PATH` flag.
+The command MUST be invoked as `ingitdb materialize`. It MUST NOT use
+positional subcommands. Artifact type is chosen by the `--collections`
+and/or `--views` flags, never by a positional argument.
 
-### materialize collection
+#### REQ: bare-command-materializes-all
 
-#### REQ: collection-readme
+`ingitdb materialize` with neither `--collections` nor `--views` supplied
+MUST regenerate every artifact of both types: all collection READMEs and
+all materialized views.
 
-`ingitdb materialize collection [--collection=ID]` MUST regenerate the `README.md` file for the named collection, or for every collection when `--collection` is omitted. The file MUST only be written when its content differs from what is already on disk.
+### Selection
 
-### materialize views
+#### REQ: collections-flag
 
-#### REQ: views-output
+`--collections` MUST select collection-README regeneration:
 
-`ingitdb materialize views [--views=LIST] [--records-delimiter=N]` MUST regenerate every materialized view (or only those listed in `--views`) into the `$views/` directory configured for each view. The `--records-delimiter` flag MUST control INGR record-delimiter behavior with values `1` (enabled), `-1` (disabled), and `0` / omitted (use the view/project default; the application default is `1`).
+- present without a value (`--collections`) MUST target every collection.
+- present with a value (`--collections=PATTERNS`) MUST target only the
+  collections whose IDs match `PATTERNS`.
+
+`PATTERNS` is a list of glob patterns separated by `,` (canonical) or `;`.
+Glob semantics MUST match those already accepted by `docs update
+--collection` (e.g. `agile.teams/*`, `agile.teams/**`).
+
+When `--collections` is absent, no collection README MUST be written
+(unless `--views` is also absent, per `req:bare-command-materializes-all`).
+
+#### REQ: views-flag
+
+`--views` MUST select materialized-view regeneration:
+
+- present without a value (`--views`) MUST target every view.
+- present with a value (`--views=PATTERNS`) MUST target only the views
+  whose names match `PATTERNS`.
+
+`PATTERNS` is a list of glob patterns separated by `,` (canonical) or `;`,
+with the same glob semantics as `--collections`.
+
+When `--views` is absent, no view MUST be written (unless `--collections`
+is also absent, per `req:bare-command-materializes-all`).
+
+#### REQ: combined-selection
+
+`--collections` and `--views` MUST be combinable in a single invocation,
+each independently in any of its three states. For example,
+`materialize --views=v1 --collections=c1,c2` MUST regenerate only view
+`v1` and the READMEs of collections `c1` and `c2`.
+
+#### REQ: equals-syntax-for-values
+
+Because each selector flag is tri-state (the bare flag means "all"),
+a list value MUST be attached with `=` (`--views=v1,v2`). The
+space-separated form (`--views v1,v2`) is NOT supported: with a bare flag
+carrying an implicit "all" default, `v1,v2` would be parsed as a
+positional argument rather than the flag's value. Help text MUST document
+the `=` requirement.
+
+### Consolidation
+
+#### REQ: supersedes-docs-update
+
+`materialize --collections` MUST be the single supported way to regenerate
+collection READMEs, routing through the same `docsbuilder` logic that
+`ingitdb docs update --collection` uses today. The `docs update` command
+MUST be marked deprecated, and its help text MUST direct users to
+`ingitdb materialize --collections`.
+
+### Output
+
+#### REQ: write-only-on-change
+
+Each regenerated file MUST be written only when its rendered content
+differs from the file already on disk. Unchanged files MUST be left
+untouched (no rewrite, no mtime churn, no spurious git diff).
+
+#### REQ: records-delimiter
+
+`--records-delimiter=N` MUST control the INGR record-delimiter behavior of
+**view** output only, with values `1` (enabled), `-1` (disabled), and `0`
+/ omitted (use the view/project default; the application default is `1`).
+When the invocation regenerates no views (e.g. `--collections` only), the
+flag MUST have no effect.
+
+#### REQ: success-output
+
+On success `materialize` MUST exit `0`. A summary of how many files were
+created, updated, deleted, and left unchanged MUST be written to stderr.
+stdout MUST stay silent so the command composes in scripts and pipelines.
+
+### Source selection
+
+#### REQ: source-selection
+
+`materialize` MUST accept `--path=PATH` to locate the database directory,
+per [path-targeting](../../path-targeting/README.md). When `--path` is
+omitted, the current working directory is used.
 
 ## Dependencies
 
-- path-targeting
+- [path-targeting](../../path-targeting/README.md) — `--path`.
 
 ## Implementation
 
@@ -42,16 +155,112 @@ Source files implementing this feature (annotated with
 
 - [`cmd/ingitdb/commands/materialize.go`](../../../cmd/ingitdb/commands/materialize.go)
 - [`cmd/ingitdb/commands/view_builder_helper.go`](../../../cmd/ingitdb/commands/view_builder_helper.go)
+- [`cmd/ingitdb/commands/flags.go`](../../../cmd/ingitdb/commands/flags.go)
+- [`cmd/ingitdb/commands/docs.go`](../../../cmd/ingitdb/commands/docs.go)
+- [`cmd/ingitdb/commands/docs_update.go`](../../../cmd/ingitdb/commands/docs_update.go)
+- [`pkg/ingitdb/materializer/view_builder.go`](../../../pkg/ingitdb/materializer/view_builder.go)
+- [`pkg/ingitdb/docsbuilder/update.go`](../../../pkg/ingitdb/docsbuilder/update.go)
+- [`pkg/ingitdb/docsbuilder/collection_readme.go`](../../../pkg/ingitdb/docsbuilder/collection_readme.go)
 
 ## Acceptance Criteria
 
-Not defined yet.
+### AC: bare-materializes-everything
+
+**Requirements:** cli/materialize#req:flat-command, cli/materialize#req:bare-command-materializes-all, cli/materialize#req:write-only-on-change, cli/materialize#req:success-output
+
+Given a database with collections `cities` and `teams` and a materialized
+view `active_cities`, `ingitdb materialize` (no flags) MUST regenerate the
+README of every collection and rebuild every view. Files whose content is
+unchanged MUST NOT be rewritten. The command MUST exit `0`, print a
+created/updated/deleted/unchanged summary to stderr, and write nothing to
+stdout.
+
+### AC: views-only-all
+
+**Requirements:** cli/materialize#req:views-flag
+
+`ingitdb materialize --views` MUST rebuild every materialized view and MUST
+NOT write any collection README.
+
+### AC: collections-only-all
+
+**Requirements:** cli/materialize#req:collections-flag
+
+`ingitdb materialize --collections` MUST regenerate every collection README
+and MUST NOT write any view file.
+
+### AC: views-subset
+
+**Requirements:** cli/materialize#req:views-flag
+
+Given views `active_cities` and `large_cities`,
+`ingitdb materialize --views=active_cities` MUST rebuild only
+`active_cities`. `large_cities` and all collection READMEs MUST be left
+untouched.
+
+### AC: collections-glob-targeting
+
+**Requirements:** cli/materialize#req:collections-flag
+
+Given nested collections `agile.teams/alpha` and `agile.teams/beta`,
+`ingitdb materialize --collections='agile.teams/**'` MUST regenerate the
+READMEs of both. `ingitdb materialize --collections='cities;teams'`
+(semicolon-separated) MUST target collections `cities` and `teams`.
+
+### AC: combined-subset
+
+**Requirements:** cli/materialize#req:combined-selection
+
+`ingitdb materialize --views=active_cities --collections=cities,teams` MUST
+rebuild only view `active_cities` and only the READMEs of collections
+`cities` and `teams`. No other artifact MUST be written.
+
+### AC: equals-syntax-required
+
+**Requirements:** cli/materialize#req:equals-syntax-for-values
+
+`ingitdb materialize --views=active_cities` MUST target view
+`active_cities`. The space-separated form
+`ingitdb materialize --views active_cities` MUST NOT bind `active_cities`
+to `--views` (it is treated as a positional argument and rejected); the
+bare `--views` form means "all views".
+
+### AC: docs-update-deprecated
+
+**Requirements:** cli/materialize#req:supersedes-docs-update
+
+`ingitdb docs update --help` MUST display a deprecation notice directing
+users to `ingitdb materialize --collections`. For the same glob,
+`ingitdb materialize --collections=GLOB` MUST produce the identical README
+output that `ingitdb docs update --collection=GLOB` produced.
+
+### AC: idempotent-second-run
+
+**Requirements:** cli/materialize#req:write-only-on-change
+
+Running `ingitdb materialize` twice in a row MUST result in zero files
+written on the second run (all reported as unchanged), because no source
+records changed between runs.
+
+### AC: records-delimiter-applies-to-views
+
+**Requirements:** cli/materialize#req:records-delimiter
+
+`ingitdb materialize --views --records-delimiter=-1` MUST disable the
+`#-` record delimiter in regenerated INGR view output.
+`ingitdb materialize --collections --records-delimiter=-1` MUST behave
+identically to `ingitdb materialize --collections` (the flag has no effect
+when no view is regenerated).
 
 ## Open Questions
 
-- Acceptance criteria not yet defined for this feature.
-- Should `materialize` support `--remote` to write generated files back to a remote repository in a single commit?
-- Should there be a `materialize all` that runs both subcommands in dependency order?
+- Should `docs update` be removed outright, or kept as a thin deprecated
+  alias that forwards to `materialize --collections` for one release before
+  removal? Decide at plan time; grep CI configs and docs for existing
+  `docs update` usage before choosing hard removal.
+- Should `materialize` support `--remote` to write generated files back to
+  a remote repository in a single commit (as `drop` does)? Deferred to a
+  follow-up after the local MVP lands.
 
 ---
 *This document follows the https://specscore.md/feature-specification*

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -18,6 +18,7 @@ Use `specscore idea new <slug>` to scaffold a new idea.
 | [derived-record-keys](derived-record-keys.md) | Approved | 2026-05-30 | alexander.trakhimenok@gmail.com | — |
 | [list-of-records-files](list-of-records-files.md) | Approved | 2026-05-29 | alexander.trakhimenok@gmail.com | — |
 | [markdown-insert-ux](markdown-insert-ux.md) | Draft | 2026-05-12 | alexander.trakhimenok@gmail.com | — |
+| [materialize-collections-and-views](materialize-collections-and-views.md) | Specified | 2026-06-04 | alexander.trakhimenok@gmail.com | cli/materialize |
 | [scripted-formulas-and-views](scripted-formulas-and-views.md) | Implemented | 2026-06-02 | alexander.trakhimenok@gmail.com | computed-columns |
 | [where-like-regex](where-like-regex.md) | Draft | 2026-05-12 | alexander.trakhimenok@gmail.com | — |
 

--- a/spec/ideas/materialize-collections-and-views.md
+++ b/spec/ideas/materialize-collections-and-views.md
@@ -1,0 +1,67 @@
+# Idea: Unified materialize command for collections and views
+
+**Status:** Specified
+**Date:** 2026-06-04
+**Owner:** alexander.trakhimenok@gmail.com
+**Promotes To:** cli/materialize
+**Supersedes:** —
+**Related Ideas:** —
+
+## Problem Statement
+
+How might we let users regenerate any subset of inGitDB's derived artifacts — collection READMEs and materialized views — with one consistent, memorable command?
+
+## Context
+
+inGitDB derives two kinds of artifacts from source records: per-collection `README.md` files and materialized view files under each view's configured `$views/` directory. Today these are produced by two unrelated commands — `ingitdb materialize` (views only; its `--views` flag is a registered no-op) and `ingitdb docs update --collection=GLOB` (collection READMEs, via the `docsbuilder` package). There is no single command to regenerate "everything derived," and no way to regenerate one collection's README and one view in the same run.
+
+This Idea supersedes the sidekick seed `materialize-subcommands-and-collection-targeting`, whose original framing ("implement `materialize collection` / `materialize views` subcommands, or reconcile the spec to the flat command") was overtaken during design discussion: subcommands were rejected outright. The feature spec at `spec/features/cli/materialize/README.md` has already been rewritten around the flat-flag design this Idea records.
+
+## Recommended Direction
+
+Make `ingitdb materialize` a single flat command that regenerates both artifact types, selected by two tri-state flags: `--collections` and `--views`. Each flag has three states — absent (don't touch that type), present without a value (every artifact of that type), or present with a value (only the named ones). Bare `ingitdb materialize` with no flags regenerates everything. The two flags compose freely, so `materialize --views=active_cities --collections=cities,teams` rebuilds exactly one view and two READMEs in one pass. Files are written only when content differs, keeping runs idempotent and diffs minimal.
+
+Both flag values are a list of glob patterns, separated by comma (canonical) or semicolon — e.g. `--collections='agile.teams/**,cities'`. This carries over the glob power that `docs update --collection` already has, while matching the list shape we want for `--views`. Because each flag is tri-state with a bare-flag "all" meaning, list values must be attached with `=` (`--views=v1,v2`); the space-separated form is not supported. This is the standard pflag `NoOptDefVal` mechanism and will be documented in help text.
+
+Collection-README generation moves into `materialize --collections`, and `docs update` is deprecated in favor of it — one command owns all derived-artifact regeneration. The redundant idea of a separate `materialize all` is dropped, since bare `materialize` already means all. Two named flags beat both the rejected positional-subcommand shape (which produced the absurd `materialize views --views=v1`) and a generic single `--target` flag (which would bury type and instance in one opaque value).
+
+## Alternatives Considered
+
+- **Positional subcommands** (`materialize collection` / `materialize views`, each with its own selector flag). Lost because the singular/plural pairing was inconsistent with the codebase's own convention (`list collections`, `drop view <name>`), and the subset form was redundant: `materialize views --views=v1` says "views" twice meaning two different things. With only two artifact types, the subcommand ceremony buys nothing.
+- **Keep `materialize` and `docs update` as separate commands.** Lost because two commands regenerating overlapping derived files is exactly the seam that drifts — users would not know which to run, and CI would have to call both. Folding into one command is the simplification.
+- **A generic single target flag** (`--target=views:v1,collections:c1`). Lost because it pushes a type-and-instance sub-grammar into a flag value, which is harder to read, remember, and tab-complete than two plainly named flags.
+
+## MVP Scope
+
+A single flat `ingitdb materialize` that: (1) regenerates all collection READMEs and all views when run bare; (2) honors `--collections` and `--views` in all three states, each accepting a comma/semicolon glob list with `=`-attached values; (3) writes only changed files; (4) routes README generation through the existing `docsbuilder` and views through the existing `materializer`, with `docs update` marked deprecated. Local working tree only. Done when the rewritten `spec/features/cli/materialize` acceptance criteria pass.
+
+## Not Doing (and Why)
+
+- Positional subcommands (materialize collection / materialize views) — rejected: inconsistent plurality and redundant invocations like 'materialize views --views=v1'
+- A separate 'materialize all' subcommand — redundant: bare 'materialize' already means all
+- --remote write-back in a single commit — deferred to a follow-up; MVP targets the local working tree only
+- A generic single target flag (e.g. --target=views:v1) — rejected: a sub-grammar in the value is harder to read than two named flags
+
+## Key Assumptions to Validate
+
+| Tier | Assumption | How to validate |
+|------|------------|-----------------|
+| Must-be-true | pflag's `NoOptDefVal` cleanly supports the absent / bare / `=value` tri-state per flag, and the `=`-only value syntax is acceptable to users | spike the flag wiring; confirm `--views`, `--views=a,b`, and omission are distinguishable, and `--views a,b` fails predictably |
+| Should-be-true | `docsbuilder.UpdateDocs` (README generation) and `materializer.BuildViews` can be driven from one command without refactoring their cores | trace both call paths; confirm both accept a path + selection and report a `MaterializeResult` |
+| Should-be-true | a glob list is the right targeting grammar for both flags (vs plain IDs) | confirm `docs update`'s existing glob semantics map onto `--collections` and read naturally for `--views` |
+| Might-be-true | nobody depends on `docs update` as a stable scripted entry point that a deprecation would break | grep CI configs and docs for `docs update` usage |
+
+## SpecScore Integration
+
+- **New Features this would create:** none — folds into the existing `cli/materialize` feature
+- **Existing Features affected:** `cli/materialize` (rewritten around this design); `docs update` (deprecated, folded in)
+- **Dependencies:** `path-targeting` (the `--path` flag)
+
+## Open Questions
+
+- Should `docs update` be removed outright or kept as a thin deprecated alias that forwards to `materialize --collections` for one release? Settle at spec/plan time.
+- Should `--remote` write-back (single commit to a remote repo, as `drop` supports) be a fast follow after the local MVP lands?
+- When an invocation regenerates no views (e.g. `--collections` only), should `--records-delimiter` be silently ignored or warn? Lean toward the existing applicability-check pattern.
+
+---
+*This document follows the https://specscore.md/idea-specification*

--- a/spec/ideas/seeds/materialize-subcommands-and-collection-targeting.md
+++ b/spec/ideas/seeds/materialize-subcommands-and-collection-targeting.md
@@ -5,9 +5,11 @@ captured_at: 2026-06-03T16:54:53Z
 captured_by: claude
 captured_during: null
 trigger: explicit
-status: queued
+status: promoted
 synchestra_task: null
 ---
 # Implement materialize subcommands (collection/views) and the --collection / --views targeting, or reconcile the spec to the flat command
+
+> **Promoted** to Idea [`materialize-collections-and-views`](../materialize-collections-and-views.md) on 2026-06-04. The subcommand framing was rejected in favor of a flat command with tri-state `--collections` / `--views` flags; the `cli/materialize` feature spec was rewritten accordingly.
 
 Gap found verifying cli/materialize (1/3 REQs). The spec mandates `ingitdb materialize collection` and `ingitdb materialize views` subcommands; the code is a single flat `materialize` command (`materialize.go`) that only rebuilds views. The `--views=LIST` flag is registered (`flags.go`) but never read (dead no-op), there is no `--collection` flag, and there is no CLI path to regenerate a single collection's README (README rendering exists in `materializer/view_builder.go` but isn't wired to a `materialize collection` subcommand). Either implement the subcommands + flags (with tests) or update the spec to match the flat command. Spec Implementation list also omits `ci.go`/`flags.go`. Blocks cli/materialize → Stable.

--- a/spec/plans/2026-06-04-cli-materialize.md
+++ b/spec/plans/2026-06-04-cli-materialize.md
@@ -1,0 +1,154 @@
+# cli/materialize — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Each task ends with a build + `go test ./...` + `golangci-lint run` gate and a commit whose message cites the satisfied AC IDs.
+
+**Goal:** Reshape `ingitdb materialize` into a single flat command that regenerates both derived-artifact types — collection `README.md` files and materialized views — selected by two tri-state flags `--collections` and `--views`. Bare `materialize` regenerates everything. Each flag is absent / bare (`=all`) / `=<glob-list>` (comma- or semicolon-separated). Collection-README generation folds in from `docs update`, which becomes deprecated. Local working tree only.
+
+**Architecture:** `cmd/ingitdb/commands/materialize.go` gets its own flag set and a new run function that (a) resolves each flag's tri-state into a selection, (b) routes collection selections through `pkg/ingitdb/docsbuilder` (the same engine `docs update` uses) and view selections through `pkg/ingitdb/materializer`, and (c) aggregates one `ingitdb.MaterializeResult` summary to stderr. Tri-state is implemented with pflag `NoOptDefVal` (a sentinel meaning "all"), which forces `=`-attached list values. Glob lists are split on `,`/`;`; collection patterns reuse `docsbuilder.ResolveCollections` (`**`, `path/*`, `path/**`, exact); view patterns match against view names.
+
+**Decoupling note:** `addMaterializeFlags` and `materializeRunE` are currently **shared with the `ci` command** (`ci.go`). This plan introduces a materialize-specific flag set and run function and leaves `ci` on the existing views-only path untouched, so CI behavior does not change.
+
+**Tech Stack:** Go stdlib (`os`, `path/filepath`, `strings`), `github.com/spf13/cobra` / `pflag`, the project's `pkg/ingitdb`, `pkg/ingitdb/materializer`, and `pkg/ingitdb/docsbuilder` packages.
+
+**Spec:** `spec/features/cli/materialize/README.md` (Source Idea: `spec/ideas/materialize-collections-and-views.md`)
+
+---
+
+## File Map
+
+| Action | File | Change |
+|--------|------|--------|
+| Modify | `cmd/ingitdb/commands/materialize.go` | Own flag set; new run func with tri-state selection + dual dispatch (docsbuilder + materializer) |
+| Create | `cmd/ingitdb/commands/materialize_selection.go` | Pure helpers: flag-state resolution, `,`/`;` list split, view-name glob match |
+| Create | `cmd/ingitdb/commands/materialize_selection_test.go` | Unit tests for the pure helpers |
+| Modify | `cmd/ingitdb/commands/materialize_test.go` | Integration tests for each AC |
+| Modify | `cmd/ingitdb/commands/flags.go` | Add `addMaterializeCommandFlags` (materialize-only); leave `addMaterializeFlags` for `ci` |
+| Modify | `cmd/ingitdb/commands/docs_update.go` | Mark `docs update` deprecated, point to `materialize --collections` |
+| Modify | `cmd/ingitdb/main.go` | Pass the docs/records reader into `Materialize` so it can drive `docsbuilder` |
+
+**Reused (no edits):** `pkg/ingitdb/docsbuilder/update.go` (`UpdateDocs`, `ResolveCollections`), `pkg/ingitdb/materializer/view_builder.go` (`BuildViews`), `cobra_helpers.go` (`resolveDBPath`).
+
+**Untouched:** `ci.go` (stays on the existing views-only `materializeRunE`), all other commands, the dalgo packages.
+
+---
+
+## Task 1 — Materialize-specific tri-state flags
+
+**Context:** Give `materialize` its own flags without disturbing `ci`. Register `--collections` and `--views` as `String` flags, then set each flag's `NoOptDefVal` to a sentinel (e.g. `"\x00all"`) so the bare flag means "all" and list values require `=`. Keep `--path` and `--records-delimiter`. Help text documents the `=` requirement.
+
+**Files:** `flags.go`, `materialize.go`, `materialize_test.go`
+
+- [ ] **Step 1.1 — Failing test:** assert `materialize` registers `collections`, `views`, `path`, `records-delimiter`; assert each selector flag's `NoOptDefVal` is the all-sentinel; assert `--views=a,b` yields the value `a,b` while bare `--views` yields the sentinel and `--views a,b` leaves `a,b` as a positional arg.
+- [ ] **Step 1.2 — Confirm failure** (`go test -run TestMaterialize_Flags ./cmd/ingitdb/commands/`).
+- [ ] **Step 1.3 — Implement** `addMaterializeCommandFlags(cmd)` in `flags.go`; switch `Materialize(...)` in `materialize.go` to use it and set `NoOptDefVal` on both selector flags. Leave `addMaterializeFlags` (used by `ci`) unchanged.
+- [ ] **Step 1.4 — Build + test + lint + commit.**
+
+**Verifies:** cli/materialize#ac:equals-syntax-required
+
+---
+
+## Task 2 — Selection helpers (pure functions)
+
+**Context:** Isolate the decision logic so it is unit-testable without cobra. Implement: `flagSelection(changed bool, raw string) selection` returning one of `{none, all, list([]string)}` based on absent / sentinel / value; `splitPatterns(raw string) []string` splitting on `,` and `;` and trimming; `matchViewNames(names []string, patterns []string) []string` for view-name glob matching. Collection patterns are delegated to `docsbuilder.ResolveCollections` and need no new matcher.
+
+**Files:** `materialize_selection.go`, `materialize_selection_test.go`
+
+- [ ] **Step 2.1 — Failing tests:** table-driven cases for each selection state; `splitPatterns("a, b;c")` → `[a b c]`; view-name matching for exact, `*`, and multi-pattern inputs.
+- [ ] **Step 2.2 — Confirm failure.**
+- [ ] **Step 2.3 — Implement** the three pure helpers.
+- [ ] **Step 2.4 — Build + test + lint + commit.**
+
+**Verifies:** cli/materialize#ac:views-subset, cli/materialize#ac:collections-glob-targeting
+
+---
+
+## Task 3 — Collections README path (fold in docsbuilder)
+
+**Context:** When the collections selection is `all`, regenerate every collection README; when it is a glob list, call `docsbuilder.UpdateDocs` once per pattern (`all` maps to the `**` pattern) and merge the `MaterializeResult`s. `main.go` must hand `Materialize` a `RecordsReader` (use `materializer.NewFileRecordsReader()`), matching what `docs update` passes today.
+
+**Files:** `materialize.go`, `main.go`, `materialize_test.go`
+
+- [ ] **Step 3.1 — Failing test:** `materialize --collections` regenerates all collection READMEs and writes no view file; `--collections='agile.teams/**'` regenerates nested collections; `--collections='cities;teams'` targets exactly those two.
+- [ ] **Step 3.2 — Confirm failure.**
+- [ ] **Step 3.3 — Implement** the collections branch calling `docsbuilder.UpdateDocs` per resolved pattern; wire the reader through `main.go`.
+- [ ] **Step 3.4 — Build + test + lint + commit.**
+
+**Verifies:** cli/materialize#ac:collections-only-all, cli/materialize#ac:collections-glob-targeting
+
+---
+
+## Task 4 — Views path with subset filtering
+
+**Context:** When the views selection is `all`, keep today's behavior (`BuildViews` per collection). When it is a glob list, build only views whose names match (filter via `matchViewNames` from Task 2, building per matched view). `--records-delimiter` applies only on this path (set `def.RuntimeOverrides.RecordsDelimiter` as today); when no view is regenerated it has no effect.
+
+**Files:** `materialize.go`, `materialize_test.go`
+
+- [ ] **Step 4.1 — Failing test:** `materialize --views` rebuilds all views and no README; `--views=active_cities` rebuilds only that view; `--views --records-delimiter=-1` disables the `#-` delimiter in INGR output; `--collections --records-delimiter=-1` behaves identically to `--collections` alone.
+- [ ] **Step 4.2 — Confirm failure.**
+- [ ] **Step 4.3 — Implement** the views branch with name-glob filtering and records-delimiter applicability.
+- [ ] **Step 4.4 — Build + test + lint + commit.**
+
+**Verifies:** cli/materialize#ac:views-only-all, cli/materialize#ac:views-subset, cli/materialize#ac:records-delimiter-applies-to-views
+
+---
+
+## Task 5 — Unified dispatch, defaults, and summary
+
+**Context:** Tie the branches together. Bare `materialize` (both selections `none`) defaults to `all` for both types. Combined flags run both branches. Aggregate a single `ingitdb.MaterializeResult`, print a `created/updated/deleted/unchanged` summary to **stderr**, write nothing to stdout, exit `0`. Write-only-on-change is already provided by both engines; a second run reports all-unchanged.
+
+**Files:** `materialize.go`, `materialize_test.go`
+
+- [ ] **Step 5.1 — Failing test:** bare `materialize` regenerates all READMEs + all views, summary on stderr, empty stdout, exit 0; `--views=v1 --collections=c1,c2` touches only those; running twice writes zero files the second time.
+- [ ] **Step 5.2 — Confirm failure.**
+- [ ] **Step 5.3 — Implement** the default-to-all logic, dual-branch invocation, result aggregation, and stderr summary.
+- [ ] **Step 5.4 — Build + test + lint + commit.**
+
+**Verifies:** cli/materialize#ac:bare-materializes-everything, cli/materialize#ac:combined-subset, cli/materialize#ac:idempotent-second-run
+
+---
+
+## Task 6 — Deprecate `docs update`
+
+**Context:** Set the `docs update` cobra command's `Deprecated` field (and/or a help note) directing users to `ingitdb materialize --collections`. Confirm output parity: `materialize --collections=GLOB` produces the same README bytes that `docs update --collection=GLOB` produced (both call `docsbuilder` with the same glob). Add a short hint guarding the `--collections` (plural) vs the old `--collection` (singular) name confusion (reviewer advisory).
+
+**Files:** `docs_update.go`, `materialize_test.go`
+
+- [ ] **Step 6.1 — Failing test:** `docs update --help` shows a deprecation notice naming `materialize --collections`; a parity test asserts identical README output between the two commands for one glob.
+- [ ] **Step 6.2 — Confirm failure.**
+- [ ] **Step 6.3 — Implement** the deprecation notice.
+- [ ] **Step 6.4 — Build + test + lint + commit.**
+
+**Verifies:** cli/materialize#ac:docs-update-deprecated
+
+---
+
+## Self-Review
+
+**AC coverage.** Every AC in `spec/features/cli/materialize/README.md` is covered by a task:
+
+| AC | Task |
+|----|------|
+| `equals-syntax-required` | 1 |
+| `views-subset` | 2, 4 |
+| `collections-glob-targeting` | 2, 3 |
+| `collections-only-all` | 3 |
+| `views-only-all` | 4 |
+| `records-delimiter-applies-to-views` | 4 |
+| `bare-materializes-everything` | 5 |
+| `combined-subset` | 5 |
+| `idempotent-second-run` | 5 |
+| `docs-update-deprecated` | 6 |
+
+No ACs deferred.
+
+**Order/dependencies.** 1 (flags) → 2 (pure helpers) → 3 (collections) and 4 (views, uses Task 2's matcher) → 5 (dispatch, needs 3 + 4) → 6 (deprecation). Linear, no gaps; each task depends only on earlier ones.
+
+**Known risks.** (1) View-name subset filtering has no existing materializer entry point that takes a name filter — Task 4 must build per matched view or add a thin filter; if `BuildViews` cannot be cleanly narrowed, fall back to building the collection's full view set and document the over-build. (2) `NoOptDefVal` removes the space-separated value form — intended, asserted in Task 1.
+
+## Open Questions
+
+- The `success-output` summary reports a `deleted` count, but no AC exercises deletion (stale view output removed when a view's output set shrinks). If deletion is in scope, add a deletion test in Task 5; otherwise drop `deleted` from the summary wording. (Reviewer advisory carried from specify.)
+- `docs update` removal vs deprecated-alias: this plan only deprecates (keeps it working). Decide hard-removal in a follow-up after grepping CI/docs for `docs update` usage.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/README.md
+++ b/spec/plans/README.md
@@ -12,6 +12,7 @@ verifiable tasks with clear acceptance criteria and dependency ordering.
 | [2026-05-12-create-record-stdin-edit](2026-05-12-create-record-stdin-edit.md) | cli/create-record | Ready |
 | [dalgo2ingitdb-referential-integrity](dalgo2ingitdb-referential-integrity.md) | dalgo2ingitdb-referential-integrity | Approved |
 | [2026-06-03-computed-columns-via-dalgo](2026-06-03-computed-columns-via-dalgo.md) | computed-columns-via-dalgo | Draft |
+| [2026-06-04-cli-materialize](2026-06-04-cli-materialize.md) | cli/materialize | Approved |
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

Reshapes `ingitdb materialize` into a single flat command that regenerates **both** derived-artifact types — collection `README.md` files and materialized views — selected by two tri-state flags `--collections` and `--views`. Bare `materialize` regenerates everything. Collection-README generation is folded in from `docs update`, which is now deprecated.

Full spec-driven trail: seed → Idea → Feature (Grade A) → Plan (reviewer A) → implementation.

- Idea: `spec/ideas/materialize-collections-and-views.md`
- Feature: `spec/features/cli/materialize/README.md` (9 REQs, 10 ACs)
- Plan: `spec/plans/2026-06-04-cli-materialize.md`

## Behavior

| Command | Effect |
|---|---|
| `materialize` | all collection READMEs + all views |
| `materialize --views` / `--collections` | all of that type |
| `materialize --views=v1,v2` | only those views (glob list, `,` or `;`) |
| `materialize --collections='agile.teams/**'` | nested collection READMEs |
| `materialize --views=v1 --collections=c1,c2` | both, narrowed |

Each selector flag is tri-state (absent / bare = all / `=<glob-list>`), implemented via pflag `NoOptDefVal`; list values require `=` (the space form is intentionally unsupported, documented in help).

## Key decisions

- **Rejected** positional subcommands (`materialize collection|views`) — inconsistent plurality and redundant `materialize views --views=v1`.
- **`docs update` deprecated**, pointing to `materialize --collections` (same `docsbuilder` engine).
- **`ci` left untouched** on its existing views-only path (the shared run func was decoupled).
- `--records-delimiter` applies to views only.

## Notable fix

Found and fixed a real non-determinism bug: `docsbuilder.BuildCollectionReadme` iterated maps in randomized order, breaking write-only-on-change. Now sorted; idempotency holds.

## Verification

- `go build ./...` OK · `go test ./...` exit 0 (20 pkgs) · `golangci-lint run` 0 issues
- 10/10 acceptance criteria covered by tests (incl. sentinel-byte "untouched" check for view subsets, idempotent second run, output parity with `docs update`)
- Real-binary checks: deprecation notice renders, `=` requirement in help, `ci` flags unchanged

## Deferred (documented open questions)

- Hard-removal vs deprecated-alias for `docs update` (currently deprecated, still works)
- `--remote` write-back
- `deleted` summary count has no dedicated test (deletion logic is in upstream engines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)