### PR TITLE
feat(cli): implement `list views`, fix md materialization, scaffold notarization

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,39 @@ archives:
 checksum:
   name_template: checksums.txt
 
+# macOS signing + notarization — DORMANT BY DEFAULT, safe to ship as-is.
+#
+# `enabled` is gated on the MACOS_SIGN_P12 env var, which the shared
+# strongo/cicd release.yml does NOT currently forward. With the var unset the
+# whole block is skipped: GoReleaser ships the same unsigned darwin binaries it
+# ships today, so this can never break a release. GoReleaser's notarize is
+# implemented in pure Go (quill), so when enabled it runs on the existing Linux
+# `core` job — no macOS runner needed.
+#
+# To ENABLE signed + notarized macOS releases, two steps are required:
+#   1. Verify the Apple credentials are still valid. The PRIOR publish-homebrew
+#      job FAILED, so MACOS_SIGN_P12 / MACOS_SIGN_PASSWORD (an Apple Developer ID
+#      Application cert) and NOTARIZE_ISSUER_ID / NOTARIZE_KEY_ID / NOTARIZE_KEY
+#      (an App Store Connect API key) may be stale and must be re-checked before
+#      trusting a release to them.
+#   2. Forward those five secrets into the GoReleaser env of strongo/cicd's
+#      reusable release.yml `core` job (they are declared here but only take
+#      effect once the shared workflow passes them through). Once MACOS_SIGN_P12
+#      is set, this block activates automatically.
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      ids: [ingitdb]
+      sign:
+        certificate: "{{ .Env.MACOS_SIGN_P12 }}"
+        password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
+      notarize:
+        wait: true
+        issuer_id: "{{ .Env.NOTARIZE_ISSUER_ID }}"
+        key_id: "{{ .Env.NOTARIZE_KEY_ID }}"
+        key: "{{ .Env.NOTARIZE_KEY }}"
+        timeout: 20m
+
 release:
   github:
     owner: ingitdb
@@ -81,12 +114,11 @@ aurs:
 # release.yml as $GORELEASER_GITHUB_TOKEN (the default GITHUB_TOKEN can't push
 # to a different repo).
 #
-# NOTE: notarization is intentionally NOT wired here. The prior publish-homebrew
-# job notarized an archive that was then discarded (its release step was
-# disabled) while the shipped cask pointed at the *unsigned* build-macos assets —
-# so releases were already unsigned. This config ships the same unsigned darwin
-# binaries. Signed/notarized releases would need a dedicated follow-up (a
-# `notarize` block + forwarding MACOS_SIGN_*/NOTARIZE_* secrets).
+# NOTE: the cask currently points at UNSIGNED darwin binaries. A dormant
+# `notarize:` block (see above, gated on MACOS_SIGN_P12) is wired but skipped
+# until the Apple credentials are verified and the shared release.yml forwards
+# the signing secrets; once active it signs the same binaries this cask ships,
+# with no change needed here.
 homebrew_casks:
   - name: ingitdb
     ids: [archive]

--- a/cmd/ingitdb/commands/list.go
+++ b/cmd/ingitdb/commands/list.go
@@ -72,7 +72,7 @@ func List(
 		Use:   "list",
 		Short: "List database objects (collections or views)",
 	}
-	cmd.AddCommand(collections(homeDir, getWd, readDefinition), listViews())
+	cmd.AddCommand(collections(homeDir, getWd, readDefinition), listViews(homeDir, getWd, readDefinition))
 	return cmd
 }
 
@@ -185,16 +185,79 @@ func listCollectionsRemoteWithSpec(ctx context.Context, spec remoteSpec, token, 
 
 // listViews is named with the parent prefix because "view" also appears as a
 // subcommand of drop.
-func listViews() *cobra.Command {
+func listViews(
+	homeDir func() (string, error),
+	getWd func() (string, error),
+	readDefinition func(string, ...ingitdb.ReadOption) (*ingitdb.Definition, error),
+) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "views",
 		Short: "List views in the database",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return fmt.Errorf("not yet implemented")
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			dirPath, resolveErr := resolveDBPath(cmd, homeDir, getWd)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			def, readErr := readDefinition(dirPath)
+			if readErr != nil {
+				return fmt.Errorf("failed to read database definition: %w", readErr)
+			}
+			inExpr, _ := cmd.Flags().GetString("in")
+			nameGlob, _ := cmd.Flags().GetString("filter-name")
+			ids, filterErr := filterViewIDs(def, inExpr, nameGlob)
+			if filterErr != nil {
+				return filterErr
+			}
+			for _, id := range ids {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), id)
+			}
+			return nil
 		},
 	}
 	addPathFlag(cmd)
 	cmd.Flags().String("in", "", "regular expression for the starting-point path")
 	cmd.Flags().String("filter-name", "", "pattern to filter view names (e.g. *substr*)")
 	return cmd
+}
+
+// filterViewIDs walks every collection (top-level and nested subcollections),
+// collecting each declared view as a qualified "collectionID/viewName"
+// identifier. inExpr is a regular expression matched against the owning
+// collection's starting-point path (the --in flag); nameGlob is a glob matched
+// against the bare view name (the --filter-name flag). An empty inExpr or
+// nameGlob disables that filter; both combine with AND. The result is sorted
+// ascending.
+func filterViewIDs(def *ingitdb.Definition, inExpr, nameGlob string) ([]string, error) {
+	var inRE *regexp.Regexp
+	if inExpr != "" {
+		re, err := regexp.Compile(inExpr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --in regular expression %q: %w", inExpr, err)
+		}
+		inRE = re
+	}
+	if nameGlob != "" {
+		// path.Match only errors on a malformed pattern, independent of input,
+		// so validate it once up front and ignore the error at match time.
+		if _, err := path.Match(nameGlob, ""); err != nil {
+			return nil, fmt.Errorf("invalid --filter-name pattern %q: %w", nameGlob, err)
+		}
+	}
+	var ids []string
+	for _, col := range eachCollection(def.Collections) {
+		if inRE != nil && !inRE.MatchString(col.DirPath) {
+			continue
+		}
+		for _, viewName := range sortedViewNames(col.Views) {
+			if nameGlob != "" {
+				matched, _ := path.Match(nameGlob, viewName)
+				if !matched {
+					continue
+				}
+			}
+			ids = append(ids, col.ID+"/"+viewName)
+		}
+	}
+	sort.Strings(ids)
+	return ids, nil
 }

--- a/cmd/ingitdb/commands/list_test.go
+++ b/cmd/ingitdb/commands/list_test.go
@@ -184,19 +184,164 @@ func TestListCollectionsLocal_ResolvePathError(t *testing.T) {
 	}
 }
 
-func TestListViews_NotYetImplemented(t *testing.T) {
+// viewsFixtureDef builds a definition with views spread across two top-level
+// collections and one nested subcollection, so tests can exercise the qualified
+// "collectionID/viewName" output and the scoping flags.
+func viewsFixtureDef(dir string) *ingitdb.Definition {
+	return &ingitdb.Definition{
+		Collections: map[string]*ingitdb.CollectionDef{
+			"todo.tasks": {
+				ID:      "todo.tasks",
+				DirPath: dir + "/todo/tasks",
+				Views: map[string]*ingitdb.ViewDef{
+					"by_status": {ID: "by_status"},
+					"by_owner":  {ID: "by_owner"},
+				},
+				SubCollections: map[string]*ingitdb.CollectionDef{
+					"todo.tasks.comments": {
+						ID:      "todo.tasks.comments",
+						DirPath: dir + "/todo/tasks/comments",
+						Views: map[string]*ingitdb.ViewDef{
+							"recent": {ID: "recent"},
+						},
+					},
+				},
+			},
+			"countries": {
+				ID:      "countries",
+				DirPath: dir + "/countries",
+				Views: map[string]*ingitdb.ViewDef{
+					"by_region": {ID: "by_region"},
+				},
+			},
+		},
+	}
+}
+
+func runListViews(t *testing.T, dir string, args ...string) []string {
+	t.Helper()
+	def := viewsFixtureDef(dir)
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return dir, nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
+		return def, nil
+	}
+	cmd := List(homeDir, getWd, readDef)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs(append([]string{"views", "--path=" + dir}, args...))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list views %v: %v", args, err)
+	}
+	return strings.Fields(buf.String())
+}
+
+func TestListViews_Success(t *testing.T) {
 	t.Parallel()
 
-	homeDir := func() (string, error) { return "/tmp/home", nil }
-	getWd := func() (string, error) { return "/tmp/db", nil }
-	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
-		return &ingitdb.Definition{}, nil
+	dir := t.TempDir()
+	got := runListViews(t, dir)
+	// Sorted, qualified by owning collection, and recursing into subcollections.
+	want := []string{
+		"countries/by_region",
+		"todo.tasks.comments/recent",
+		"todo.tasks/by_owner",
+		"todo.tasks/by_status",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("views output = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("views output = %v, want %v", got, want)
+			break
+		}
+	}
+}
+
+func TestListViews_ScopingFlags(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// --filter-name globs the bare view name across all collections.
+	byName := runListViews(t, dir, "--filter-name=by_*")
+	wantByName := []string{"countries/by_region", "todo.tasks/by_owner", "todo.tasks/by_status"}
+	if strings.Join(byName, ",") != strings.Join(wantByName, ",") {
+		t.Errorf("--filter-name output = %v, want %v", byName, wantByName)
 	}
 
+	// --in is a regex on the owning collection's path.
+	byPath := runListViews(t, dir, "--in=/todo/tasks$")
+	wantByPath := []string{"todo.tasks/by_owner", "todo.tasks/by_status"}
+	if strings.Join(byPath, ",") != strings.Join(wantByPath, ",") {
+		t.Errorf("--in output = %v, want %v", byPath, wantByPath)
+	}
+}
+
+func TestListViews_ReadDefError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	homeDir := func() (string, error) { return "/tmp/home", nil }
+	getWd := func() (string, error) { return dir, nil }
+	readDef := func(_ string, _ ...ingitdb.ReadOption) (*ingitdb.Definition, error) {
+		return nil, fmt.Errorf("read error")
+	}
 	cmd := List(homeDir, getWd, readDef)
-	err := runCobraCommand(cmd, "views")
-	if err == nil {
-		t.Fatal("expected error for not-yet-implemented command")
+	if err := runCobraCommand(cmd, "views", "--path="+dir); err == nil {
+		t.Fatal("expected error when readDefinition fails")
+	}
+}
+
+func TestFilterViewIDs(t *testing.T) {
+	t.Parallel()
+
+	dir := "/db"
+	def := viewsFixtureDef(dir)
+
+	tests := []struct {
+		name     string
+		inExpr   string
+		nameGlob string
+		want     []string
+		wantErr  bool
+	}{
+		{name: "no filters returns all sorted", want: []string{
+			"countries/by_region", "todo.tasks.comments/recent", "todo.tasks/by_owner", "todo.tasks/by_status",
+		}},
+		{name: "filter-name glob on bare view name", nameGlob: "by_*", want: []string{
+			"countries/by_region", "todo.tasks/by_owner", "todo.tasks/by_status",
+		}},
+		{name: "in regex on owning path", inExpr: "/todo/tasks$", want: []string{
+			"todo.tasks/by_owner", "todo.tasks/by_status",
+		}},
+		{name: "in and filter-name combine with AND", inExpr: "/todo/", nameGlob: "recent", want: []string{
+			"todo.tasks.comments/recent",
+		}},
+		{name: "no match yields empty", nameGlob: "nope*", want: nil},
+		{name: "invalid regex errors", inExpr: "[", wantErr: true},
+		{name: "invalid glob errors", nameGlob: "[", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := filterViewIDs(def, tc.inExpr, tc.nameGlob)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for in=%q name=%q", tc.inExpr, tc.nameGlob)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/ingitdb/dalgo2ingitdb v0.2.1
 	github.com/ingitdb/dalgo2ingitdb4github v0.2.1
 	github.com/ingitdb/dalgo2ingitdb4local v0.0.3
-	github.com/ingitdb/ingitdb-go/ingitdb v0.4.0
+	github.com/ingitdb/ingitdb-go/ingitdb v0.5.1
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/strongo/random v0.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/ingitdb/dalgo2ingitdb4github v0.2.1 h1:km/5NmRQpWVSjc/94dFe4f62qF2z4h
 github.com/ingitdb/dalgo2ingitdb4github v0.2.1/go.mod h1:xWO8PjukHH9Y6KhitxFmprttmx8zIcil30IysRkt/50=
 github.com/ingitdb/dalgo2ingitdb4local v0.0.3 h1:pnf+lzshNWoC1wd6bVGfeASiaaNIlaNiMRFpkBXpS2c=
 github.com/ingitdb/dalgo2ingitdb4local v0.0.3/go.mod h1:CjXvDiWSBWdWZCc8D5XGJK9imTzKQGnxX3NMqbdy2l0=
-github.com/ingitdb/ingitdb-go/ingitdb v0.4.0 h1:ibo2/iLQwrgJwqZbnNsmYJeRPVYEmv9tNfXj2etdN9g=
-github.com/ingitdb/ingitdb-go/ingitdb v0.4.0/go.mod h1:Gs7q7s5Q961W2Xvd5szq6qLPpLul762gs+P6GslE+eU=
+github.com/ingitdb/ingitdb-go/ingitdb v0.5.1 h1:i0DoKxhoJ++zJq0y298en4MijCXSq7LvkYoVEKvBcGw=
+github.com/ingitdb/ingitdb-go/ingitdb v0.5.1/go.mod h1:Gs7q7s5Q961W2Xvd5szq6qLPpLul762gs+P6GslE+eU=
 github.com/ingr-io/ingr-go v0.0.2 h1:2AfFllqzCe2dCNtxIUo306oYzaZr//YzrVOHd0C73nI=
 github.com/ingr-io/ingr-go v0.0.2/go.mod h1:gb/dGW0qXziCq9iAIgk0yITyWY013w2bhdYiXO0RLuY=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -19,6 +19,7 @@ This directory tracks the SpecScore feature specifications for the **ingitdb-cli
 | [cli/delete](cli/delete/README.md) | Implementing | `ingitdb delete` — delete records by ID or by `--from`/`--where`. |
 | [cli/drop](cli/drop/README.md) | Implementing | `ingitdb drop` — drop a collection or view. |
 | [cli/list-collections](cli/list-collections/README.md) | Implementing | `ingitdb list collections` — list collection IDs. |
+| [cli/list-views](cli/list-views/README.md) | Implementing | `ingitdb list views` — list views as `collectionID/viewName`. |
 | [cli/rebase](cli/rebase/README.md) | Implementing | `ingitdb rebase` — rebase with auto-resolution of generated-file conflicts. |
 | [cli/read-record](cli/read-record/README.md) | Superseded by [cli/select](cli/select/README.md) | `ingitdb read record` (removed). |
 | [cli/create-record](cli/create-record/README.md) | Superseded by [cli/insert](cli/insert/README.md) | `ingitdb create record` (removed). |
@@ -75,6 +76,9 @@ Drops schema objects: `drop collection <name>` and `drop view <name>`. Removes b
 
 ### cli/list-collections
 Lists collection IDs from a local DB or a GitHub repository, with optional `--in` regex scoping and `--filter-name` glob filtering.
+
+### cli/list-views
+Lists views across all collections (recursing into subcollections) as sorted `collectionID/viewName` identifiers, with optional `--in` regex scoping (on the owning collection path) and `--filter-name` glob filtering (on the bare view name).
 
 ### cli/rebase
 Runs `git rebase` on top of a base ref and auto-resolves conflicts in generated files (collection `README.md`, materialized views, indexes) when the user opts in via `--resolve`.

--- a/spec/features/cli/README.md
+++ b/spec/features/cli/README.md
@@ -37,6 +37,7 @@ CLI surface; keep those skills in sync when a command's flags or behavior change
 | [delete](delete/README.md) | Implementing | `ingitdb delete` |
 | [drop](drop/README.md) | Implementing | `ingitdb drop` |
 | [list-collections](list-collections/README.md) | Implementing | `ingitdb list collections` |
+| [list-views](list-views/README.md) | Implementing | `ingitdb list views` |
 | [rebase](rebase/README.md) | Implementing | `ingitdb rebase` |
 | [materialize](materialize/README.md) | Draft | `ingitdb materialize` |
 | [diff](diff/README.md) | Draft | `ingitdb diff` |

--- a/spec/features/cli/list-views/README.md
+++ b/spec/features/cli/list-views/README.md
@@ -1,0 +1,75 @@
+---
+format: https://specscore.md/feature-specification
+status: Implementing
+---
+
+# Feature: List Views Command
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-views?op=explore) | [Edit](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-views?op=edit) | [Ask question](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-views?op=ask) | [Request change](https://specscore.studio/app/github.com/ingitdb/ingitdb-cli/spec/features/cli/list-views?op=request-change) |
+**Status:** Implementing
+**Source Ideas:** —
+
+## Summary
+
+The `ingitdb list views` command prints every view defined in a database, one per line, as a qualified `collectionID/viewName` identifier. It works against a local directory (`--path`) and supports two narrowing flags: `--in` (regex on the owning collection's starting-point path) and `--filter-name` (glob on the bare view name).
+
+## Problem
+
+A collection can declare any number of views (materializable projections such as `status_{status}`). Before this command, `ingitdb list views` returned `not yet implemented`, so the only way to discover which views exist — a precondition for `materialize --views=<name>` — was to grep the `.collection/views/` directories by hand. Listing views is the natural companion to `list collections`.
+
+## Behavior
+
+### Invocation
+
+#### REQ: subcommand-name
+
+The command MUST be invoked as `ingitdb list views`. All flags are optional. When no `--path` is given the current working directory is used.
+
+### Enumeration
+
+#### REQ: qualified-view-ids
+
+The command MUST enumerate views across every collection, recursing into subcollections, and MUST print each as a `collectionID/viewName` identifier so that identically-named views on different collections remain distinct. Output MUST be sorted ascending and deterministic given a fixed database state and flag set.
+
+### Flags
+
+#### REQ: in-flag
+
+The `--in=REGEXP` flag MUST scope the listing to views whose owning collection's starting-point path matches the regular expression.
+
+#### REQ: filter-name-flag
+
+The `--filter-name=PATTERN` flag MUST filter views by their bare (unqualified) name using a glob-style pattern (e.g. `status_*`). `--in` and `--filter-name` combine with AND.
+
+## Dependencies
+
+- path-targeting
+
+## Implementation
+
+Source files implementing this feature (annotated with
+`// specscore: feature/cli/list-collections`, which registers the shared
+`cmd/ingitdb/commands/list.go` file that hosts both `list` subcommands):
+
+- [`cmd/ingitdb/commands/list.go`](../../../cmd/ingitdb/commands/list.go)
+
+## Acceptance Criteria
+
+### AC: lists-all-views
+
+**Requirements:** cli/list-views#req:subcommand-name, cli/list-views#req:qualified-view-ids
+
+Given a database whose collections (including subcollections) declare N views in total, when `ingitdb list views` runs, then it prints exactly N `collectionID/viewName` lines to stdout in ascending order and exits `0`.
+
+### AC: scoped-listing
+
+**Requirements:** cli/list-views#req:in-flag, cli/list-views#req:filter-name-flag
+
+Given views spread across several collections, when `ingitdb list views --in='/todo/tasks$' --filter-name='by_*'` runs, then only views whose owning collection path matches the regex AND whose bare name matches the glob are printed.
+
+## Open Questions
+
+- Should `list views` gain a `--remote` source like `list collections`, reading view definitions over the GitHub file reader?
+
+---
+*This document follows the https://specscore.md/feature-specification*


### PR DESCRIPTION
Completes the three ingitdb-cli follow-ups flagged during the release-convergence work. (The initial background agent stalled after only bumping the dep to the wrong version, `v0.5.0`; this is the finished, corrected work.)

## 1. `list views` — implemented (was a stub)

`ingitdb list views` returned `not yet implemented`. It now:
- enumerates every view across all collections, **recursing into subcollections**;
- prints each as a sorted `collectionID/viewName` identifier (so identically-named views on different collections stay distinct);
- supports `--in` (regex on the owning collection's starting-point path) and `--filter-name` (glob on the **bare** view name), combined with AND — mirroring `list collections`.

New unit + command tests cover success, both scoping flags, subcollection recursion, and the read-definition error path.

## 2. Materialized `md` views — fixed via dep bump `v0.5.0 → v0.5.1`

The stalled agent bumped to **v0.5.0**, which *predates* the md-extension fix, so `formats: [md]` views still materialized as `.ingr`. Corrected to **v0.5.1** (ingitdb-go `9624da9`, "materialize formats:[md] views as .md").

Verified end-to-end against `demo-ingitdb`'s `todo.tasks/status_{status}` view (`formats: [md]`, template-less):

| dep | `materialize --views` result |
|---|---|
| v0.5.0 | `status_new.**ingr**` (wrong extension) |
| **v0.5.1** | `status_new.**md**` — `materialized: 1 created` ✅ |

## 3. macOS notarization — dormant, secret-gated scaffold

Adds a `notarize.macos` block to `.goreleaser.yaml`, **off by default**:

```yaml
enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
```

With the secret unset the block is skipped entirely — the **same unsigned darwin binaries ship as today**, so it can never break a release. GoReleaser's notarize is pure-Go (quill), so when enabled it runs on the existing Linux `core` job (no macOS runner). `goreleaser check` passes.

⚠️ **This is scaffolded-but-off, needs a credential check.** The prior publish-homebrew signing job **failed**, so `MACOS_SIGN_*` / `NOTARIZE_*` may be stale. Enabling requires: (1) verifying the Apple credentials are still valid, and (2) forwarding the five secrets through `strongo/cicd`'s reusable `release.yml` `core` job (deliberately **not** touched here). Both steps are documented inline in `.goreleaser.yaml`.

## Notes
- Full Go test suite green; `go vet` and `goreleaser check` clean.
- Adds the `cli/list-views` feature spec + index rows (dogfooding SpecScore). The only `specscore spec lint` errors in the tree are pre-existing P-004 `done→complete` migrations in unrelated `plans/*.md`; left untouched (no CI job lints specs, and they're out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)