### PR TITLE
fix: SpecScore lint violations (204)

### DIFF
--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/features-index-specification
+---
+
 # Features
 
 This directory tracks the SpecScore feature specifications for the **ingitdb-cli** repository. Each feature describes the externally observable behavior of a single CLI command or a cross-cutting concern (flag conventions, output formats, ID syntax). Storage format and collection schema definitions live in the [ingitdb-specs](https://github.com/ingitdb/ingitdb-specs) repository and are referenced from here when needed.

--- a/spec/features/cli/README.md
+++ b/spec/features/cli/README.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/feature-specification
+---
+
 # CLI Features
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli?op=request-change) |

--- a/spec/features/cli/create-record/README.md
+++ b/spec/features/cli/create-record/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Superseded by [spec/features/cli/insert/](../insert/README.md). The `ingitdb create record` command has been removed; use `ingitdb insert --into=... --key=...` instead. This document is preserved as a historical record.
+---
+
 # Feature: Create Record Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/create-record?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/create-record?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/create-record?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/create-record?op=request-change) |
 **Status:** Superseded by [spec/features/cli/insert/](../insert/README.md). The `ingitdb create record` command has been removed; use `ingitdb insert --into=... --key=...` instead. This document is preserved as a historical record.
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/delete-collection/README.md
+++ b/spec/features/cli/delete-collection/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Superseded by [spec/features/cli/drop/](../drop/README.md). The `ingitdb delete collection` command has been replaced by `ingitdb drop collection <name>`. This document is preserved as a historical record.
+---
+
 # Feature: Delete Collection Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-collection?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-collection?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-collection?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-collection?op=request-change) |
 **Status:** Superseded by [spec/features/cli/drop/](../drop/README.md). The `ingitdb delete collection` command has been replaced by `ingitdb drop collection <name>`. This document is preserved as a historical record.
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/delete-record/README.md
+++ b/spec/features/cli/delete-record/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Superseded by [spec/features/cli/delete/](../delete/README.md). The `ingitdb delete record` command has been removed; use `ingitdb delete --id=...` instead. This document is preserved as a historical record.
+---
+
 # Feature: Delete Record Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-record?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-record?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-record?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-record?op=request-change) |
 **Status:** Superseded by [spec/features/cli/delete/](../delete/README.md). The `ingitdb delete record` command has been removed; use `ingitdb delete --id=...` instead. This document is preserved as a historical record.
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/delete-records/README.md
+++ b/spec/features/cli/delete-records/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Superseded by [spec/features/cli/delete/](../delete/README.md). The `ingitdb delete records` command has been replaced by `ingitdb delete --from=... --where=...` (or `--all`). This document is preserved as a historical record.
+---
+
 # Feature: Delete Records Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-records?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-records?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-records?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete-records?op=request-change) |
 **Status:** Superseded by [spec/features/cli/delete/](../delete/README.md). The `ingitdb delete records` command has been replaced by `ingitdb delete --from=... --where=...` (or `--all`). This document is preserved as a historical record.
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/delete/README.md
+++ b/spec/features/cli/delete/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Delete
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/delete?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/describe/README.md
+++ b/spec/features/cli/describe/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Describe Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/describe?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/describe?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/describe?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/describe?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/diff/README.md
+++ b/spec/features/cli/diff/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Implementing
+---
+
 # Feature: Diff Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/diff?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/diff?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/diff?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/diff?op=request-change) |
 **Status:** Implementing
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/drop/README.md
+++ b/spec/features/cli/drop/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Drop
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/drop?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/drop?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/drop?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/drop?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/find/README.md
+++ b/spec/features/cli/find/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Withdrawn — moved to DataTug CLI. The `ingitdb find` command will not be implemented in this repo; the cross-tool record-search feature belongs in DataTug. This document is preserved as a historical record of the original design.
+---
+
 # Feature: Find Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/find?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/find?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/find?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/find?op=request-change) |
 **Status:** Withdrawn — moved to DataTug CLI. The `ingitdb find` command will not be implemented in this repo; the cross-tool record-search feature belongs in DataTug. This document is preserved as a historical record of the original design.
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/insert/README.md
+++ b/spec/features/cli/insert/README.md
@@ -1,8 +1,14 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Insert
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/insert?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/insert?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/insert?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/insert?op=request-change) |
 
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/list-collections/README.md
+++ b/spec/features/cli/list-collections/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: List Collections Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-collections?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-collections?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-collections?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-collections?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/materialize/README.md
+++ b/spec/features/cli/materialize/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Approved
+---
+
 # Feature: Materialize Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/materialize?op=request-change) |

--- a/spec/features/cli/migrate/README.md
+++ b/spec/features/cli/migrate/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Withdrawn (deferred) — scope and design are not clear enough to implement today. The feature may be revived once concrete migration use cases and patterns emerge. This document is preserved as a historical record of the original draft.
+---
+
 # Feature: Migrate Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/migrate?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/migrate?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/migrate?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/migrate?op=request-change) |
 **Status:** Withdrawn (deferred) — scope and design are not clear enough to implement today. The feature may be revived once concrete migration use cases and patterns emerge. This document is preserved as a historical record of the original draft.
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/pull/README.md
+++ b/spec/features/cli/pull/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Implementing
+---
+
 # Feature: Pull Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/pull?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/pull?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/pull?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/pull?op=request-change) |
 **Status:** Implementing
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/query/README.md
+++ b/spec/features/cli/query/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Superseded by [spec/features/cli/select/](../select/README.md). The `ingitdb query` command has been replaced by `ingitdb select --from=... --where=...`. This document is preserved as a historical record.
+---
+
 # Feature: Query Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/query?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/query?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/query?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/query?op=request-change) |
 **Status:** Superseded by [spec/features/cli/select/](../select/README.md). The `ingitdb query` command has been replaced by `ingitdb select --from=... --where=...`. This document is preserved as a historical record.
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/read-record/README.md
+++ b/spec/features/cli/read-record/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Superseded by [spec/features/cli/select/](../select/README.md). The `ingitdb read record` command has been removed; use `ingitdb select --id=...` instead. This document is preserved as a historical record.
+---
+
 # Feature: Read Record Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/read-record?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/read-record?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/read-record?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/read-record?op=request-change) |
 **Status:** Superseded by [spec/features/cli/select/](../select/README.md). The `ingitdb read record` command has been removed; use `ingitdb select --id=...` instead. This document is preserved as a historical record.
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/rebase/README.md
+++ b/spec/features/cli/rebase/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Rebase Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/rebase?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/rebase?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/rebase?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/rebase?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/resolve/README.md
+++ b/spec/features/cli/resolve/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Resolve Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/resolve/auto-resolve/README.md
+++ b/spec/features/cli/resolve/auto-resolve/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Auto-Resolve Generated Conflicts
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 **Parent Feature:** [`cli/resolve`](../README.md)
 
 ## Summary

--- a/spec/features/cli/resolve/auto-resolve/record-merge/README.md
+++ b/spec/features/cli/resolve/auto-resolve/record-merge/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Auto-Merge Logically Non-Conflicting Record Data
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve/record-merge?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve/record-merge?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve/record-merge?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/auto-resolve/record-merge?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 **Parent Feature:** [`cli/resolve/auto-resolve`](../README.md)
 
 ## Summary

--- a/spec/features/cli/resolve/manual-resolve/README.md
+++ b/spec/features/cli/resolve/manual-resolve/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Draft
+---
+
 # Feature: Manual (Interactive) Conflict Resolution
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/manual-resolve?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/manual-resolve?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/manual-resolve?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/resolve/manual-resolve?op=request-change) |
 **Status:** Draft
+**Source Ideas:** —
 **Parent Feature:** [`cli/resolve`](../README.md)
 
 ## Summary

--- a/spec/features/cli/select/README.md
+++ b/spec/features/cli/select/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Select
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/select?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/select?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/select?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/select?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/serve/README.md
+++ b/spec/features/cli/serve/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Withdrawn — the `serve` command and its HTTP API / MCP gateway were removed as a still-born, datatug-overlapping surface (see [docs/adr/0001-remove-serve-command.md](../../../../docs/adr/0001-remove-serve-command.md)). This document is preserved as a historical record of the original design.
+---
+
 # Feature: Serve Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/serve?op=request-change) |
 **Status:** Withdrawn — the `serve` command and its HTTP API / MCP gateway were removed as a still-born, datatug-overlapping surface (see [docs/adr/0001-remove-serve-command.md](../../../../docs/adr/0001-remove-serve-command.md)). This document is preserved as a historical record of the original design.
+**Source Ideas:** —
 
 > **Withdrawn & removed.** The `serve` command and its HTTP API / MCP gateway
 > implementation were removed as a still-born, datatug-overlapping surface. For

--- a/spec/features/cli/setup/README.md
+++ b/spec/features/cli/setup/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Implementing
+---
+
 # Feature: Setup Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/setup?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/setup?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/setup?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/setup?op=request-change) |
 **Status:** Implementing
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/truncate/README.md
+++ b/spec/features/cli/truncate/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Withdrawn — superseded by `delete --from=COLLECTION --all`. A standalone `truncate` verb would duplicate `delete`'s set-mode semantics for no benefit, so the SQL `delete --all` path covers this use case. This document is preserved as a historical record of the original design.
+---
+
 # Feature: Truncate Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/truncate?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/truncate?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/truncate?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/truncate?op=request-change) |
 **Status:** Withdrawn — superseded by `delete --from=COLLECTION --all`. A standalone `truncate` verb would duplicate `delete`'s set-mode semantics for no benefit, so the SQL `delete --all` path covers this use case. This document is preserved as a historical record of the original design.
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/update-record/README.md
+++ b/spec/features/cli/update-record/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Superseded by [spec/features/cli/update/](../update/README.md). The `ingitdb update record` command has been renamed to `ingitdb update`. This document is preserved as a historical record.
+---
+
 # Feature: Update Record Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update-record?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update-record?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update-record?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update-record?op=request-change) |
 **Status:** Superseded by [spec/features/cli/update/](../update/README.md). The `ingitdb update record` command has been renamed to `ingitdb update`. This document is preserved as a historical record.
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/update/README.md
+++ b/spec/features/cli/update/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Update
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/update?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/validate/README.md
+++ b/spec/features/cli/validate/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Validate Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/validate?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/validate?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/validate?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/validate?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/version/README.md
+++ b/spec/features/cli/version/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Version Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/version?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/version?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/version?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/version?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/cli/watch/README.md
+++ b/spec/features/cli/watch/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Withdrawn (deferred)
+---
+
 # Feature: Watch Command
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/watch?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/watch?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/watch?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/watch?op=request-change) |
 **Status:** Withdrawn (deferred)
+**Source Ideas:** —
 
 > **Parked.** This feature is deferred — not on the roadmap right now. The stub
 > `ingitdb watch` command and the `pkg/watcher` scaffolding (interfaces only,

--- a/spec/features/computed-columns-via-dalgo/README.md
+++ b/spec/features/computed-columns-via-dalgo/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Computed Columns via dalgo (lazy delegation)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns-via-dalgo?op=request-change) |

--- a/spec/features/computed-columns/README.md
+++ b/spec/features/computed-columns/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Computed Columns (Inline Starlark Formulas)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/computed-columns?op=request-change) |

--- a/spec/features/computed-columns/_tests/README.md
+++ b/spec/features/computed-columns/_tests/README.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenarios-index-specification
+---
+
 # Rehearse Scenarios: Computed Columns
 
 **Status:** Draft

--- a/spec/features/computed-columns/_tests/builtin-helpers-builtin-math-helper-available.md
+++ b/spec/features/computed-columns/_tests/builtin-helpers-builtin-math-helper-available.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: builtin-math-helper-available
 
 **Validates:** [computed-columns#req:builtin-helpers](../README.md#req-builtin-helpers)

--- a/spec/features/computed-columns/_tests/builtin-helpers-builtin-string-helper-available.md
+++ b/spec/features/computed-columns/_tests/builtin-helpers-builtin-string-helper-available.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: builtin-string-helper-available
 
 **Validates:** [computed-columns#req:builtin-helpers](../README.md#req-builtin-helpers)

--- a/spec/features/computed-columns/_tests/coerce-to-type-type-coercion-success.md
+++ b/spec/features/computed-columns/_tests/coerce-to-type-type-coercion-success.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: type-coercion-success
 
 **Validates:** [computed-columns#req:coerce-to-type](../README.md#req-coerce-to-type)

--- a/spec/features/computed-columns/_tests/coerce-to-type-unsupported-type-rejected.md
+++ b/spec/features/computed-columns/_tests/coerce-to-type-unsupported-type-rejected.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: unsupported-type-rejected
 
 **Validates:** [computed-columns#req:coerce-to-type](../README.md#req-coerce-to-type)

--- a/spec/features/computed-columns/_tests/declare-formula-formula-declared-and-computed.md
+++ b/spec/features/computed-columns/_tests/declare-formula-formula-declared-and-computed.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: formula-declared-and-computed
 
 **Validates:** [computed-columns#req:declare-formula](../README.md#req-declare-formula)

--- a/spec/features/computed-columns/_tests/declare-formula-formula-syntax-error.md
+++ b/spec/features/computed-columns/_tests/declare-formula-formula-syntax-error.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: formula-syntax-error
 
 **Validates:** [computed-columns#req:declare-formula](../README.md#req-declare-formula)

--- a/spec/features/computed-columns/_tests/fail-loud-runtime-error-fails-read.md
+++ b/spec/features/computed-columns/_tests/fail-loud-runtime-error-fails-read.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: runtime-error-fails-read
 
 **Validates:** [computed-columns#req:fail-loud](../README.md#req-fail-loud)

--- a/spec/features/computed-columns/_tests/foreign-key-parent-side-foreign-key-parent-delete-detected.md
+++ b/spec/features/computed-columns/_tests/foreign-key-parent-side-foreign-key-parent-delete-detected.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: foreign-key-parent-delete-detected
 
 **Validates:** [computed-columns#req:foreign-key-parent-side](../README.md#req-foreign-key-parent-side)

--- a/spec/features/computed-columns/_tests/foreign-key-parent-side-foreign-key-parent-rename-detected.md
+++ b/spec/features/computed-columns/_tests/foreign-key-parent-side-foreign-key-parent-rename-detected.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: foreign-key-parent-rename-detected
 
 **Validates:** [computed-columns#req:foreign-key-parent-side](../README.md#req-foreign-key-parent-side)

--- a/spec/features/computed-columns/_tests/foreign-key-revalidate-on-input-change-foreign-key-revalidates-on-input-change.md
+++ b/spec/features/computed-columns/_tests/foreign-key-revalidate-on-input-change-foreign-key-revalidates-on-input-change.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: foreign-key-revalidates-on-input-change
 
 **Validates:** [computed-columns#req:foreign-key-revalidate-on-input-change](../README.md#req-foreign-key-revalidate-on-input-change)

--- a/spec/features/computed-columns/_tests/foreign-key-support-foreign-key-on-insert-violation.md
+++ b/spec/features/computed-columns/_tests/foreign-key-support-foreign-key-on-insert-violation.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: foreign-key-on-insert-violation
 
 **Validates:** [computed-columns#req:foreign-key-support](../README.md#req-foreign-key-support)

--- a/spec/features/computed-columns/_tests/reject-stored-value-reject-stored-computed-value.md
+++ b/spec/features/computed-columns/_tests/reject-stored-value-reject-stored-computed-value.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: reject-stored-computed-value
 
 **Validates:** [computed-columns#req:reject-stored-value](../README.md#req-reject-stored-value)

--- a/spec/features/computed-columns/_tests/sandboxed-deterministic-deterministic-evaluation.md
+++ b/spec/features/computed-columns/_tests/sandboxed-deterministic-deterministic-evaluation.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: deterministic-evaluation
 
 **Validates:** [computed-columns#req:sandboxed-deterministic](../README.md#req-sandboxed-deterministic)

--- a/spec/features/computed-columns/_tests/stored-fields-only-reject-chained-computed-reference.md
+++ b/spec/features/computed-columns/_tests/stored-fields-only-reject-chained-computed-reference.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: reject-chained-computed-reference
 
 **Validates:** [computed-columns#req:stored-fields-only](../README.md#req-stored-fields-only)

--- a/spec/features/computed-columns/_tests/usable-in-filter-and-sort-filter-on-computed-column.md
+++ b/spec/features/computed-columns/_tests/usable-in-filter-and-sort-filter-on-computed-column.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: filter-on-computed-column
 
 **Validates:** [computed-columns#req:usable-in-filter-and-sort](../README.md#req-usable-in-filter-and-sort)

--- a/spec/features/computed-columns/_tests/usable-in-filter-and-sort-order-by-computed-column.md
+++ b/spec/features/computed-columns/_tests/usable-in-filter-and-sort-order-by-computed-column.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: order-by-computed-column
 
 **Validates:** [computed-columns#req:usable-in-filter-and-sort](../README.md#req-usable-in-filter-and-sort)

--- a/spec/features/dalgo2ingitdb-dbschema-ddl-coverage/README.md
+++ b/spec/features/dalgo2ingitdb-dbschema-ddl-coverage/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: dbschema + ddl + ConcurrencyAware Coverage for inGitDB
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-dbschema-ddl-coverage?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 **Source Idea:** —
 **Date:** 2026-05-13
 **Owner:** alex

--- a/spec/features/dalgo2ingitdb-referential-integrity/README.md
+++ b/spec/features/dalgo2ingitdb-referential-integrity/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: DALgo Referential Integrity
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-referential-integrity?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-referential-integrity?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-referential-integrity?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/dalgo2ingitdb-referential-integrity?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 **Date:** 2026-05-30
 **Owner:** @trakhimenok
 **Source Idea:** [`dalgo2ingitdb-referential-integrity`](../../ideas/dalgo2ingitdb-referential-integrity.md)

--- a/spec/features/id-flag-format/README.md
+++ b/spec/features/id-flag-format/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: ID Flag Format
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/id-flag-format?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/id-flag-format?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/id-flag-format?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/id-flag-format?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/output-formats/README.md
+++ b/spec/features/output-formats/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Output Formats
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/output-formats?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/output-formats?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/output-formats?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/output-formats?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/path-targeting/README.md
+++ b/spec/features/path-targeting/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Path Targeting
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/path-targeting?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/path-targeting?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/path-targeting?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/path-targeting?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/record-format/README.md
+++ b/spec/features/record-format/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Record Format Extensions
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 **Source Idea:** [`default-record-format`](../../ideas/default-record-format.md)
 
 ## Summary

--- a/spec/features/record-format/cli-default-format-flag/README.md
+++ b/spec/features/record-format/cli-default-format-flag/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: `ingitdb setup --default-format` Flag
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/cli-default-format-flag?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/cli-default-format-flag?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/cli-default-format-flag?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/cli-default-format-flag?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 **Source Idea:** [`default-record-format`](../../../ideas/default-record-format.md)
 **Parent Feature:** [`record-format`](../README.md)
 

--- a/spec/features/record-format/csv-support/README.md
+++ b/spec/features/record-format/csv-support/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: CSV Format Support
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/csv-support?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/csv-support?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/csv-support?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/csv-support?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 **Source Idea:** [`default-record-format`](../../../ideas/default-record-format.md)
 **Parent Feature:** [`record-format`](../README.md)
 

--- a/spec/features/record-format/list-of-records/README.md
+++ b/spec/features/record-format/list-of-records/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: List-of-Records Files (YAML/JSON Sequences + JSONL)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/list-of-records?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/list-of-records?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/list-of-records?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/list-of-records?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 **Parent Feature:** [`record-format`](../README.md)
 **Source Idea:** [`list-of-records-files`](../../../ideas/list-of-records-files.md)
 

--- a/spec/features/record-format/project-default/README.md
+++ b/spec/features/record-format/project-default/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Project-Level Default Record Format
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/project-default?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/project-default?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/project-default?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-format/project-default?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 **Source Idea:** [`default-record-format`](../../../ideas/default-record-format.md)
 **Parent Feature:** [`record-format`](../README.md)
 

--- a/spec/features/record-key/README.md
+++ b/spec/features/record-key/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Draft
+---
+
 # Feature: Record Key
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key?op=request-change) |
 **Status:** Draft
+**Source Ideas:** —
 **Source Idea:** [`derived-record-keys`](../../ideas/derived-record-keys.md)
 
 ## Summary

--- a/spec/features/record-key/derived-keys/README.md
+++ b/spec/features/record-key/derived-keys/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Derived Record Keys
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key/derived-keys?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key/derived-keys?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key/derived-keys?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/record-key/derived-keys?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 **Date:** 2026-05-30
 **Owner:** alexander.trakhimenok@gmail.com
 **Source Idea:** [`derived-record-keys`](../../../ideas/derived-record-keys.md)

--- a/spec/features/remote-repo-access/README.md
+++ b/spec/features/remote-repo-access/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Remote Repository Access
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/remote-repo-access?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/remote-repo-access?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/remote-repo-access?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/remote-repo-access?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/shared-cli-flags/README.md
+++ b/spec/features/shared-cli-flags/README.md
@@ -1,7 +1,13 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Shared CLI Flags
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/shared-cli-flags?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/shared-cli-flags?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/shared-cli-flags?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/shared-cli-flags?op=request-change) |
 **Status:** Stable
+**Source Ideas:** —
 
 ## Summary
 

--- a/spec/features/tui-lazy-computed-cells/README.md
+++ b/spec/features/tui-lazy-computed-cells/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: TUI lazy computed-cell evaluation
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/tui-lazy-computed-cells?op=request-change) |

--- a/spec/features/tui-lazy-computed-cells/_tests/README.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/README.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenarios-index-specification
+---
+
 # Rehearse Scenarios: TUI lazy computed-cell evaluation
 
 **Status:** Draft

--- a/spec/features/tui-lazy-computed-cells/_tests/computed-width-from-schema-width-sizing-does-not-evaluate.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/computed-width-from-schema-width-sizing-does-not-evaluate.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: width-sizing-does-not-evaluate
 
 **Validates:** [tui-lazy-computed-cells#req:computed-width-from-schema](../README.md#req-computed-width-from-schema)

--- a/spec/features/tui-lazy-computed-cells/_tests/numeric-alignment-from-type-numeric-alignment-does-not-evaluate.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/numeric-alignment-from-type-numeric-alignment-does-not-evaluate.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: numeric-alignment-does-not-evaluate
 
 **Validates:** [tui-lazy-computed-cells#req:numeric-alignment-from-type](../README.md#req-numeric-alignment-from-type)

--- a/spec/features/tui-lazy-computed-cells/_tests/per-row-memoization-scroll-evaluates-only-newly-visible.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/per-row-memoization-scroll-evaluates-only-newly-visible.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: scroll-evaluates-only-newly-visible
 
 **Validates:** [tui-lazy-computed-cells#req:per-row-memoization](../README.md#req-per-row-memoization)

--- a/spec/features/tui-lazy-computed-cells/_tests/render-time-computed-eval-off-viewport-error-never-evaluated.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/render-time-computed-eval-off-viewport-error-never-evaluated.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: off-viewport-error-never-evaluated
 
 **Validates:** [tui-lazy-computed-cells#req:render-time-computed-eval](../README.md#req-render-time-computed-eval)

--- a/spec/features/tui-lazy-computed-cells/_tests/render-time-computed-eval-off-viewport-rows-not-evaluated.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/render-time-computed-eval-off-viewport-rows-not-evaluated.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: off-viewport-rows-not-evaluated
 
 **Validates:** [tui-lazy-computed-cells#req:render-time-computed-eval](../README.md#req-render-time-computed-eval)

--- a/spec/features/tui-lazy-computed-cells/_tests/stored-columns-unchanged-stored-locale-discovery-unchanged.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/stored-columns-unchanged-stored-locale-discovery-unchanged.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: stored-locale-discovery-unchanged
 
 **Validates:** [tui-lazy-computed-cells#req:stored-columns-unchanged](../README.md#req-stored-columns-unchanged)

--- a/spec/features/tui-lazy-computed-cells/_tests/visible-error-non-fatal-visible-computed-error-non-fatal.md
+++ b/spec/features/tui-lazy-computed-cells/_tests/visible-error-non-fatal-visible-computed-error-non-fatal.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/scenario-specification
+---
+
 # Scenario: visible-computed-error-non-fatal
 
 **Validates:** [tui-lazy-computed-cells#req:visible-error-non-fatal](../README.md#req-visible-error-non-fatal)

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/ideas-index-specification
+---
+
 # Ideas
 
 Raw ideas explored before promotion to a SpecScore Feature. Each idea is a one-pager covering

--- a/spec/ideas/batch-insert.md
+++ b/spec/ideas/batch-insert.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Approved
+---
+
 # Idea: Batch Insert from Stdin
 
 **Status:** Approved

--- a/spec/ideas/cli-describe.md
+++ b/spec/ideas/cli-describe.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Draft
+---
+
 # Idea: CLI describe command
 
 **Status:** Draft

--- a/spec/ideas/cli-sql-verbs.md
+++ b/spec/ideas/cli-sql-verbs.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Approved
+---
+
 # Idea: SQL-Verb CLI Redesign
 
 **Status:** Approved

--- a/spec/ideas/dalgo2ingitdb-referential-integrity.md
+++ b/spec/ideas/dalgo2ingitdb-referential-integrity.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Approved
+---
+
 # Idea: DALgo referential integrity on writes
 
 **Status:** Approved

--- a/spec/ideas/default-record-format.md
+++ b/spec/ideas/default-record-format.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Approved
+---
+
 # Idea: Project-Level Default Record Format + CSV Format Support
 
 **Status:** Approved

--- a/spec/ideas/derived-record-keys.md
+++ b/spec/ideas/derived-record-keys.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Approved
+---
+
 # Idea: Derived Record Keys from Record Fields
 
 **Status:** Approved

--- a/spec/ideas/list-of-records-files.md
+++ b/spec/ideas/list-of-records-files.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Approved
+---
+
 # Idea: List-of-Records Files: Top-Level YAML/JSON Sequences + JSONL
 
 **Status:** Approved

--- a/spec/ideas/markdown-insert-ux.md
+++ b/spec/ideas/markdown-insert-ux.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Draft
+---
+
 # Idea: Markdown Record Insert UX
 
 **Status:** Draft

--- a/spec/ideas/materialize-collections-and-views.md
+++ b/spec/ideas/materialize-collections-and-views.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Specified
+---
+
 # Idea: Unified materialize command for collections and views
 
 **Status:** Specified

--- a/spec/ideas/scripted-formulas-and-views.md
+++ b/spec/ideas/scripted-formulas-and-views.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Implemented
+---
+
 # Idea: Scripted Computed Fields & Materialized Views (Starlark)
 
 **Status:** Implemented

--- a/spec/ideas/seeds/assert-version-command-output-fields-in-tests.md
+++ b/spec/ideas/seeds/assert-version-command-output-fields-in-tests.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: assert-version-command-output-fields-in-tests
-captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: done
-synchestra_task: null
 ---
 # Add a test that captures `ingitdb version` stdout and asserts all three fields (version, commit, date) are present
 

--- a/spec/ideas/seeds/enforce-token-for-remote-writes-and-github-enterprise-provider.md
+++ b/spec/ideas/seeds/enforce-token-for-remote-writes-and-github-enterprise-provider.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: enforce-token-for-remote-writes-and-github-enterprise-provider
-captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: done
-synchestra_task: null
 ---
 # Enforce a local token-required pre-flight for remote writes
 

--- a/spec/ideas/seeds/explore-derived-keys-for-list-of-records-row-identity.md
+++ b/spec/ideas/seeds/explore-derived-keys-for-list-of-records-row-identity.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: explore-derived-keys-for-list-of-records-row-identity
-captured_at: 2026-05-30T11:12:33Z
 captured_by: specstudio:ideate
-captured_during: spec/ideas/derived-record-keys.md
-trigger: explicit
 status: queued
-synchestra_task: null
 ---
 
 # Explore derived keys for list-of-records row identity

--- a/spec/ideas/seeds/implement-incremental-validation-commit-range.md
+++ b/spec/ideas/seeds/implement-incremental-validation-commit-range.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: implement-incremental-validation-commit-range
-captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: done
-synchestra_task: null
 ---
 # Implement IncrementalValidator so `validate --from-commit/--to-commit` scopes validation to changed records instead of returning not-implemented
 

--- a/spec/ideas/seeds/implement-or-remove-list-collections-scoping-flags.md
+++ b/spec/ideas/seeds/implement-or-remove-list-collections-scoping-flags.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: implement-or-remove-list-collections-scoping-flags
-captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: done
-synchestra_task: null
 ---
 # Implement --in and --filter-name scoped filtering for `list collections` (or remove the dead flags from the command and spec)
 

--- a/spec/ideas/seeds/materialize-subcommands-and-collection-targeting.md
+++ b/spec/ideas/seeds/materialize-subcommands-and-collection-targeting.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: materialize-subcommands-and-collection-targeting
-captured_at: 2026-06-03T16:54:53Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: promoted
-synchestra_task: null
 ---
 # Implement materialize subcommands (collection/views) and the --collection / --views targeting, or reconcile the spec to the flat command
 

--- a/spec/ideas/seeds/rebase-abort-on-unresolvable-source-conflicts.md
+++ b/spec/ideas/seeds/rebase-abort-on-unresolvable-source-conflicts.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: rebase-abort-on-unresolvable-source-conflicts
-captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: done
-synchestra_task: null
 ---
 # Make `ingitdb rebase` run `git rebase --abort` and report unresolved paths on conflicts outside the --resolve scope, with a test
 

--- a/spec/ideas/seeds/reconcile-dbschema-concurrency-contract.md
+++ b/spec/ideas/seeds/reconcile-dbschema-concurrency-contract.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: reconcile-dbschema-concurrency-contract
-captured_at: 2026-06-03T16:54:53Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: done
-synchestra_task: null
 ---
 # Reconcile the dbschema-ddl concurrency contract: spec says single-writer (false), code returns true via flock
 

--- a/spec/ideas/seeds/revalidate-auto-merged-records-against-schema.md
+++ b/spec/ideas/seeds/revalidate-auto-merged-records-against-schema.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: revalidate-auto-merged-records-against-schema
-captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: done
-synchestra_task: null
 ---
 # Re-validate auto-merged records against the collection schema and escalate invalid merges instead of staging them
 

--- a/spec/ideas/seeds/serve-combinable-services-and-watcher-wiring.md
+++ b/spec/ideas/seeds/serve-combinable-services-and-watcher-wiring.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: serve-combinable-services-and-watcher-wiring
-captured_at: 2026-06-03T16:54:53Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: done
-synchestra_task: null
 ---
 # Make `serve` run combinable services and wire --watcher
 

--- a/spec/ideas/seeds/setup-starter-config-and-overwrite-guard.md
+++ b/spec/ideas/seeds/setup-starter-config-and-overwrite-guard.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: setup-starter-config-and-overwrite-guard
-captured_at: 2026-06-03T16:54:53Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: queued
-synchestra_task: null
 ---
 # Make `setup` write a real starter config and refuse to overwrite an initialised db; reconcile the stale spec layout
 

--- a/spec/ideas/seeds/specify-computed-columns-and-materialized-view-scripts-in.md
+++ b/spec/ideas/seeds/specify-computed-columns-and-materialized-view-scripts-in.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: specify-computed-columns-and-materialized-view-scripts-in
-captured_at: 2026-06-02T07:42:06Z
 captured_by: specstudio:implement
-captured_during: null
-trigger: explicit
 status: queued
-synchestra_task: null
 ---
 # Specify computed columns and materialized-view scripts in the inGitDB standard repo as a language-agnostic Idea so Go and TypeScript implementations share one standard
 

--- a/spec/ideas/seeds/tui-collection-screen-should-evaluate-only-painted-visible.md
+++ b/spec/ideas/seeds/tui-collection-screen-should-evaluate-only-painted-visible.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: tui-collection-screen-should-evaluate-only-painted-visible
-captured_at: 2026-06-03T12:03:29Z
 captured_by: specstudio:implement
-captured_during: spec/features/computed-columns-via-dalgo
-trigger: explicit
 status: queued
-synchestra_task: null
 ---
 # TUI collection screen should evaluate only painted visible computed-column cells, not all cells at load
 

--- a/spec/ideas/seeds/wire-collection-id-charset-validation-into-id-flag-parsing.md
+++ b/spec/ideas/seeds/wire-collection-id-charset-validation-into-id-flag-parsing.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: wire-collection-id-charset-validation-into-id-flag-parsing
-captured_at: 2026-06-03T14:25:20Z
 captured_by: claude
-captured_during: null
-trigger: explicit
 status: done
-synchestra_task: null
 ---
 # Wire ValidateCollectionID into the --id resolution path so invalid collection segments yield a syntax diagnostic, and reconcile the underscore charset discrepancy
 

--- a/spec/ideas/seeds/wire-write-time-validations-foreign-keys-and-reject-stored.md
+++ b/spec/ideas/seeds/wire-write-time-validations-foreign-keys-and-reject-stored.md
@@ -1,12 +1,7 @@
 ---
 type: sidekick-seed
-slug: wire-write-time-validations-foreign-keys-and-reject-stored
-captured_at: 2026-06-02T08:46:12Z
 captured_by: specstudio:implement
-captured_during: null
-trigger: explicit
 status: queued
-synchestra_task: null
 ---
 # Wire write-time validations (foreign keys and reject-stored-computed-values) into the CLI dalgo2fsingitdb read-write path so inserts and updates enforce them, not just the dalgo2ingitdb DALgo layer
 

--- a/spec/ideas/where-like-regex.md
+++ b/spec/ideas/where-like-regex.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Draft
+---
+
 # Idea: LIKE/Regex Predicates in --where
 
 **Status:** Draft

--- a/spec/plans/README.md
+++ b/spec/plans/README.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/plans-index-specification
+---
+
 # Plans
 
 Implementation plans linked to SpecScore Features. Each plan breaks a Feature into ordered,


### PR DESCRIPTION
Resolves 204 lint violations: format-field/status-mirror via migrate, feature-source-ideas via lint --fix, and 15 sidekick-seed unknown-key violations via frontmatter cleanup.