### PR TITLE
ci(release): publish macOS binaries reliably (build-macos job)

### DIFF
--- a/.github/goreleaser-homebrew.yaml
+++ b/.github/goreleaser-homebrew.yaml
@@ -48,7 +48,12 @@ release:
   github:
     owner: ingitdb
     name: ingitdb-cli
-  mode: keep-existing
+  # The build-macos job owns the darwin release assets now; this job only
+  # publishes the Homebrew cask, so it must not re-upload the same-named
+  # archives (goreleaser errors on a duplicate asset). Disabling the release
+  # step leaves the cask's download URL pointing at the assets build-macos
+  # uploaded.
+  disable: true
 
 homebrew_casks:
   - name: ingitdb

--- a/.github/goreleaser-macos.yaml
+++ b/.github/goreleaser-macos.yaml
@@ -1,0 +1,47 @@
+version: 2
+
+project_name: ingitdb
+
+before:
+  hooks:
+    - go mod tidy
+
+# Unsigned macOS binaries, uploaded as release assets. Deliberately decoupled
+# from notarization and Homebrew: those live in the publish-homebrew job, whose
+# failure previously meant NO macOS assets shipped at all (v0.40.1 published
+# Linux + Windows but nothing for macOS because "Publish to Homebrew" failed).
+# Pure Go with CGO disabled cross-compiles darwin from the Linux runner, so this
+# needs no macOS runner and no Apple secrets, and nothing fragile can block the
+# upload. Signed/notarized artifacts remain the Homebrew job's concern.
+builds:
+  - id: ingitdb-darwin
+    main: ./cmd/ingitdb
+    binary: ingitdb
+    env: [CGO_ENABLED=0]
+    goos: [darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+
+archives:
+  - id: tarball-macos
+    formats: [tar.gz]
+    # Same naming as the Linux/Windows assets, so an install script that
+    # templates ingitdb_{version}_{os}_{arch} resolves macOS the same way.
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    ids: [ingitdb-darwin]
+    files:
+      - README.md
+      - LICENSE*
+
+checksum:
+  name_template: checksums-macos.txt
+
+release:
+  github:
+    owner: ingitdb
+    name: ingitdb-cli
+  # Attach to the release the build-linux job already created; never recreate it.
+  mode: keep-existing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,10 +109,47 @@ jobs:
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
           INGITDB_GORELEASER_GITHUB_TOKEN: ${{ secrets.INGITDB_GORELEASER_GITHUB_TOKEN }}
 
+  # Publishes unsigned macOS binaries as release assets. Separate from
+  # publish-homebrew on purpose: that job failing (as it did for v0.40.1) must
+  # no longer mean macOS ships nothing. Pure-Go + CGO_ENABLED=0 cross-compiles
+  # darwin on the Linux runner, so no macOS runner or Apple secrets are needed.
+  build-macos:
+    name: Build macOS binaries
+    needs:
+      - build-linux
+    if: "!failure() && !cancelled()"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags --force
+
+      - name: Check out release tag
+        shell: bash
+        run: git checkout --quiet "${{ needs.build-linux.outputs.tag }}"
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.5"
+
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          version: v2
+          args: release --clean --config .github/goreleaser-macos.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.INGITDB_GORELEASER_GITHUB_TOKEN }}
+
   # See docs/release/homebrew.md for setup instructions
   publish-homebrew:
     name: Publish to Homebrew
     needs:
+      - build-macos
       - build-linux
     if: "!failure() && !cancelled()"
     runs-on: macos-latest


### PR DESCRIPTION
Ships macOS binaries as release assets — the "A" step. macOS was produced only inside `publish-homebrew`, coupled to notarization + the Homebrew-tap push; when that job failed (v0.40.1's run failed there), **no macOS assets shipped at all** despite Linux and Windows releasing fine.

Adds a dedicated `build-macos` job: builds unsigned darwin amd64/arm64 (pure Go, `CGO_ENABLED=0`, cross-compiled on the Linux runner — no macOS runner or Apple secrets) and uploads them to the release `build-linux` created. Nothing fragile can block the upload, so macOS ships as reliably as Linux/Windows under the same `ingitdb_{version}_{os}_{arch}` naming. `publish-homebrew` now waits on it and no longer re-uploads darwin archives (`release.disable`), so there's no duplicate-asset collision — it only publishes the cask.

This is the self-contained interim fix. The broader consolidation onto the shared `strongo/cicd` release (the "B" step) follows separately and will supersede this job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZythDmdpA3cm1pNdeirwp