### PR TITLE
ci: drop the paths: filters

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -6,24 +6,10 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'go.*'
-      - '**/*.go'
-      - 'src/**'
-      - '.github/workflows/*.yml'
-      - '.github/goreleaser*.yaml'
-      - '.golangci.yml'
 
   pull_request:
     branches:
       - '**'
-    paths:
-      - 'go.*'
-      - '**/*.go'
-      - 'src/**'
-      - '.golangci.yml'
-      - '.github/workflows/*.yml'
-      - '.github/goreleaser*.yaml'
 
 jobs:
   strongo_workflow:


### PR DESCRIPTION
Makes this repo's CI and release signals mean what they claim.

## The `paths:` filters

A commit outside the filter produces **no run at all**. Two consequences, both bad:

- A required status check that never runs stays **pending forever**, so a pull request outside the filter could never merge. That blocks adopting branch protection here.
- `release.yml`'s `require_workflow_success` gate asks whether this workflow succeeded for the exact commit. No run means nothing to check, so it waits out its 180 second grace and **releases ungated**.

Both triggers lose their filters. Branch scoping is untouched, so pull-request branches are still covered exactly once. The cost is one short run on changes that touch no Go code, which is the price of the checks being trustworthy enough to require.


🤖 Generated with [Claude Code](https://claude.com/claude-code)