### PR TITLE
ci: raise release go_version to 1.27.0 to match go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,11 @@ jobs:
     permissions:
       contents: write
     with:
-      go_version: '1.26.5'
+      # Must be >= go.mod's `go` directive. The shared release job runs its
+      # `go mod tidy` before-hook under this setup-go version with
+      # GOTOOLCHAIN=local, so a lower value fails with
+      # "go.mod requires go >= 1.27.0" before the build ever starts.
+      go_version: '1.27.0'
       # Pre-1.0: cap an accidental major (feat!:) to a minor bump. Cut v1.0.0
       # only by pushing that tag explicitly.
       allow_major_version_bump: false


### PR DESCRIPTION
Unblocks releases, which have been failing since #137.

Adopting `github.com/strongo/buildinfo` raised `go.mod` to `go 1.27.0` — `go mod tidy` folded the previous `go 1.26.4` + `toolchain go1.27.0` pair into a single directive. But `release.yml` still pinned `go_version: '1.26.5'`.

The shared release job runs its `go mod tidy` before-hook under that `setup-go` version with `GOTOOLCHAIN=local`, which blocks toolchain auto-upgrade, so the release failed before building anything:

```
go: go.mod requires go >= 1.27.0 (running go 1.26.5; GOTOOLCHAIN=local)
```

The `macOS signing preflight` job failed and GoReleaser was skipped, so nothing was published — `v0.65.11` remains `Latest` and is a verified-good notarized binary. No bad artifact escaped.

`specscore-cli` hit this same trap earlier and documents it in its own `release.yml`; this adds an equivalent comment so the constraint is visible at the line that must satisfy it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFsyYhYi9h9Am1JbAMxuhv