### PR TITLE
docs: refresh materialize CLI docs + fix stale test-data reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,8 @@ The codebase has two main packages:
   been removed; see `spec/features/cli/{select,insert,update,delete,drop}/`
   for the current specifications.
 
-Test data lives in `test-ingitdb/` and `.ingitdb.yaml` at the repo root points to it.
+Tests construct their database fixtures in temporary directories (`t.TempDir()`); there is
+no committed sample database. The repo dogfoods its own configuration under `.ingitdb/`.
 
 ## Code Conventions
 

--- a/docs/cli/commands/docs.md
+++ b/docs/cli/commands/docs.md
@@ -2,7 +2,12 @@
 
 Manage documentation.
 
-## 🔸 docs update
+## 🔸 docs update _(deprecated)_
+
+> ⚠️ **Deprecated** — use [`ingitdb materialize --collections`](materialize.md) instead
+> (note the plural flag name). `docs update` still works but will be removed in a future
+> release; it now regenerates the same collection READMEs that `materialize --collections`
+> produces.
 
 ```shell
 ingitdb docs update [--path=PATH] [--collection=ID]

--- a/docs/cli/commands/materialize.md
+++ b/docs/cli/commands/materialize.md
@@ -1,47 +1,72 @@
-### 🧾 materialize` — build generated files from records _(not yet implemented)_
+### 🧾 materialize` — regenerate derived files from records
 
 [Source Code](../../../cmd/ingitdb/commands/materialize.go)
 
-Top-level command with subcommands for materializing views and README files.
-
-#### 🔸 materialize collection`
-
-```
-ingitdb materialize collection [--collection=ID] [--path=PATH]
-```
-
-Renders the `README.md` file for a collection. If the generated content differs from the existing file, it is automatically updated. See [Collection README Builder](../components/readme-builders/collection.md) for details on what is included in the generated README.
-
-| Flag              | Description                                                                                             |
-| ----------------- | ------------------------------------------------------------------------------------------------------- |
-| `--collection=ID` | Collection ID to materialize (e.g. `countries`). If omitted, READMEs for all collections are processed. |
-| `--path=PATH`     | Path to the database directory. Defaults to the current working directory.                              |
-
-#### 🔸 materialize views`
+A single flat command that regenerates inGitDB's derived artifacts: per-collection
+`README.md` files and materialized view files under each view's configured `$views/`
+directory. Run with no flags it regenerates **everything**; the `--collections` and
+`--views` flags narrow what is regenerated. Files are written only when their content
+differs from what is already on disk, so repeated runs are idempotent.
 
 ```
-ingitdb materialize views [--path=PATH] [--views=VIEW1,VIEW2,...] [--records-delimiter=N]
+ingitdb materialize [--collections[=GLOB[,GLOB...]]] [--views[=GLOB[,GLOB...]]] [--records-delimiter=N] [--path=PATH]
 ```
 
-| Flag                      | Description                                                                                                                                                   |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--path=PATH`             | Path to the database directory. Defaults to the current working directory.                                                                                    |
-| `--views=LIST`            | Comma-separated list of view names to materialize. Without this flag, all views are materialized.                                                             |
-| `--records-delimiter=N`   | Override the `#-` delimiter behaviour for INGR output. `1` = enabled, `-1` = disabled, `0` or omitted = use view/project default (app default is `1`). |
+#### Selection flags
 
-Output is written into the `$views/` directory defined in the collection's view definition.
+`--collections` and `--views` are each **tri-state**:
+
+- **absent** — that artifact type is not touched.
+- **bare flag** (`--collections`) — every artifact of that type.
+- **with a value** (`--collections=GLOB[,GLOB...]`) — only the matching ones.
+
+Running `ingitdb materialize` with **neither** flag regenerates all collection READMEs
+**and** all views.
+
+> ⚠️ Because the bare flag means "all", a value MUST be attached with `=` — use
+> `--views=v1,v2`, **not** `--views v1,v2` (the space-separated form is parsed as a
+> positional argument).
+
+| Flag                    | Description                                                                                                                                                |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--collections[=GLOB]`  | Regenerate collection `README.md` files. Bare = all collections; `=GLOB[,GLOB]` = matching collection IDs. Patterns are separated by `,` (canonical) or `;`. |
+| `--views[=GLOB]`        | Regenerate materialized views. Bare = all views; `=GLOB[,GLOB]` = matching view names. Same separators as `--collections`.                                  |
+| `--records-delimiter=N` | Override the `#-` delimiter behaviour for INGR **view** output. `1` = enabled, `-1` = disabled, `0` or omitted = use view/project default (app default `1`). No effect when only collections are regenerated. |
+| `--path=PATH`           | Path to the database directory. Defaults to the current working directory.                                                                                |
+
+Glob semantics match those used by collection targeting elsewhere: `**` (all), `path/*`
+(direct subcollections), `path/**` (recursive), or an exact ID. View output is written
+into the `$views/` directory defined in each view's definition. A summary of
+created/updated/deleted/unchanged files is printed to stderr; stdout stays silent for
+scriptability.
 
 **Examples:**
 
 ```shell
-# 🧾 Rebuild all views
+# 🧾 Regenerate everything (all collection READMEs + all views)
 ingitdb materialize
 
-# 🔁 Rebuild specific views only
+# 📄 All collection READMEs only
+ingitdb materialize --collections
+
+# 🔁 All views only
+ingitdb materialize --views
+
+# 🔁 Specific views (note the '=')
 ingitdb materialize --views=by_status,by_assignee
 
-# 🔁 Rebuild views for a database at a specific path
+# 📄 Specific collections, including nested ones, via globs
+ingitdb materialize --collections='agile.teams/**,countries'
+
+# 🎯 Mix: one view plus two collection READMEs in one run
+ingitdb materialize --views=by_status --collections=countries,teams
+
+# 🔁 Target a database at a specific path
 ingitdb materialize --path=/var/db/myapp
 ```
+
+> ℹ️ Collection-README regeneration was previously a separate command,
+> [`docs update`](docs.md), which is now **deprecated** in favour of
+> `materialize --collections`.
 
 ---


### PR DESCRIPTION
Follow-up to #94 (unified `materialize` command).

## What changed

- **`docs/cli/commands/materialize.md`** — rewritten for the shipped design: flat command, tri-state `--collections`/`--views` glob-list flags, bare = all, the `=`-required value syntax, combined usage, and examples. Removes the obsolete "not yet implemented" `materialize collection` / `materialize views` subcommand docs.
- **`docs/cli/commands/docs.md`** — `docs update` marked deprecated, pointing to `materialize --collections`.
- **`CLAUDE.md`** — corrected the stale "Test data lives in `test-ingitdb/`" line; that directory was restructured away and tests now build fixtures in `t.TempDir()`.

## Not touched

- `.claude/agents/` — checked; only `schema-designer` mentions *materialized views* as a schema concept, not the CLI command flags, so no change needed.
- Any external AI-skills repository is out of scope here (see PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)