### PR TITLE
ci(release): refuse to publish unless 'CI (build, lint, test, bump)' passed for the commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,21 @@ jobs:
     # 2026-08-28 from v1.14.5 to v1.14.9 (same commit fd908b7c as v1 at time
     # of bump) to pick up the fix that makes verification use
     # `spctl -a -vv -t install` and assert `source=Notarized Developer ID`.
-    uses: strongo/cicd/.github/workflows/release.yml@v1.14.20
+    uses: strongo/cicd/.github/workflows/release.yml@v1.18.0
     permissions:
       contents: write
+      # Lets the require_workflow_success guard read the quality
+      # workflow's result for this commit. A reusable workflow cannot
+      # grant itself more than its caller allows, so it belongs here.
+      actions: read
     with:
+      # Refuse to tag or publish unless this repo's quality workflow
+      # passed for this exact commit. Release and that workflow are
+      # siblings started by the same push, with no cross-workflow
+      # `needs:` between them, so before this a red suite could not
+      # stop a release. datatug-cli shipped v0.13.2 that way. Names
+      # the workflow's `name:`, not its filename.
+      require_workflow_success: 'CI (build, lint, test, bump)'
       # Must be >= go.mod's `go` directive. The shared release job runs its
       # `go mod tidy` before-hook under this setup-go version with
       # GOTOOLCHAIN=local, so a lower value fails with


### PR DESCRIPTION
Adopts `require_workflow_success` from `strongo/cicd@v1.18.0` (strongo/cicd#83), naming this repo's **`CI (build, lint, test, bump)`** workflow.

## Why

`Release` and `CI (build, lint, test, bump)` are **sibling** workflows started by the same push, with no cross-workflow `needs:` between them. A red suite could not stop a release.

That is not theoretical. `datatug/datatug-cli` published `v0.13.2` from a commit whose `go build ./...` was red, and the published binaries were built against the wrong dependency major:

```
$ go version -m datatug   # from the published v0.13.2 tarball
dep  github.com/google/go-github/v90  v90.0.0     # while go.mod declared v91
```

## What the guard does

It observes `CI (build, lint, test, bump)`'s conclusion for this exact commit and refuses **before** the tag step mutates anything.

| Situation | Result |
|---|---|
| `CI (build, lint, test, bump)` `success` / `skipped` | release proceeds |
| `failure`, `cancelled`, `timed_out` | **refused before any tag is cut** |
| Still running | waited for, then refused on timeout |
| Name matches no workflow | **refused**, so a typo cannot quietly disable it |
| No run for this commit (`paths:` filtered) | proceeds, with a notice |

`actions: read` is granted on the calling job because a reusable workflow cannot grant itself more than its caller allows.

The pin also moves to `v1.18.0`. No input was removed between the previous pin and this one.

## Verification

The guard's script was run unmodified against live GitHub data before release, and rejects `a913de4`, the exact commit that published the broken `v0.13.2`. Its tests drive that same script against a stubbed `gh` across five outcomes, and were confirmed to fail when the guard is stubbed to `exit 0`.

Verified in production on datatug/datatug-cli#190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)