### PR TITLE
ci: point workflows at strongo/cicd

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -29,7 +29,7 @@ jobs:
   strongo_workflow:
     permissions:
       contents: write
-    uses: strongo/go-ci-action/.github/workflows/workflow.yml@main
+    uses: strongo/cicd/.github/workflows/workflow.yml@main
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:


### PR DESCRIPTION
strongo/go-ci-action renamed to strongo/cicd; updates the ref explicitly (old ref redirects).