### PR TITLE
ci: verify go.mod tidiness instead of silently imposing it

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -42,3 +42,28 @@ jobs:
       # push to main). This workflow only builds/lints/tests — disable its bump
       # so it does not create a competing tag.
       disable-version-bumping: true
+
+  # Fail fast on go.mod/go.sum drift.
+  #
+  # This is the signal that would have caught datatug-cli's v0.13.2 before it
+  # shipped: two renovate pull requests for the same major bump interleaved and
+  # left go.mod requiring a version nothing imported. Build-and-test caught the
+  # stale imports only after both had merged; an untidy go.mod is visible on the
+  # FIRST of the pair, on its own pull request.
+  #
+  # `-diff` only reports; it never rewrites go.mod, so unlike a mutating
+  # `go mod tidy` it cannot mask the drift it is meant to find. This job belongs
+  # to the workflow named by release.yml's `require_workflow_success`, so drift
+  # also blocks the release, not just the merge.
+  go-mod-tidy:
+    name: go.mod is tidy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          # Must be >= this repo's go.mod `go` directive.
+          go-version: '1.27.0'
+          cache: true
+      - name: go mod tidy -diff
+        run: go mod tidy -diff

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,15 @@ project_name: ingitdb
 
 before:
   hooks:
-    - go mod tidy
+    # VERIFY tidiness; never impose it. A mutating `go mod tidy` here rewrites
+    # go.mod inside the ephemeral release runner, so GoReleaser can build and
+    # publish something other than the tagged tree. datatug-cli's v0.13.2
+    # shipped exactly that way: two renovate pull requests for the same
+    # go-github major interleaved, this hook re-added the removed old major,
+    # and the published binaries were built against it while the tagged
+    # go.mod declared the new one. `-diff` writes nothing and exits non-zero
+    # on drift, so the release stops instead of healing itself.
+    - go mod tidy -diff
 
 builds:
   - id: ingitdb

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/dal-go/dalgo v0.74.2 h1:i80DdaEG617Ki93hTrT6WSpmP/Pb3Siosxkkrtymi78=
-github.com/dal-go/dalgo v0.74.2/go.mod h1:ffWy4OC32BDoseIh+9KF/W9VUGk3FfkAtIvUzUf1zAY=
 github.com/dal-go/dalgo v0.79.3 h1:awEX08IaxK135rrftqutBbdi/fWwAMx756YWgF2+W44=
 github.com/dal-go/dalgo v0.79.3/go.mod h1:p0VdxLWu+Z/+kNYj7EdZHR+k3LzlpaUBo8atVeUiKBs=
 github.com/dal-go/record v0.1.3 h1:K85k/kSX08lTefMiMmPpC12nmCY2TVJk7+ZyC5PD9XU=
@@ -94,8 +92,6 @@ github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
-github.com/strongo/buildinfo v0.2.0 h1:4lVoCUfUbwJN8EbqFNQ1oYdBnjKrKRx6FlLVrTPSleI=
-github.com/strongo/buildinfo v0.2.0/go.mod h1:JpxZ3Jku81LJC1RNIqCNYwguDzLk90eemxUXx4JnSlA=
 github.com/strongo/buildinfo v0.2.1 h1:z6H2UJYT8hAgzCUnNIjOCEAWmNnvj3KZdYXIw5dZngs=
 github.com/strongo/buildinfo v0.2.1/go.mod h1:JpxZ3Jku81LJC1RNIqCNYwguDzLk90eemxUXx4JnSlA=
 github.com/strongo/random v0.0.1 h1:OZHJBb/3uEa7OX8L2Dv2pLnSeewRmXMyTACoeto6O8I=


### PR DESCRIPTION
Closes the mechanism behind datatug-cli's `v0.13.2` in this repo. Companion to datatug/datatug-cli#189, where it was first fixed.

## The problem

GoReleaser's before-hook ran a **mutating** `go mod tidy`. That rewrites `go.mod` inside the ephemeral release runner, so a release can build and publish something other than the tagged tree, leaving no trace.

`datatug-cli` shipped exactly that. Two Renovate pull requests for the same `go-github` major interleaved and left `go.mod` requiring v91 while every source file still imported v90. The hook re-added v90 in the runner:

```
$ go version -m datatug   # from the published v0.13.2 tarball
dep  github.com/google/go-github/v90  v90.0.0     # while go.mod declared v91
```

Every consumer of the shared release workflow except `datatug-cli` still runs that hook.

## The two guards

Both report rather than rewrite, which is the whole point:

| Change | Effect |
|---|---|
| `.goreleaser`: `go mod tidy` → `go mod tidy -diff` | drift stops the release instead of being healed out from under the tag |
| new `go.mod is tidy` CI job | drift goes red on the pull request that introduces it |

The CI job matters independently. Build-and-test only catches stale imports once **both** of an interleaved pair have merged. An untidy `go.mod` is visible on the **first one alone** — it would have failed the earlier of the two Renovate pull requests, before they could collide.

That job also sits in the workflow named by `release.yml`'s `require_workflow_success`, so drift blocks the release as well as the merge.

> **This repo's `go.mod` was already untidy**, so it is tidied in the same change. Without that, both new guards would have failed on arrival.

## Verification

`go mod tidy -diff` exits 0 on this branch and `go build ./...` passes. The guard was verified in both directions on `datatug-cli`: exit 1 on the commit that shipped the broken release, exit 0 once fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)