### PR TITLE
chore(ci): repin strongo/cicd workflows to v1.14.17

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -32,7 +32,7 @@ jobs:
     # Pinned to an exact tag, not the moving @v1 tag: @v1 has been retired
     # because it drifted patch releases behind while still accepting inputs
     # it did not implement, so a configured input could silently no-op.
-    uses: strongo/cicd/.github/workflows/workflow.yml@v1.14.15
+    uses: strongo/cicd/.github/workflows/workflow.yml@v1.14.17
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     # 2026-08-28 from v1.14.5 to v1.14.9 (same commit fd908b7c as v1 at time
     # of bump) to pick up the fix that makes verification use
     # `spctl -a -vv -t install` and assert `source=Notarized Developer ID`.
-    uses: strongo/cicd/.github/workflows/release.yml@v1.14.14
+    uses: strongo/cicd/.github/workflows/release.yml@v1.14.17
     permissions:
       contents: write
     with:


### PR DESCRIPTION
Picks up `strongo/cicd` v1.14.16 and v1.14.17.

v1.14.17 (PR strongo/cicd#73) fixes two release-workflow defects:
- **Silent no-op publish.** A run that declined to cut a tag exited 0 with no output, indistinguishable on the run summary from one that published. It now emits a `::notice::` naming the proposed version, the baseline, `default_bump`, and which of those caused the decline.
- **Cold start.** A repo with no prior tag could never bootstrap its first release: with no range, git-cliff returns `initial_tag` verbatim regardless of history, so the proposal was always `0.0.0`. It now diffs against a synthetic orphan-commit baseline that is deleted before GoReleaser or the tag-push step can see it.

Workflow-file pin change only; no source changes.