### PR TITLE
docs(spec): mark serve/watch features as Withdrawn

### DIFF
--- a/spec/features/cli/README.md
+++ b/spec/features/cli/README.md
@@ -36,8 +36,8 @@ CLI surface; keep those skills in sync when a command's flags or behavior change
 | [materialize](materialize/README.md) | Draft | `ingitdb materialize` |
 | [diff](diff/README.md) | Draft | `ingitdb diff` |
 | [pull](pull/README.md) | Draft | `ingitdb pull` |
-| [watch](watch/README.md) | Draft | `ingitdb watch` |
-| [serve](serve/README.md) | Draft | `ingitdb serve` |
+| [watch](watch/README.md) | Withdrawn (deferred) | `ingitdb watch` (not implemented) |
+| [serve](serve/README.md) | Withdrawn — removed from CLI (ADR 0001) | `ingitdb serve` (removed) |
 | [resolve](resolve/README.md) | Draft | `ingitdb resolve` |
 | [setup](setup/README.md) | Draft | `ingitdb setup` |
 | [find](find/README.md) | Withdrawn — moved to DataTug CLI | `ingitdb find` (not implemented) |

--- a/spec/features/cli/serve/README.md
+++ b/spec/features/cli/serve/README.md
@@ -1,7 +1,7 @@
 # Feature: Serve Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=request-change) |
-**Status:** Deprecated
+**Status:** Withdrawn — the `serve` command and its HTTP API / MCP gateway were removed as a still-born, datatug-overlapping surface (see [docs/adr/0001-remove-serve-command.md](../../../../docs/adr/0001-remove-serve-command.md)). This document is preserved as a historical record of the original design.
 
 > **Deprecated & removed.** The `serve` command and its HTTP API / MCP gateway
 > implementation were removed as a still-born, datatug-overlapping surface. For


### PR DESCRIPTION
The `serve` and `watch` commands are gone from the CLI, but their feature specs / index rows didn't reflect that.

- **`serve/README.md`** — `Deprecated` → `Withdrawn`. The command and its HTTP API / MCP gateway were removed (see `docs/adr/0001-remove-serve-command.md`); "Withdrawn" matches reality better than "Deprecated".
- **`spec/features/cli/README.md`** (index) — `serve` and `watch` were still listed as `Draft`; updated to their actual Withdrawn status and marked the commands `(removed)` / `(not implemented)`, consistent with the `find`/`truncate`/`migrate` rows.

Note: `watch/README.md` was already `Withdrawn (deferred)` at the spec level — only its stale index row needed fixing.

`specscore spec lint` → 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)