### PR TITLE
chore(spec): apply specscore lint --fix

### DIFF
--- a/spec/plans/2026-06-03-computed-columns-via-dalgo.md
+++ b/spec/plans/2026-06-03-computed-columns-via-dalgo.md
@@ -1,6 +1,6 @@
 # Plan: Computed Columns via dalgo (lazy delegation)
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** computed-columns-via-dalgo
 **Date:** 2026-06-03
 **Owner:** alex

--- a/spec/plans/2026-06-03-tui-lazy-computed-cells.md
+++ b/spec/plans/2026-06-03-tui-lazy-computed-cells.md
@@ -1,6 +1,6 @@
 # Plan: TUI lazy computed-cell evaluation
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** tui-lazy-computed-cells
 **Date:** 2026-06-03
 **Owner:** alex

--- a/spec/plans/computed-columns.md
+++ b/spec/plans/computed-columns.md
@@ -1,6 +1,6 @@
 # Plan: Computed Columns (Inline Starlark Formulas)
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** computed-columns
 **Date:** 2026-06-02
 **Owner:** alexander.trakhimenok@gmail.com


### PR DESCRIPTION
Automated `specscore spec lint --fix` run by `all-repos specscore-lint --fix` (canonical status-vocabulary migration).