### PR TITLE
ci: continuous-delivery releases (single guarded bump, pin cicd @v1)

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -29,9 +29,13 @@ jobs:
   strongo_workflow:
     permissions:
       contents: write
-    uses: strongo/cicd/.github/workflows/workflow.yml@main
+    uses: strongo/cicd/.github/workflows/workflow.yml@v1
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:
       code_coverage: true
       min_test_coverage_percent: 80
+      # Version bump + release now happen in release.yml (continuous delivery on
+      # push to main). This workflow only builds/lints/tests — disable its bump
+      # so it does not create a competing tag.
+      disable-version-bumping: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,16 @@
 name: Release
 
-# Release is triggered by pushing a vX.Y.Z tag. The tag fixes the version
-# (ingitdb is past v1, so we never want an automatic major bump from a `feat!:`
-# commit) — pushing the tag IS the explicit, human-gated release action:
+# Continuous delivery: every merge to `main` runs the shared strongo/cicd
+# release workflow, which bumps the version from conventional commits and
+# releases it — all in one run (the release uses the tag it just cut, so there
+# is no GITHUB_TOKEN cross-workflow trigger problem). Pushing an explicit
+# `vX.Y.Z` tag also works and releases that exact version (the shared workflow
+# skips the bump on a tag ref). A docs/chore-only merge cuts no tag and
+# publishes nothing.
 #
-#   git tag v1.32.0 && git push origin v1.32.0
+# ingitdb is pre-1.0: allow_major_version_bump stays false, so a stray `feat!:`
+# is CAPPED to a minor bump (v0.64.2 -> v0.65.0) instead of jumping to v1 — the
+# guard added in strongo/cicd. Cut v1.0.0 deliberately by pushing that tag.
 #
 # Job graph:
 #   core       — strongo/cicd shared workflow: builds every OS + archives +
@@ -16,14 +22,19 @@ name: Release
 # The core job's GoReleaser uploads the release (all binaries, incl. the
 # unsigned macOS ones) BEFORE running its publishers, so a publisher failure
 # never blocks the binaries from shipping — which is why the old dedicated
-# build-macos job is no longer needed.
+# build-macos job is no longer needed. chocolatey/snap run only when core
+# actually cut a tag this run (needs.core.outputs.tag), so a no-op merge does
+# not try to publish an untagged commit.
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
+  workflow_dispatch:
 
-# One release at a time; a second tag push queues instead of racing the first.
+# One release at a time; a second push queues instead of racing the first.
 concurrency:
   group: release
   cancel-in-progress: false
@@ -40,6 +51,9 @@ jobs:
       contents: write
     with:
       go_version: '1.26.5'
+      # Pre-1.0: cap an accidental major (feat!:) to a minor bump. Cut v1.0.0
+      # only by pushing that tag explicitly.
+      allow_major_version_bump: false
     secrets:
       # Cross-repo PAT for the Homebrew tap + Scoop bucket (the default
       # GITHUB_TOKEN can't push to those repos).
@@ -55,7 +69,7 @@ jobs:
   chocolatey:
     name: Publish Chocolatey (Windows)
     needs: core
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && (needs.core.outputs.tag != '' || github.ref_type == 'tag') }}
     runs-on: windows-latest
     permissions:
       contents: read
@@ -87,7 +101,7 @@ jobs:
   snap:
     name: Publish Snapcraft
     needs: core
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && (needs.core.outputs.tag != '' || github.ref_type == 'tag') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Moves ingitdb-cli onto the ecosystem **single release process** (continuous delivery), and fixes the two bugs found while auditing releases.

## What was broken
- Releases **silently stalled at v0.40.1** (March): the CI bump job created tags with `GITHUB_TOKEN`, which by GitHub's rules can't trigger the tag-listening `release.yml`. Tags climbed to v1.32.0; nothing published.
- A `feat(cli)!:` commit had **accidentally major-bumped v0.64.2 → v1.0.0** (github-tag-action treats `!` as major regardless of the `major_string_token` sentinel). ingitdb is pre-1.0. The 85 orphan v1.x tags (zero of them released) have been deleted; the tag line resumes at **v0.64.2**.

## What this does
- **`release.yml`**: triggers on push to `main` (+ tag push + `workflow_dispatch`). The shared strongo/cicd workflow bumps from conventional commits **and releases in one run** — no cross-workflow token cascade. An explicit `vX.Y.Z` tag still releases that exact version.
- **`golangci.yml`**: `disable-version-bumping: true` (CI only builds/lints/tests; `release.yml` is the sole bumper). Pinned `@v1` (was `@main`).
- **Pre-1.0 guard**: `allow_major_version_bump: false` → the accumulated breaking commits since v0.64.2 are **capped to a minor** (→ **v0.65.0**), not a v1 jump. Cut v1.0.0 deliberately by pushing that tag.
- **choco/snap** run only when `core` actually cut a tag (`needs.core.outputs.tag`) or on a tag push — a docs-only merge won't try to publish an untagged commit.

## Effect on merge
The first CD run should publish **v0.65.0** — ingitdb-cli's first release since March — exercising the dormant notarize scaffold (skipped, unsigned) and the Homebrew cask for the first time.

Depends on the strongo/cicd guard (merged; `v1` → v1.9.1) and the orphan-tag cleanup (done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)