### PR TITLE
docs: link to ingitdb-ai-skills plugin; fix stale materialize row

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ languages:
 | [`drop`](docs/cli/commands/drop.md)               | ✅ done    | Drop a collection or view definition                     |
 | [`list collections`](docs/cli/commands/list.md)   | ✅ done    | List collection IDs (local or remote)                    |
 | `list views`                                      | 🟡 planned | List view definitions                                    |
-| [`materialize`](docs/cli/commands/materialize.md) | 🟡 planned | Build materialized views into `$views/`                  |
+| [`materialize`](docs/cli/commands/materialize.md) | ✅ done    | Regenerate collection READMEs and materialized views     |
 | [`diff`](docs/cli/commands/diff.md)               | ✅ done    | Show record-level changes between two git refs           |
 | [`pull`](docs/cli/commands/pull.md)               | ✅ done    | Pull remote changes, resolve conflicts, and rebuild views |
 | [`resolve`](docs/cli/commands/resolve.md)         | 🟡 planned | Interactive TUI for resolving data-file merge conflicts  |
@@ -265,6 +265,7 @@ See the [CLI reference](docs/cli/) for flags and examples.
 | [CLI reference](docs/cli/)                                    | Every subcommand, flag, and exit code                                |
 | [Architecture](docs/ARCHITECTURE.md)                          | CLI component architecture and package map                           |
 | [Contributing](docs/CONTRIBUTING.md)                          | How to open issues and submit pull requests                          |
+| [Claude Code AI plugin](https://github.com/ingitdb/ingitdb-ai-skills) | Agent skills that teach AI tools how to drive the `ingitdb` CLI |
 
 ## 📐 Specification
 

--- a/spec/features/cli/README.md
+++ b/spec/features/cli/README.md
@@ -5,6 +5,10 @@ This directory contains feature specifications for individual `ingitdb` CLI subc
 Each subdirectory corresponds to one command. Older verb-noun specs (e.g. `create-record`)
 are kept as historical records and are marked **Superseded** in the index below.
 
+Many of these commands are also exposed to AI agents as Claude Code skills in the
+[ingitdb-ai-skills](https://github.com/ingitdb/ingitdb-ai-skills) plugin, which wraps the
+CLI surface; keep those skills in sync when a command's flags or behavior change here.
+
 ## Contents
 
 | Child | Description |


### PR DESCRIPTION
Follow-up to #94 / #95.

- **README.md** — adds the **Claude Code AI plugin** ([ingitdb-ai-skills](https://github.com/ingitdb/ingitdb-ai-skills)) to the Documentation table, and fixes the `materialize` command row (was "🟡 planned / Build materialized views into `$views/`" → "✅ done / Regenerate collection READMEs and materialized views").
- **spec/features/cli/README.md** — notes that CLI commands are wrapped as agent skills in `ingitdb-ai-skills`, with a reminder to keep them in sync when flags/behavior change.

`specscore spec lint` → 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)