### PR TITLE
ci: require notarized macOS build before publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,11 @@ jobs:
       # Pre-1.0: cap an accidental major (feat!:) to a minor bump. Cut v1.0.0
       # only by pushing that tag explicitly.
       allow_major_version_bump: false
+      # Block publication unless the macOS build is genuinely signed, notarized,
+      # AND executable. Without this the preflight gate never runs: specscore-cli
+      # v0.37.10 shipped a binary macOS SIGKILLs, with a green release.
+      # See https://github.com/strongo/cicd/issues/66
+      require_notarized_macos: true
     secrets:
       # Cross-repo PAT for the Homebrew tap + Scoop bucket (the default
       # GITHUB_TOKEN can't push to those repos).


### PR DESCRIPTION
Enables the strongo/cicd macOS notarization preflight gate (previously never ran because it defaults to off), so a release publishes only after a genuinely signed, notarized, and executable macOS build is verified.

See https://github.com/strongo/cicd/issues/66