### PR TITLE
ci: repin CI workflow to strongo/cicd@v1.14.15

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -29,7 +29,10 @@ jobs:
   strongo_workflow:
     permissions:
       contents: write
-    uses: strongo/cicd/.github/workflows/workflow.yml@v1
+    # Pinned to an exact tag, not the moving @v1 tag: @v1 has been retired
+    # because it drifted patch releases behind while still accepting inputs
+    # it did not implement, so a configured input could silently no-op.
+    uses: strongo/cicd/.github/workflows/workflow.yml@v1.14.15
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:


### PR DESCRIPTION
## Why

The moving `strongo/cicd@v1` tag is being retired and deleted. It drifted
14 patch releases behind `strongo/cicd@v1.14.15` while still accepting
inputs added after it, so a consumer could set an input, see a green run,
and have no gate for it actually execute (this exact class of bug is what
broke this repo's release earlier today via a go.mod/go_version mismatch —
see the existing pin in `release.yml`). This repins
`.github/workflows/golangci.yml` to the exact `strongo/cicd@v1.14.15` tag.

## Behaviour changes between @v1 and @v1.14.15

Verified directly against both tags in `strongo/cicd`:

1. **`build_command` default changed from `go build ./...` to empty**, and
   the Build step is now skipped when unset. This repo does not set
   `build_command` or `artifact_name`/`artifact_path`, so it currently
   relies on the default. `go test ./...` (which this workflow always runs)
   already compiles every package it runs against, including packages with
   no test files, so build errors are still caught — just by the test step
   instead of a separate build step.
2. **`go_version` is now an input** (default `'1.27.0'`, matching what
   `@v1` hardcoded). This repo does not set it, so no change.

## Per-repo checks

- `go.mod` directive: `go 1.27.0` — equal to the workflow's default
  `go_version` (`1.27.0`), so no `GOTOOLCHAIN=local` mismatch (this is the
  exact failure mode that broke this repo's release job earlier today).
- Inputs this file passes (`code_coverage`, `min_test_coverage_percent`,
  `disable-version-bumping`) all still exist at `@v1.14.15`.

## Scope

Only the `uses:` ref and an explanatory comment changed. Nothing else in
this file or repo was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFsyYhYi9h9Am1JbAMxuhv